### PR TITLE
Hides the password output in logs when pgaudit is enabled

### DIFF
--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -411,6 +411,7 @@ END;$$""".format(quote_literal(name), quote_ident(name, self._postgresql.connect
         self._postgresql.query('SET log_min_duration_statement TO -1')
         self._postgresql.query("SET log_min_error_statement TO 'log'")
         self._postgresql.query("SET pg_stat_statements.track_utility to 'off'")
+        self._postgresql.query("SET pgaudit.log TO none")
         try:
             self._postgresql.query(sql)
         finally:
@@ -418,6 +419,7 @@ END;$$""".format(quote_literal(name), quote_ident(name, self._postgresql.connect
             self._postgresql.query('RESET log_min_duration_statement')
             self._postgresql.query('RESET log_statement')
             self._postgresql.query('RESET pg_stat_statements.track_utility')
+            self._postgresql.query('RESET pgaudit.log')
 
     def post_bootstrap(self, config: Dict[str, Any], task: CriticalTask) -> Optional[bool]:
         try:


### PR DESCRIPTION
Patroni logging superuser, replication and rewind passwords in logs when PostgreSQL extensions [PGAUDIT](https://github.com/pgaudit/pgaudit) enabled.

patroni.yaml:
-------------------
```yaml
bootstrap:
  dcs:
    postgresql:
      parameters:
        shared_preload_libraries: pgaudit
        log_destination: "stderr"
        logging_collector: 'off'
        pgaudit.log_catalog: 'off'
        pgaudit.log: "ROLE,FUNCTION,DDL"
        pgaudit.log_relation: 'on'
        pgaudit.log_parameter: 'on'
postgresql:
  authentication:
    replication:
      username: replicator
      password: password
    superuser:  
      username: postgres
      password: password
    rewind:
      username: rewind
      password: password
```

Logs:
--------
```
2024-10-02 08:17:40 UTC postgres@postgres 127.0.0.1(44328) [34]:LOG:  connection authorized: user=postgres database=postgres appli>
2024-10-02 08:17:40 UTC postgres@postgres 127.0.0.1(44328) [34]:LOG:  AUDIT: SESSION,1,1,FUNCTION,DO,,,"DO $$
        BEGIN
            SET local synchronous_commit = 'local';
            PERFORM * FROM pg_catalog.pg_authid WHERE rolname = 'postgres';
            IF FOUND THEN
                ALTER ROLE ""postgres"" WITH SUPERUSER LOGIN PASSWORD 'password';
            ELSE
                CREATE ROLE ""postgres"" WITH SUPERUSER LOGIN PASSWORD 'password';
            END IF;
        END;$$",<none>
```