### PR TITLE
Release v3.3.3

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -186,7 +186,7 @@ jobs:
 
     - uses: jakebailey/pyright-action@v2
       with:
-        version: 1.1.371
+        version: 1.1.379
 
   docs:
     runs-on: ubuntu-latest

--- a/patroni/version.py
+++ b/patroni/version.py
@@ -2,4 +2,4 @@
 
 :var __version__: the current Patroni version.
 """
-__version__ = '3.3.2'
+__version__ = '3.3.3'


### PR DESCRIPTION
This is a minor release for Patroni version 3.3 with the latest bugfixes back-patched from Patroni 4.0.2

- Increase version
- Use newer pyright (not latest)
- Add RNs