### PR TITLE
Fix defaults 'max_wal_senders' and 'max_replication_slots' in documentation

### DIFF
--- a/docs/patroni_configuration.rst
+++ b/docs/patroni_configuration.rst
@@ -49,8 +49,8 @@ Some of the PostgreSQL parameters **must hold the same values on the primary and
 
 For the parameters below, PostgreSQL does not require equal values among the primary and all the replicas. However, considering the possibility of a replica to become the primary at any time, it doesn't really make sense to set them differently; therefore, **Patroni restricts setting their values to the** :ref:`dynamic configuration <dynamic_configuration>`.
 
-- **max_wal_senders**: 5
-- **max_replication_slots**: 5
+- **max_wal_senders**: 10
+- **max_replication_slots**: 10
 - **wal_keep_segments**: 8
 - **wal_keep_size**: 128MB
 


### PR DESCRIPTION
From the actual code, in [patroni/postgresql/config.py::ConfigHandler.CMDLINE_OPTIONS](https://github.com/patroni/patroni/blob/969d7ec4aba6db4c581ee0beb4e1bb31e6ed69bd/patroni/postgresql/config.py#L316), the previous defaults were wrong.