### PR TITLE
Typo in ports section of haproxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
         container_name: demo-haproxy
         ports:
             - "5000:5000"
-            - "5001:5001"
+            - "7000:7000"
         command: haproxy
         environment: &haproxy_env
             ETCDCTL_ENDPOINTS: http://etcd1:2379,http://etcd2:2379,http://etcd3:2379


### PR DESCRIPTION
Typo in ports section. Haproxy listen 7000 port for stats in repo config.

https://github.com/patroni/patroni/blob/master/haproxy.cfg#L13-L17