### PR TITLE
Cancel long-running jobs on Patroni stop

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -2297,6 +2297,7 @@ class Ha(object):
                 return 'Unexpected exception raised, please report it as a BUG'
 
     def shutdown(self) -> None:
+        self._async_executor.cancel()
         if self.is_paused():
             logger.info('Leader key is not deleted and Postgresql is not stopped due paused state')
             self.watchdog.disable()

--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -314,6 +314,8 @@ class Bootstrap(object):
                     else:
                         logger.error('Error creating replica using method %s: %s exited with code=%s',
                                      replica_method, cmd, ret)
+                        if not method_config.get('keep_data', False):
+                            self._postgresql.remove_data_directory()
                 except Exception:
                     logger.exception('Error creating replica using method %s', replica_method)
                     ret = 1
@@ -341,10 +343,10 @@ class Bootstrap(object):
         ] + user_options
 
         for bbfailures in range(0, maxfailures):
-            if self._postgresql.cancellable.is_cancelled:
-                break
             if not self._postgresql.data_directory_empty():
                 self._postgresql.remove_data_directory()
+            if self._postgresql.cancellable.is_cancelled:
+                break
             try:
                 logger.debug('calling: %r', cmd)
                 ret = self._postgresql.cancellable.call(cmd, env=env)

--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -314,11 +314,13 @@ class Bootstrap(object):
                     else:
                         logger.error('Error creating replica using method %s: %s exited with code=%s',
                                      replica_method, cmd, ret)
-                        if not method_config.get('keep_data', False):
-                            self._postgresql.remove_data_directory()
                 except Exception:
                     logger.exception('Error creating replica using method %s', replica_method)
                     ret = 1
+
+                # replica creation method failed, clean up data directory if configuration allows
+                if not method_config.get('keep_data', False) and not self._postgresql.data_directory_empty():
+                    self._postgresql.remove_data_directory()
 
         self._postgresql.set_state('stopped')
         return ret
@@ -343,10 +345,10 @@ class Bootstrap(object):
         ] + user_options
 
         for bbfailures in range(0, maxfailures):
-            if not self._postgresql.data_directory_empty():
-                self._postgresql.remove_data_directory()
             if self._postgresql.cancellable.is_cancelled:
                 break
+            if not self._postgresql.data_directory_empty():
+                self._postgresql.remove_data_directory()
             try:
                 logger.debug('calling: %r', cmd)
                 ret = self._postgresql.cancellable.call(cmd, env=env)
@@ -361,6 +363,9 @@ class Bootstrap(object):
             if bbfailures < maxfailures - 1:
                 logger.warning('Trying again in 5 seconds')
                 time.sleep(5)
+            elif not self._postgresql.data_directory_empty():
+                # pg_basebackup failed, clean up data directory
+                self._postgresql.remove_data_directory()
 
         return ret
 


### PR DESCRIPTION
Patroni could be doing replica bootstrap and we don't want want pg_basebackup/wal-g/pgBackRest/barman or similar keep running.

Besides that, remove data directory on replica bootstrap failure if configuration allows.

Close #3224