### PR TITLE
Fix label migration documentation example

### DIFF
--- a/docs/kubernetes.rst
+++ b/docs/kubernetes.rst
@@ -40,7 +40,7 @@ Customize role label
 By default, Patroni will set corresponding labels on the pod it runs in based on node's role, such as ``role=primary``.
 The key and value of label can be customized by `kubernetes.role_label`, `kubernetes.leader_label_value`, `kubernetes.follower_label_value` and `kubernetes.standby_leader_label_value`.
 
-Note that if you migrate from default role labels to custom ones, you can reduce downtime by following migration steps:
+Note that if you migrate from previous role labels to new ones, i.e. from `master` to `primary`, you can reduce downtime by following migration steps:
 
 1. Add a temporary label using original role value for the pod with `kubernetes.tmp_role_label` (like ``tmp_role``). Once pods are restarted they will get following labels set by Patroni:
 
@@ -48,8 +48,8 @@ Note that if you migrate from default role labels to custom ones, you can reduce
 
     labels:
       cluster-name: foo
-      role: primary
-      tmp_role: primary
+      role: master
+      tmp_role: master
 
 2. After all pods have been updated, modify the service selector to select the temporary label.
 
@@ -57,7 +57,7 @@ Note that if you migrate from default role labels to custom ones, you can reduce
 
     selector:
       cluster-name: foo
-      tmp_role: primary
+      tmp_role: master
 
 3. Add your custom role label (e.g., set `kubernetes.leader_label_value=primary`). Once pods are restarted they will get following new labels set by Patroni:
 
@@ -66,7 +66,7 @@ Note that if you migrate from default role labels to custom ones, you can reduce
     labels:
       cluster-name: foo
       role: primary
-      tmp_role: primary
+      tmp_role: master
 
 4. After all pods have been updated again, modify the service selector to use new role value.
 


### PR DESCRIPTION
This PR addresses an issue in the documentation example for label migration. Previously, the old label value and the new label value were identical, which caused confusion. While this setup was [initially correct](https://github.com/patroni/patroni/pull/2659/files), it appears to have been overwritten at some point. This PR fixes the example to ensure clarity.