### PR TITLE
Temporary pin psycopg2-binary version for macOS

### DIFF
--- a/.github/workflows/install_deps.py
+++ b/.github/workflows/install_deps.py
@@ -25,7 +25,8 @@ def install_requirements(what):
     requirements += ['coverage']
     # try to split tests between psycopg2 and psycopg3
     requirements += ['psycopg[binary]'] if sys.version_info >= (3, 8, 0) and\
-        (sys.platform != 'darwin' or what == 'etcd3') else ['psycopg2-binary']
+        (sys.platform != 'darwin' or what == 'etcd3') else ['psycopg2-binary==2.9.9' 
+                                                            if sys.platform == 'darwin' else 'psycopg2-binary']
     for r in read('requirements.txt').split('\n'):
         r = r.strip()
         if r != '':

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,4 @@
+psycopg2-binary==2.9.9; sys_platform == "darwin"
 psycopg2-binary
 behave
 coverage

--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -3,4 +3,5 @@ sphinx_rtd_theme>1
 sphinxcontrib-apidoc
 sphinx-github-style<1.0.3
 psycopg[binary]
+psycopg2-binary==2.9.9; sys_platform == "darwin"
 psycopg2-binary


### PR DESCRIPTION
Use `2.9.9` till `2.9.10` is published properly