### PR TITLE
Handle logical slots invalidation on a standby

### DIFF
--- a/patroni/postgresql/slots.py
+++ b/patroni/postgresql/slots.py
@@ -86,7 +86,8 @@ class SlotsAdvanceThread(Thread):
         except Exception as e:
             logger.error("Failed to advance logical replication slot '%s': %r", slot, e)
             failed = True
-            copy = isinstance(e, OperationalError) and e.diag.sqlstate == '58P01'  # WAL file is gone
+            # WAL file is gone or slot is invalidated
+            copy = isinstance(e, OperationalError) and e.diag.sqlstate in ('58P01', '55000')
         with self._condition:
             if self._scheduled and failed:
                 if copy and slot not in self._copy_slots:

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -273,7 +273,7 @@ class TestSlotsHandler(BaseTestPostgresql):
                 type(mock_diag).sqlstate = PropertyMock(return_value=err)
                 self.s.schedule_advance_slots({'foo': {'bar': 100}})
                 self.s._advance.sync_slots()
-                self.assertCountEqual(self.s._advance._copy_slots, ["bar"])
+                self.assertEqual(self.s._advance._copy_slots, ["bar"])
 
         with patch.object(SlotsAdvanceThread, 'sync_slots', Mock(side_effect=Exception)):
             self.s._advance._condition.wait = Mock()

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -269,9 +269,11 @@ class TestSlotsHandler(BaseTestPostgresql):
     def test_slots_advance_thread(self):
         with patch.object(MockCursor, 'execute', Mock(side_effect=psycopg.OperationalError)), \
                 patch.object(psycopg.OperationalError, 'diag') as mock_diag:
-            type(mock_diag).sqlstate = PropertyMock(return_value='58P01')
-            self.s.schedule_advance_slots({'foo': {'bar': 100}})
-            self.s._advance.sync_slots()
+            for err in ('58P01', '55000'):
+                type(mock_diag).sqlstate = PropertyMock(return_value=err)
+                self.s.schedule_advance_slots({'foo': {'bar': 100}})
+                self.s._advance.sync_slots()
+                self.assertCountEqual(self.s._advance._copy_slots, ["bar"])
 
         with patch.object(SlotsAdvanceThread, 'sync_slots', Mock(side_effect=Exception)):
             self.s._advance._condition.wait = Mock()


### PR DESCRIPTION
Since PG16 logical replication slots on a standby can be invalidated due to horizon. In this case, pg_replication_slot_advance() will fail with ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE. We should force slot copy (i.e., recreation) of such slots.

Ref:
https://github.com/postgres/postgres/commit/be87200efd9308ccfe217ce8828f316e93e370da
https://github.com/postgres/postgres/commit/26669757b6a7665c1069e77e6472bd8550193ca6