### PR TITLE
Fix bug in member slots retention feature

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -3,6 +3,18 @@
 Release notes
 =============
 
+Version 4.0.1
+-------------
+
+Released 2024-08-30
+
+**Bugfix**
+
+- Patroni was creating unnecessary replication slots for itself (Alexander Kukushkin)
+
+  It was happening if ``name`` contains upper case or sepcial characters.
+
+
 Version 4.0.0
 -------------
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -12,7 +12,7 @@ Released 2024-08-30
 
 - Patroni was creating unnecessary replication slots for itself (Alexander Kukushkin)
 
-  It was happening if ``name`` contains upper case or sepcial characters.
+  It was happening if ``name`` contains upper-case or special characters.
 
 
 Version 4.0.0

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -1170,8 +1170,9 @@ class Cluster(NamedTuple('Cluster',
                 # `max` is only a fallback so we take the LSN from the slot when there is no feedback from the member.
                 lsn = max(member.lsn or 0, lsn)
             ret[slot_name] = {'type': 'physical', 'lsn': lsn}
+        slot_name = slot_name_from_member_name(name)
         ret.update({slot: {'type': 'physical'} for slot in self.status.retain_slots
-                    if slot not in ret and slot != name})
+                    if slot not in ret and slot != slot_name})
 
         if len(ret) < len(members):
             # Find which names are conflicting for a nicer error message

--- a/patroni/version.py
+++ b/patroni/version.py
@@ -2,4 +2,4 @@
 
 :var __version__: the current Patroni version.
 """
-__version__ = '4.0.0'
+__version__ = '4.0.1'


### PR DESCRIPTION
If `name` contains upper case or special characters the node was creating unused replication slot for itself.