### PR TITLE
Fix request URL in failsafe handling log

### DIFF
--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -260,6 +260,19 @@ class Member(Tags, NamedTuple('Member',
                 ret['user'] = ret.pop('username')
         return ret
 
+    def get_endpoint_url(self, endpoint: Optional[str] = None) -> str:
+        """Get URL from member :attr:`~Member.api_url` and endpoint.
+
+        :param endpoint: URL path of REST API.
+
+        :returns: full URL for this REST API.
+        """
+        url = self.api_url or ''
+        if endpoint:
+            scheme, netloc, _, _, _, _ = urlparse(url)
+            url = urlunparse((scheme, netloc, endpoint, '', '', ''))
+        return url
+
     @property
     def api_url(self) -> Optional[str]:
         """The ``api_url`` value from :attr:`~Member.data` if defined."""

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1174,15 +1174,17 @@ class Ha(object):
 
         :returns: a :class:`_FailsafeResponse` object.
         """
+        endpoint = 'failsafe'
+        url = member.get_endpoint_url(endpoint)
         try:
-            response = self.patroni.request(member, 'post', 'failsafe', data, timeout=2, retries=1)
+            response = self.patroni.request(member, 'post', endpoint, data, timeout=2, retries=1)
             response_data = response.data.decode('utf-8')
-            logger.info('Got response from %s %s: %s', member.name, member.api_url, response_data)
+            logger.info('Got response from %s %s: %s', member.name, url, response_data)
             accepted = response.status == 200 and response_data == 'Accepted'
             # member may return its current received/replayed LSN in the "lsn" header.
             return _FailsafeResponse(member.name, accepted, parse_int(response.headers.get('lsn')))
         except Exception as e:
-            logger.warning("Request failed to %s: POST %s (%s)", member.name, member.api_url, e)
+            logger.warning("Request failed to %s: POST %s (%s)", member.name, url, e)
         return _FailsafeResponse(member.name, False, None)
 
     def check_failsafe_topology(self) -> bool:

--- a/patroni/request.py
+++ b/patroni/request.py
@@ -2,7 +2,6 @@
 import json
 
 from typing import Any, Dict, Optional, Union
-from urllib.parse import urlparse, urlunparse
 
 import urllib3
 
@@ -164,10 +163,7 @@ class PatroniRequest(object):
 
         :returns: the response returned upon request.
         """
-        url = member.api_url or ''
-        if endpoint:
-            scheme, netloc, _, _, _, _ = urlparse(url)
-            url = urlunparse((scheme, netloc, endpoint, '', '', ''))
+        url = member.get_endpoint_url(endpoint)
         return self.request(method, url, data, **kwargs)
 
 


### PR DESCRIPTION
When addressing a DCS error, the URLs in the log do not reflect the actual ones.

```
2024-08-13 16:16:03,091 ERROR: Error communicating with DCS
2024-08-13 16:16:03,163 INFO: Got response from postgres-15add5e6-0-0 https://245.0.0.119:8009/patroni: Accepted
2024-08-13 16:16:03,163 INFO: Got response from postgres-15add5e6-1-0 https://245.0.1.149:8009/patroni: Accepted
2024-08-13 16:16:03,165 INFO: continue to run as a leader because failsafe mode is enabled and all members are accessible
```

We called `/failsafe`, not `/patroni`.