### PR TITLE
Pyright 1.1.385

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -186,7 +186,7 @@ jobs:
 
     - uses: jakebailey/pyright-action@v2
       with:
-        version: 1.1.379
+        version: 1.1.385
 
   docs:
     runs-on: ubuntu-latest

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -8,7 +8,7 @@ import tempfile
 
 from collections import defaultdict
 from copy import deepcopy
-from typing import Any, Callable, Collection, Dict, List, Optional, TYPE_CHECKING, Union
+from typing import Any, Callable, cast, Collection, Dict, List, Optional, TYPE_CHECKING, Union
 
 import yaml
 
@@ -695,8 +695,8 @@ class Config(object):
         config = self._safe_copy_dynamic_configuration(dynamic_configuration)
         for name, value in local_configuration.items():
             if name == 'citus':  # remove invalid citus configuration
-                if isinstance(value, dict) and isinstance(value.get('group'), int)\
-                        and isinstance(value.get('database'), str):
+                if isinstance(value, dict) and isinstance(cast(Dict[str, Any], value).get('group'), int) \
+                        and isinstance(cast(Dict[str, Any], value).get('database'), str):
                     config[name] = value
             elif name == 'postgresql':
                 for name, value in (value or {}).items():

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -10,8 +10,8 @@ from collections import defaultdict
 from copy import deepcopy
 from random import randint
 from threading import Event, Lock
-from typing import Any, Callable, Collection, Dict, Iterator, List, \
-    NamedTuple, Optional, Set, Tuple, Type, TYPE_CHECKING, Union
+from typing import Any, Callable, cast, Collection, Dict, Iterator, \
+    List, NamedTuple, Optional, Set, Tuple, Type, TYPE_CHECKING, Union
 from urllib.parse import parse_qsl, urlparse, urlunparse
 
 import dateutil.parser
@@ -219,7 +219,7 @@ class Member(Tags, NamedTuple('Member',
 
         return None
 
-    def conn_kwargs(self, auth: Union[Any, Dict[str, Any], None] = None) -> Dict[str, Any]:
+    def conn_kwargs(self, auth: Optional[Any] = None) -> Dict[str, Any]:
         """Give keyword arguments used for PostgreSQL connection settings.
 
         :param auth: Authentication properties - can be defined as anything supported by the ``psycopg2`` or
@@ -255,7 +255,7 @@ class Member(Tags, NamedTuple('Member',
 
         # apply any remaining authentication parameters
         if auth and isinstance(auth, dict):
-            ret.update({k: v for k, v in auth.items() if v is not None})
+            ret.update({k: v for k, v in cast(Dict[str, Any], auth).items() if v is not None})
             if 'username' in auth:
                 ret['user'] = ret.pop('username')
         return ret
@@ -949,7 +949,7 @@ class Cluster(NamedTuple('Cluster',
         return candidates[randint(0, len(candidates) - 1)] if candidates else self.leader
 
     @staticmethod
-    def is_physical_slot(value: Union[Any, Dict[str, Any]]) -> bool:
+    def is_physical_slot(value: Any) -> bool:
         """Check whether provided configuration is for permanent physical replication slot.
 
         :param value: configuration of the permanent replication slot.
@@ -957,11 +957,11 @@ class Cluster(NamedTuple('Cluster',
         :returns: ``True`` if *value* is a physical replication slot, otherwise ``False``.
         """
         return not value \
-            or (isinstance(value, dict) and not Cluster.is_logical_slot(value)
-                and value.get('type', 'physical') == 'physical')
+            or (isinstance(value, dict) and not Cluster.is_logical_slot(cast(Dict[str, Any], value))
+                and cast(Dict[str, Any], value).get('type', 'physical') == 'physical')
 
     @staticmethod
-    def is_logical_slot(value: Union[Any, Dict[str, Any]]) -> bool:
+    def is_logical_slot(value: Any) -> bool:
         """Check whether provided configuration is for permanent logical replication slot.
 
         :param value: configuration of the permanent replication slot.
@@ -969,8 +969,8 @@ class Cluster(NamedTuple('Cluster',
         :returns: ``True`` if *value* is a logical replication slot, otherwise ``False``.
         """
         return isinstance(value, dict) \
-            and value.get('type', 'logical') == 'logical' \
-            and bool(value.get('database') and value.get('plugin'))
+            and cast(Dict[str, Any], value).get('type', 'logical') == 'logical' \
+            and bool(cast(Dict[str, Any], value).get('database') and cast(Dict[str, Any], value).get('plugin'))
 
     @property
     def __permanent_slots(self) -> Dict[str, Union[Dict[str, Any], Any]]:
@@ -992,7 +992,7 @@ class Cluster(NamedTuple('Cluster',
                     value['lsn'] = lsn
                 else:
                     # Don't let anyone set 'lsn' in the global configuration :)
-                    value.pop('lsn', None)
+                    value.pop('lsn', None)  # pyright: ignore [reportUnknownMemberType]
         return ret
 
     @property
@@ -1066,8 +1066,9 @@ class Cluster(NamedTuple('Cluster',
                 logger.error("Slot name may only contain lower case letters, numbers, and the underscore chars")
                 continue
 
-            value = deepcopy(value) if value else {'type': 'physical'}
-            if isinstance(value, dict):
+            tmp = deepcopy(value) if value else {'type': 'physical'}
+            if isinstance(tmp, dict):
+                value = cast(Dict[str, Any], tmp)
                 if 'type' not in value:
                     value['type'] = 'logical' if value.get('database') and value.get('plugin') else 'physical'
 

--- a/patroni/dcs/etcd3.py
+++ b/patroni/dcs/etcd3.py
@@ -150,8 +150,7 @@ errStringToClientError = {getattr(s, 'error'): s for s in Etcd3ClientError.get_s
 errCodeToClientError = {getattr(s, 'code'): s for s in Etcd3ClientError.__subclasses__()}
 
 
-def _raise_for_data(data: Union[bytes, str, Dict[str, Union[Any, Dict[str, Any]]]],
-                    status_code: Optional[int] = None) -> Etcd3ClientError:
+def _raise_for_data(data: Union[bytes, str, Dict[str, Any]], status_code: Optional[int] = None) -> Etcd3ClientError:
     try:
         if TYPE_CHECKING:  # pragma: no cover
             assert isinstance(data, dict)

--- a/patroni/dcs/exhibitor.py
+++ b/patroni/dcs/exhibitor.py
@@ -3,7 +3,7 @@ import logging
 import random
 import time
 
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Callable, cast, Dict, List, Union
 
 from ..postgresql.mpp import AbstractMPP
 from ..request import get as requests_get
@@ -41,8 +41,9 @@ class ExhibitorEnsembleProvider(object):
 
         if isinstance(json, dict) and 'servers' in json and 'port' in json:
             self._next_poll = time.time() + self._poll_interval
-            servers: List[str] = json['servers']
-            zookeeper_hosts = ','.join([h + ':' + str(json['port']) for h in sorted(servers)])
+            servers: List[str] = cast(Dict[str, Any], json)['servers']
+            port = str(cast(Dict[str, Any], json)['port'])
+            zookeeper_hosts = ','.join([h + ':' + port for h in sorted(servers)])
             if self._zookeeper_hosts != zookeeper_hosts:
                 logger.info('ZooKeeper connection string has changed: %s => %s', self._zookeeper_hosts, zookeeper_hosts)
                 self._zookeeper_hosts = zookeeper_hosts
@@ -50,7 +51,7 @@ class ExhibitorEnsembleProvider(object):
                 return True
         return False
 
-    def _query_exhibitors(self, exhibitors: List[str]) -> Union[Dict[str, Any], Any]:
+    def _query_exhibitors(self, exhibitors: List[str]) -> Any:
         random.shuffle(exhibitors)
         for host in exhibitors:
             try:

--- a/patroni/dcs/kubernetes.py
+++ b/patroni/dcs/kubernetes.py
@@ -648,7 +648,7 @@ class ObjectCache(Thread):
         with self._object_cache_lock:
             return self._object_cache.get(name)
 
-    def _process_event(self, event: Dict[str, Union[Any, Dict[str, Union[Any, Dict[str, Any]]]]]) -> None:
+    def _process_event(self, event: Dict[str, Any]) -> None:
         ev_type = event['type']
         obj = event['object']
         name = obj['metadata']['name']

--- a/patroni/dcs/raft.py
+++ b/patroni/dcs/raft.py
@@ -255,7 +255,7 @@ class KVStoreTTL(DynMemberSyncObj):
                         self.__limb.pop(key)
                 self._expire(key, value, callback=callback)
 
-    def get(self, key: str, recursive: bool = False) -> Union[None, Dict[str, Any], Dict[str, Dict[str, Any]]]:
+    def get(self, key: str, recursive: bool = False) -> Optional[Dict[str, Any]]:
         if not recursive:
             return self.__data.get(key)
         return {k: v for k, v in self.__data.items() if k.startswith(key)}

--- a/patroni/dcs/zookeeper.py
+++ b/patroni/dcs/zookeeper.py
@@ -4,7 +4,7 @@ import select
 import socket
 import time
 
-from typing import Any, Callable, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
+from typing import Any, Callable, cast, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 from kazoo.client import KazooClient, KazooRetry, KazooState
 from kazoo.exceptions import ConnectionClosedError, NodeExistsError, NoNodeError, SessionExpiredError
@@ -180,7 +180,8 @@ class ZooKeeper(AbstractDCS):
         return int(self._client._session_timeout / 1000.0)
 
     def set_retry_timeout(self, retry_timeout: int) -> None:
-        retry = self._client.retry if isinstance(self._client.retry, KazooRetry) else self._client._retry
+        old_kazoo = isinstance(self._client.retry, KazooRetry)  # pyright: ignore [reportUnnecessaryIsInstance]
+        retry = cast(KazooRetry, self._client.retry) if old_kazoo else self._client._retry
         retry.deadline = retry_timeout
 
     def get_node(

--- a/patroni/global_config.py
+++ b/patroni/global_config.py
@@ -8,7 +8,7 @@ import sys
 import types
 
 from copy import deepcopy
-from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
+from typing import Any, cast, Dict, List, Optional, TYPE_CHECKING
 
 from .collections import EMPTY_DICT
 from .utils import parse_bool, parse_int
@@ -121,7 +121,7 @@ class GlobalConfig(types.ModuleType):
         """``True`` if at least one synchronous node is required."""
         return self.check_mode('synchronous_mode_strict')
 
-    def get_standby_cluster_config(self) -> Union[Dict[str, Any], Any]:
+    def get_standby_cluster_config(self) -> Any:
         """Get ``standby_cluster`` configuration.
 
         :returns: a copy of ``standby_cluster`` configuration.
@@ -133,7 +133,7 @@ class GlobalConfig(types.ModuleType):
         """``True`` if global configuration has a valid ``standby_cluster`` section."""
         config = self.get_standby_cluster_config()
         return isinstance(config, dict) and\
-            bool(config.get('host') or config.get('port') or config.get('restore_command'))
+            any(cast(Dict[str, Any], config).get(p) for p in ('host', 'port', 'restore_command'))
 
     def get_int(self, name: str, default: int = 0, base_unit: Optional[str] = None) -> int:
         """Gets current value of *name* from the global configuration and try to return it as :class:`int`.

--- a/patroni/log.py
+++ b/patroni/log.py
@@ -12,7 +12,7 @@ from io import TextIOWrapper
 from logging.handlers import RotatingFileHandler
 from queue import Full, Queue
 from threading import Lock, Thread
-from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
+from typing import Any, cast, Dict, List, Optional, TYPE_CHECKING, Union
 
 from .file_perm import pg_perm
 from .utils import deep_compare, parse_int
@@ -358,6 +358,7 @@ class PatroniLogger(Thread):
             jsonformat = logformat
             rename_fields = {}
         elif isinstance(logformat, list):
+            logformat = cast(List[Any], logformat)
             log_fields: List[str] = []
             rename_fields: Dict[str, str] = {}
 
@@ -365,6 +366,7 @@ class PatroniLogger(Thread):
                 if isinstance(field, str):
                     log_fields.append(field)
                 elif isinstance(field, dict):
+                    field = cast(Dict[str, Any], field)
                     for original_field, renamed_field in field.items():
                         if isinstance(renamed_field, str):
                             log_fields.append(original_field)

--- a/patroni/postgresql/cancellable.py
+++ b/patroni/postgresql/cancellable.py
@@ -2,7 +2,7 @@ import logging
 import subprocess
 
 from threading import Lock
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 import psutil
 
@@ -76,7 +76,7 @@ class CancellableSubprocess(CancellableExecutor):
         super(CancellableSubprocess, self).__init__()
         self._is_cancelled = False
 
-    def call(self, *args: Any, **kwargs: Union[Any, Dict[str, str]]) -> Optional[int]:
+    def call(self, *args: Any, **kwargs: Any) -> Optional[int]:
         for s in ('stdin', 'stdout', 'stderr'):
             kwargs.pop(s, None)
 

--- a/patroni/postgresql/mpp/citus.py
+++ b/patroni/postgresql/mpp/citus.py
@@ -3,7 +3,7 @@ import re
 import time
 
 from threading import Condition, Event, Thread
-from typing import Any, Collection, Dict, Iterator, List, Optional, Set, Tuple, TYPE_CHECKING, Union
+from typing import Any, cast, Collection, Dict, Iterator, List, Optional, Set, Tuple, TYPE_CHECKING, Union
 from urllib.parse import urlparse
 
 from ...dcs import Cluster
@@ -359,7 +359,7 @@ class Citus(AbstractMPP):
     group_re = re.compile('^(0|[1-9][0-9]*)$')
 
     @staticmethod
-    def validate_config(config: Union[Any, Dict[str, Union[str, int]]]) -> bool:
+    def validate_config(config: Any) -> bool:
         """Check whether provided config is good for a given MPP.
 
         :param config: configuration of ``citus`` MPP section.
@@ -367,8 +367,8 @@ class Citus(AbstractMPP):
         :returns: ``True`` is config passes validation, otherwise ``False``.
         """
         return isinstance(config, dict) \
-            and isinstance(config.get('database'), str) \
-            and parse_int(config.get('group')) is not None
+            and isinstance(cast(Dict[str, Any], config).get('database'), str) \
+            and parse_int(cast(Dict[str, Any], config).get('group')) is not None
 
     @property
     def group(self) -> int:

--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -25,7 +25,7 @@ import time
 from collections import OrderedDict
 from json import JSONDecoder
 from shlex import split
-from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Type, TYPE_CHECKING, Union
+from typing import Any, Callable, cast, Dict, Iterator, List, Optional, Tuple, Type, TYPE_CHECKING, Union
 
 from dateutil import tz
 from urllib3.response import HTTPResponse
@@ -79,7 +79,7 @@ def get_conversion_table(base_unit: str) -> Dict[str, Dict[str, Union[int, float
     return OrderedDict()
 
 
-def deep_compare(obj1: Dict[Any, Union[Any, Dict[Any, Any]]], obj2: Dict[Any, Union[Any, Dict[Any, Any]]]) -> bool:
+def deep_compare(obj1: Dict[Any, Any], obj2: Dict[Any, Any]) -> bool:
     """Recursively compare two dictionaries to check if they are equal in terms of keys and values.
 
     .. note::
@@ -112,14 +112,14 @@ def deep_compare(obj1: Dict[Any, Union[Any, Dict[Any, Any]]], obj2: Dict[Any, Un
 
     for key, value in obj1.items():
         if isinstance(value, dict):
-            if not (isinstance(obj2[key], dict) and deep_compare(value, obj2[key])):
+            if not (isinstance(obj2[key], dict) and deep_compare(cast(Dict[Any, Any], value), obj2[key])):
                 return False
         elif str(value) != str(obj2[key]):
             return False
     return True
 
 
-def patch_config(config: Dict[Any, Union[Any, Dict[Any, Any]]], data: Dict[Any, Union[Any, Dict[Any, Any]]]) -> bool:
+def patch_config(config: Dict[Any, Any], data: Dict[Any, Any]) -> bool:
     """Update and append to dictionary *config* from overrides in *data*.
 
     .. note::
@@ -142,7 +142,7 @@ def patch_config(config: Dict[Any, Union[Any, Dict[Any, Any]]], data: Dict[Any, 
         elif name in config:
             if isinstance(value, dict):
                 if isinstance(config[name], dict):
-                    if patch_config(config[name], value):
+                    if patch_config(config[name], cast(Dict[Any, Any], value)):
                         is_changed = True
                 else:
                     config[name] = value
@@ -156,7 +156,7 @@ def patch_config(config: Dict[Any, Union[Any, Dict[Any, Any]]], data: Dict[Any, 
     return is_changed
 
 
-def parse_bool(value: Any) -> Union[bool, None]:
+def parse_bool(value: Any) -> Optional[bool]:
     """Parse a given value to a :class:`bool` object.
 
     .. note::
@@ -186,7 +186,7 @@ def parse_bool(value: Any) -> Union[bool, None]:
         return False
 
 
-def strtol(value: Any, strict: Optional[bool] = True) -> Tuple[Union[int, None], str]:
+def strtol(value: Any, strict: Optional[bool] = True) -> Tuple[Optional[int], str]:
     """Extract the long integer part from the beginning of a string that represents a configuration value.
 
     As most as possible close equivalent of ``strtol(3)`` C function (with base=0), which is used by postgres to parse
@@ -240,7 +240,7 @@ def strtol(value: Any, strict: Optional[bool] = True) -> Tuple[Union[int, None],
     return (None if strict else 1), value
 
 
-def strtod(value: Any) -> Tuple[Union[float, None], str]:
+def strtod(value: Any) -> Tuple[Optional[float], str]:
     """Extract the double precision part from the beginning of a string that reprensents a configuration value.
 
     As most as possible close equivalent of ``strtod(3)`` C function, which is used by postgres to parse parameter


### PR DESCRIPTION
Declaring variables with `Union` and using `isinstance()` hack doesn't work anymore. Therefore the code is updated to use `Any` for variable and `cast` function after firguring out the correct type in order to avoid getting errors about `Unknown` types.