### PR TITLE
Compatibility with v17 beta3

### DIFF
--- a/patroni/postgresql/available_parameters/0_postgres.yml
+++ b/patroni/postgresql/available_parameters/0_postgres.yml
@@ -1342,9 +1342,6 @@ parameters:
   standard_conforming_strings:
   - type: Bool
     version_from: 90300
-  standby_slot_names:
-  - type: String
-    version_from: 170000
   statement_timeout:
   - type: Integer
     version_from: 90300
@@ -1387,6 +1384,9 @@ parameters:
   synchronize_seqscans:
   - type: Bool
     version_from: 90300
+  synchronized_standby_slots:
+  - type: String
+    version_from: 170000
   synchronous_commit:
   - type: EnumBool
     version_from: 90300


### PR DESCRIPTION
`standby_slot_names` was renamed to `synchronized_standby_slots`