### PR TITLE
Fix timeline metric None value

### DIFF
--- a/kubernetes/entrypoint.sh
+++ b/kubernetes/entrypoint.sh
@@ -15,6 +15,7 @@ bootstrap:
       pg_hba:
       - host all all 0.0.0.0/0 md5
       - host replication ${PATRONI_REPLICATION_USERNAME} ${PATRONI_KUBERNETES_POD_IP}/16 md5
+      - host replication ${PATRONI_REPLICATION_USERNAME} 127.0.0.1/32 md5
   initdb:
   - auth-host: md5
   - auth-local: trust

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -627,7 +627,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
 
         metrics.append("# HELP patroni_postgres_timeline Postgres timeline of this node (if running), 0 otherwise.")
         metrics.append("# TYPE patroni_postgres_timeline counter")
-        metrics.append("patroni_postgres_timeline{0} {1}".format(labels, postgres.get('timeline', 0)))
+        metrics.append("patroni_postgres_timeline{0} {1}".format(labels, postgres.get('timeline') or 0))
 
         metrics.append("# HELP patroni_dcs_last_seen Epoch timestamp when DCS was last contacted successfully"
                        " by Patroni.")

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -1075,15 +1075,11 @@ class Postgresql(object):
                 return row[1] if row else None
         except Exception:
             logger.exception('Can not fetch local timeline and lsn from replication connection')
-            return None
 
     def replica_cached_timeline(self, primary_timeline: Optional[int]) -> Optional[int]:
         if not self._cached_replica_timeline or not primary_timeline\
                 or self._cached_replica_timeline != primary_timeline:
             self._cached_replica_timeline = self.get_replica_timeline()
-        if self._cached_replica_timeline is None:
-            logger.warning("replica_cached_timeline is None, returning 0 instead.")
-            return 0
         return self._cached_replica_timeline
 
     def get_primary_timeline(self) -> int:

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -1075,11 +1075,15 @@ class Postgresql(object):
                 return row[1] if row else None
         except Exception:
             logger.exception('Can not fetch local timeline and lsn from replication connection')
+            return None
 
     def replica_cached_timeline(self, primary_timeline: Optional[int]) -> Optional[int]:
         if not self._cached_replica_timeline or not primary_timeline\
                 or self._cached_replica_timeline != primary_timeline:
             self._cached_replica_timeline = self.get_replica_timeline()
+        if self._cached_replica_timeline is None:
+            logger.warning("replica_cached_timeline is None, returning 0 instead.")
+            return 0
         return self._cached_replica_timeline
 
     def get_primary_timeline(self) -> int:


### PR DESCRIPTION
**Motivation**
Opening PR to resolve https://github.com/patroni/patroni/issues/3164 metric bug

**Added**
* An `hba_conf` entry for `standby` user using loopback address to resolve authentication issue in [Patroni on K8's example demo environment](https://github.com/patroni/patroni/tree/master/kubernetes#patroni-on-k8s)
* Ensure `replica_cached_timeline` returns 0 on exception to prevent `patroni_postgres_timeline` returning a `None` value as a failsafe

**Testing**
* Tested both changes in the K8 demo environment
  * Resulted in successful timeline metric 

```bash
postgres@patronidemo-1:~$ curl localhost:8008/ | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   456    0   456    0     0   190k      0 --:--:-- --:--:-- --:--:--  222k
{
  "state": "running",
  "postmaster_start_time": "2024-09-15 20:54:55.826305+00:00",
  "role": "replica",
  "server_version": 160004,
  "xlog": {
    "received_location": 67108960,
    "replayed_location": 67108960,
    "replayed_timestamp": null,
    "paused": false
  },
  "timeline": 1,
  "replication_state": "streaming",
  "dcs_last_seen": 1726433712,
  "database_system_identifier": "7414976246274842650",
  "patroni": {
    "version": "4.0.1",
    "scope": "patronidemo",
    "name": "patronidemo-1"
  }
}
```

```bash
patroni_postgres_timeline{scope="patronidemo",name="patronidemo-1"} 1
# HELP patroni_dcs_last_seen Epoch timestamp when DCS was last contacted successfully by Patroni.
# TYPE patroni_dcs_last_seen gauge
```