### PR TITLE
Fix unhandled DCSError cause patroni exit during startup phase

### DIFF
--- a/patroni/__main__.py
+++ b/patroni/__main__.py
@@ -18,6 +18,7 @@ from patroni.tags import Tags
 
 if TYPE_CHECKING:  # pragma: no cover
     from .config import Config
+    from .dcs import Cluster
 
 logger = logging.getLogger(__name__)
 
@@ -63,10 +64,11 @@ class Patroni(AbstractPatroniDaemon, Tags):
         self.dcs = get_dcs(self.config)
         self.request = PatroniRequest(self.config, True)
 
-        self.ensure_unique_name()
+        cluster = self.ensure_dcs_access()
+        self.ensure_unique_name(cluster)
 
         self.watchdog = Watchdog(self.config)
-        self.load_dynamic_configuration()
+        self.apply_dynamic_configuration(cluster)
 
         self.postgresql = Postgresql(self.config['postgresql'], self.dcs.mpp)
         self.api = RestApiServer(self, self.config['restapi'])
@@ -76,40 +78,49 @@ class Patroni(AbstractPatroniDaemon, Tags):
         self.next_run = time.time()
         self.scheduled_restart: Dict[str, Any] = {}
 
-    def load_dynamic_configuration(self) -> None:
-        """Load Patroni dynamic configuration.
+    def ensure_dcs_access(self, sleep_time: int = 5) -> 'Cluster':
+        """Continuously attempt to retrieve cluster from DCS with delay.
 
-        Load dynamic configuration from the DCS, if `/config` key is available in the DCS, otherwise fall back to
+        :param sleep_time: seconds to wait between retry attempts after dcs connection raise :exc:`DCSError`.
+
+        :returns: a PostgreSQL or MPP implementation of :class:`Cluster`.
+        """
+        from patroni.exceptions import DCSError
+
+        while True:
+            try:
+                return self.dcs.get_cluster()
+            except DCSError:
+                logger.warning('Can not get cluster from dcs')
+                time.sleep(sleep_time)
+
+    def apply_dynamic_configuration(self, cluster: 'Cluster') -> None:
+        """Apply Patroni dynamic configuration.
+
+        Apply dynamic configuration from the DCS, if `/config` key is available in the DCS, otherwise fall back to
         ``bootstrap.dcs`` section from the configuration file.
-
-        If the DCS connection fails returning the exception :class:`~patroni.exceptions.DCSError` an attempt will be
-        remade every 5 seconds.
 
         .. note::
             This method is called only once, at the time when Patroni is started.
-        """
-        from patroni.exceptions import DCSError
-        while True:
-            try:
-                cluster = self.dcs.get_cluster()
-                if cluster and cluster.config and cluster.config.data:
-                    if self.config.set_dynamic_configuration(cluster.config):
-                        self.dcs.reload_config(self.config)
-                        self.watchdog.reload_config(self.config)
-                elif not self.config.dynamic_configuration and 'bootstrap' in self.config:
-                    if self.config.set_dynamic_configuration(self.config['bootstrap']['dcs']):
-                        self.dcs.reload_config(self.config)
-                        self.watchdog.reload_config(self.config)
-                break
-            except DCSError:
-                logger.warning('Can not get cluster from dcs')
-                time.sleep(5)
 
-    def ensure_unique_name(self) -> None:
-        """A helper method to prevent splitbrain from operator naming error."""
+        :param cluster: a PostgreSQL or MPP implementation of :class:`Cluster`.
+        """
+        if cluster and cluster.config and cluster.config.data:
+            if self.config.set_dynamic_configuration(cluster.config):
+                self.dcs.reload_config(self.config)
+                self.watchdog.reload_config(self.config)
+        elif not self.config.dynamic_configuration and 'bootstrap' in self.config:
+            if self.config.set_dynamic_configuration(self.config['bootstrap']['dcs']):
+                self.dcs.reload_config(self.config)
+                self.watchdog.reload_config(self.config)
+
+    def ensure_unique_name(self, cluster: 'Cluster') -> None:
+        """A helper method to prevent splitbrain from operator naming error.
+
+        :param cluster: a PostgreSQL or MPP implementation of :class:`Cluster`.
+        """
         from patroni.dcs import Member
 
-        cluster = self.dcs.get_cluster()
         if not cluster:
             return
         member = cluster.get_member(self.config['name'], False)


### PR DESCRIPTION
DCSError in startup phase will cause patroni exit immediately because `Patroni.ensure_unique_name()` didn't catch exception raised by `Patroni.dcs.get_cluster()`