### PR TITLE
Compatibility with python 3.13

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,10 +83,13 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.13
+      if: matrix.os != 'macos'
     - name: Install dependencies
       run: python .github/workflows/install_deps.py
+      if: matrix.os != 'macos'
     - name: Run tests and flake8
       run: python .github/workflows/run_tests.py
+      if: matrix.os != 'macos'
 
     - name: Combine coverage
       run: python .github/workflows/run_tests.py combine

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -79,6 +79,15 @@ jobs:
     - name: Run tests and flake8
       run: python .github/workflows/run_tests.py
 
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.13
+    - name: Install dependencies
+      run: python .github/workflows/install_deps.py
+    - name: Run tests and flake8
+      run: python .github/workflows/run_tests.py
+
     - name: Combine coverage
       run: python .github/workflows/run_tests.py combine
 
@@ -102,7 +111,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        python-version: [3.7, 3.12]
+        python-version: [3.7, 3.13]
         dcs: [etcd, etcd3, consul, exhibitor, kubernetes, raft]
         include:
         - os: macos
@@ -194,10 +203,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.12
+    - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12
+        python-version: 3.13
     - name: Install dependencies
       run: python .github/workflows/install_deps.py
     - name: Update ydiff

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Programming Language :: Python :: Implementation :: CPython',
 ]
 

--- a/tests/test_consul.py
+++ b/tests/test_consul.py
@@ -196,7 +196,8 @@ class TestConsul(unittest.TestCase):
                 self.assertTrue(self.c.update_leader(cluster, 12345, failsafe={'foo': 'bar'}))
             with patch.object(KV, 'put', Mock(side_effect=ConsulException)):
                 self.assertFalse(self.c.update_leader(cluster, 12345))
-            with patch('time.time', Mock(side_effect=[0, 0, 0, 0, 100, 200, 300])):
+            mock_time = Mock(side_effect=[0, 0, 0, 0, 100, 200, 300])
+            with patch('time.time', mock_time), patch('time.time_ns', mock_time):
                 self.assertRaises(ConsulError, self.c.update_leader, cluster, 12345)
         with patch('time.time', Mock(side_effect=[0, 100, 200, 300])):
             self.assertRaises(ConsulError, self.c.update_leader, cluster, 12345)

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -425,7 +425,8 @@ class TestKubernetesEndpoints(BaseTestKubernetes):
         mock_patch.side_effect = [k8s_client.rest.ApiException(409, ''),
                                   k8s_client.rest.ApiException(409, ''), mock_namespaced_kind()]
         mock_read.return_value.metadata.resource_version = '2'
-        with patch('time.time', Mock(side_effect=[0, 0, 100, 200, 0, 0, 0, 0, 0, 100, 200])):
+        mock_time = Mock(side_effect=[0, 0, 100, 200, 0, 0, 0, 0, 0, 100, 200])
+        with patch('time.time', mock_time), patch('time.time_ns', mock_time):
             self.assertFalse(self.k.update_leader(cluster, '123'))
             self.assertFalse(self.k.update_leader(cluster, '123'))
         mock_patch.side_effect = k8s_client.rest.ApiException(409, '')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [common]
-python_matrix = {36,37,38,39,310,311}
+python_matrix = {36,37,38,39,310,311,312,313}
 postgres_matrix =
     pg11: PG_MAJOR = 11
     pg12: PG_MAJOR = 12
@@ -8,7 +8,7 @@ postgres_matrix =
     pg15: PG_MAJOR = 15
     pg16: PG_MAJOR = 16
 psycopg_deps =
-    py{37,38,39,310,311}-{lin,win}: psycopg[binary]
+    py{37,38,39,310,311,312,313}-{lin,win}: psycopg[binary]
     mac: psycopg2-binary
     py36: psycopg2-binary
 platforms =
@@ -44,7 +44,7 @@ commands = flake8 {posargs:patroni tests setup.py}
 deps =
     flake8
 
-[testenv:py{36,37,38,39,310,311}-test-{lin,win,mac}]
+[testenv:py{36,37,38,39,310,311,312,313}-test-{lin,win,mac}]
 description = Run unit tests with pytest
 labels =
     test
@@ -88,7 +88,7 @@ deps =
     pipdeptree
     {[common]psycopg_deps}
 
-[testenv:py{37,38,39,310,311}-type-{lin,mac,win}]
+[testenv:py{37,38,39,310,311,312,313}-type-{lin,mac,win}]
 description = Run static type checking with pyright
 labels =
     type
@@ -137,7 +137,7 @@ depends =
     pg{11,12,13,14,15,16}-docker-build
 
 # There's a bug which affects calling multiple envs on the command line
-# This should be a valid command: tox -e 'py{36,37,38,39,310,311}-behave-{env:DCS}-lin'
+# This should be a valid command: tox -e 'py{36,37,38,39,310,311,312,313}-behave-{env:DCS}-lin'
 # Replaced with workaround, see https://github.com/tox-dev/tox/issues/2850
 commands =
     docker run \
@@ -159,7 +159,7 @@ platform =
 ;    win: win32
     mac: darwin
 
-[testenv:py{36,38,39,310,311}-behave-{etcd,etcd3}-{lin,win,mac}]
+[testenv:py{36,38,39,310,311,312,313}-behave-{etcd,etcd3}-{lin,win,mac}]
 description = Run behaviour tests (locally with tox)
 deps =
     -r requirements.txt


### PR DESCRIPTION
- fix unit tests (logging now uses time.time_ns() instead of time.time())
- update setup.py
- update tox.ini
- enable unix and behave tests with 3.13

Close https://github.com/patroni/patroni/issues/3243