### PR TITLE
Added a new flag to ignore unsuccessful bind

### DIFF
--- a/docs/patroni_configuration.rst
+++ b/docs/patroni_configuration.rst
@@ -238,7 +238,7 @@ Validate Patroni configuration
 
 .. code:: text
 
-   patroni --validate-config [configfile]
+   patroni --validate-config [configfile] [--ignore-listen-port | -i]
 
 Description
 """""""""""
@@ -250,3 +250,6 @@ Parameters
 
 ``configfile``
     Full path to the configuration file to check. If not given or file does not exist, will try to read from the ``PATRONI_CONFIG_VARIABLE`` environment variable or, if not set, from the :ref:`Patroni environment variables <environment>`.
+
+``--ignore-listen-port | -i``
+    Optional flag to ignore bind failures for ``listen`` ports that are already in use when validating the ``configfile``.

--- a/patroni/__main__.py
+++ b/patroni/__main__.py
@@ -241,6 +241,8 @@ def process_arguments() -> Namespace:
       * ``--validate-config`` -- used to validate the Patroni configuration file
       * ``--generate-config`` -- used to generate Patroni configuration from a running PostgreSQL instance
       * ``--generate-sample-config`` -- used to generate a sample Patroni configuration
+      * ``--ignore-listen-port`` | ``-i`` -- used to ignore ``listen`` ports already in use.\
+          Can be used only with ``--validate-config``
 
     .. note::
         If running with ``--generate-config``, ``--generate-sample-config`` or ``--validate-flag`` will exit
@@ -259,6 +261,9 @@ def process_arguments() -> Namespace:
                        help='Generate a Patroni yaml configuration file for a running instance')
     parser.add_argument('--dsn', help='Optional DSN string of the instance to be used as a source \
                                     for config generation. Superuser connection is required.')
+    parser.add_argument('--ignore-listen-port', '-i', action='store_true',
+                        help='Ignore `listen` ports already in use.\
+                              Can only be used with --validate-config')
     args = parser.parse_args()
 
     if args.generate_sample_config:
@@ -269,7 +274,9 @@ def process_arguments() -> Namespace:
         sys.exit(0)
     elif args.validate_config:
         from patroni.config import Config, ConfigParseError
-        from patroni.validator import schema
+        from patroni.validator import populate_validate_params, schema
+
+        populate_validate_params(ignore_listen_port=args.ignore_listen_port)
 
         try:
             Config(args.configfile, validator=schema)

--- a/patroni/__main__.py
+++ b/patroni/__main__.py
@@ -241,7 +241,7 @@ def process_arguments() -> Namespace:
       * ``--validate-config`` -- used to validate the Patroni configuration file
       * ``--generate-config`` -- used to generate Patroni configuration from a running PostgreSQL instance
       * ``--generate-sample-config`` -- used to generate a sample Patroni configuration
-      * ``--ignore-listen-port`` | ``-i`` -- used to ignore ``listen`` ports already in use.\
+      * ``--ignore-listen-port`` | ``-i`` -- used to ignore ``listen`` ports already in use.
           Can be used only with ``--validate-config``
 
     .. note::


### PR DESCRIPTION
This is a feature request made here : [Issue 3056](https://github.com/patroni/patroni/issues/3056)

Ask:
A new flag to ignore bind errors in the case where user wants re-validate parameters on a running Patroni cluster. In other words, if patroni is already running, Ansible (or other orchestrators) should get a successful code; even when the ports with `listen` specified are already bound by other process (most likely another Patroni instance)

Changes discussed and made:
A variable will be set when a flag is specified in CLI. If set, this flag should ignore the port as requested.