### PR TITLE
Compatibility with python-json-logger>=3.1

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   unit:
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ fromJson('{"ubuntu":"ubuntu-22.04","windows":"windows-latest","macos":"macos-latest"}')[matrix.os] }}
     strategy:
       fail-fast: false
       matrix:
@@ -93,7 +93,7 @@ jobs:
       run: python -m coveralls --service=github
 
   behave:
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ fromJson('{"ubuntu":"ubuntu-22.04","windows":"windows-latest","macos":"macos-latest"}')[matrix.os] }}
     env:
       DCS: ${{ matrix.dcs }}
       ETCDVERSION: 3.4.23

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -186,7 +186,7 @@ jobs:
 
     - uses: jakebailey/pyright-action@v2
       with:
-        version: 1.1.389
+        version: 1.1.391
 
   ydiff:
     name: Test compatibility with the latest version of ydiff

--- a/patroni/log.py
+++ b/patroni/log.py
@@ -395,14 +395,14 @@ class PatroniLogger(Thread):
         try:
             try:
                 from pythonjsonlogger import json as jsonlogger  # pyright: ignore
-            except ImportError:
-                from pythonjsonlogger import jsonlogger  # pyright: ignore
+            except ImportError:  # pragma: no cover
+                from pythonjsonlogger import jsonlogger
                 if hasattr(jsonlogger, 'RESERVED_ATTRS') \
-                        and 'taskName' not in jsonlogger.RESERVED_ATTRS:  # pragma: no cover
+                        and 'taskName' not in jsonlogger.RESERVED_ATTRS:  # pyright: ignore [reportPrivateImportUsage]
                     # compatibility with python 3.12, that added a new attribute to LogRecord
-                    jsonlogger.RESERVED_ATTRS += ('taskName',)  # pyright: ignore [reportAttributeAccessIssue]
+                    jsonlogger.RESERVED_ATTRS += ('taskName',)  # pyright: ignore
 
-            return jsonlogger.JsonFormatter(
+            return jsonlogger.JsonFormatter(  # pyright: ignore [reportPrivateImportUsage]
                 jsonformat,
                 dateformat,
                 rename_fields=rename_fields,

--- a/patroni/log.py
+++ b/patroni/log.py
@@ -393,11 +393,14 @@ class PatroniLogger(Thread):
             _LOGGER.warning('Expected log format to be a string or a list, but got "%s"', _type(logformat))
 
         try:
-            from pythonjsonlogger import jsonlogger
-            if hasattr(jsonlogger, 'RESERVED_ATTRS') \
-                    and 'taskName' not in jsonlogger.RESERVED_ATTRS:  # pyright: ignore [reportUnnecessaryContains]
-                # compatibility with python 3.12, that added a new attribute to LogRecord
-                jsonlogger.RESERVED_ATTRS += ('taskName',)
+            try:
+                from pythonjsonlogger import json as jsonlogger  # pyright: ignore
+            except ImportError:
+                from pythonjsonlogger import jsonlogger  # pyright: ignore
+                if hasattr(jsonlogger, 'RESERVED_ATTRS') \
+                        and 'taskName' not in jsonlogger.RESERVED_ATTRS:  # pragma: no cover
+                    # compatibility with python 3.12, that added a new attribute to LogRecord
+                    jsonlogger.RESERVED_ATTRS += ('taskName',)  # pyright: ignore [reportAttributeAccessIssue]
 
             return jsonlogger.JsonFormatter(
                 jsonformat,

--- a/patroni/watchdog/base.py
+++ b/patroni/watchdog/base.py
@@ -140,10 +140,8 @@ class Watchdog(object):
             self.impl.open()
             actual_timeout = self._set_timeout()
         except WatchdogError as e:
-            if self.config.mode == MODE_REQUIRED:
-                logger.warning("Could not activate %s: %s", self.impl.describe(), e)
-            else:
-                logger.debug("Could not activate %s: %s", self.impl.describe(), e)
+            log = logger.warning if self.config.mode == MODE_REQUIRED else logger.debug
+            log("Could not activate %s: %s", self.impl.describe(), e)
             self.impl = NullWatchdog()
             actual_timeout = self.impl.get_timeout()
 

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -404,6 +404,7 @@ class TestCtl(unittest.TestCase):
         mock_post.return_value.status = 200
         result = self.runner.invoke(ctl, ctl_args, input='y')
         assert result.exit_code == 0
+        assert 'might be different from the ones' in result.output
 
         # get restart with the non-200 return code
         # normal restart, the schedule is actually parsed, but not validated in patronictl

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -399,6 +399,12 @@ class TestCtl(unittest.TestCase):
         result = self.runner.invoke(ctl, ctl_args, input='y')
         assert result.exit_code == 0
 
+        ctl_args = ['restart', 'alpha', '--pg-version', '99.0', '--pending', '--scheduled', '2300-10-01T14:30']
+        # normal restart, the schedule is actually parsed, but not validated in patronictl
+        mock_post.return_value.status = 200
+        result = self.runner.invoke(ctl, ctl_args, input='y')
+        assert result.exit_code == 0
+
         # get restart with the non-200 return code
         # normal restart, the schedule is actually parsed, but not validated in patronictl
         mock_post.return_value.status = 204

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -13,9 +13,13 @@ from patroni.config import Config
 from patroni.log import PatroniLogger
 
 try:
-    from pythonjsonlogger import jsonlogger
+    try:
+        from pythonjsonlogger import json as jsonlogger
+    except ImportError:
+        from pythonjsonlogger import jsonlogger
 
-    jsonlogger.JsonFormatter(None, None, rename_fields={}, static_fields={})
+        jsonlogger.JsonFormatter(None, None, rename_fields={}, static_fields={})
+
     json_formatter_is_available = True
 
     import json  # we need json.loads() function
@@ -274,6 +278,7 @@ class TestPatroniLogger(unittest.TestCase):
         with self.assertLogs() as captured_log:
             logger = PatroniLogger()
             pythonjsonlogger = Mock()
+            pythonjsonlogger.json.JsonFormatter = Mock(side_effect=Exception)
             pythonjsonlogger.jsonlogger.JsonFormatter = Mock(side_effect=Exception)
             with patch('builtins.__import__', Mock(return_value=pythonjsonlogger)):
                 logger.reload_config({'type': 'json'})


### PR DESCRIPTION
After refactoring the old API is still working, but producing warnings and pyright also fails.

Besides that improve coverage of watchdog/base.py and ctl.py