### PR TITLE
Replace forward slash in cluster_name

### DIFF
--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -2065,9 +2065,10 @@ def invoke_editor(before_editing: str, cluster_name: str) -> Tuple[str, Dict[str
     if not editor_cmd:
         raise PatroniCtlException('EDITOR environment variable is not set. editor or vi are not available')
 
+    safe_cluster_name = cluster_name.replace("/", "_")
     with temporary_file(contents=before_editing.encode('utf-8'),
                         suffix='.yaml',
-                        prefix='{0}-config-'.format(cluster_name)) as tmpfile:
+                        prefix='{0}-config-'.format(safe_cluster_name)) as tmpfile:
         ret = subprocess.call([editor_cmd, tmpfile])
         if ret:
             raise PatroniCtlException("Editor exited with return code {0}".format(ret))


### PR DESCRIPTION
If cluster name was defined with a "/" in it, which is actually normal if `pg_createcluster` was used, then trying to launch `patronictl edit-config` will result in an error that looks like this:

```
...
  File "/usr/lib/python3.12/tempfile.py", line 395, in _mkstemp_inner
    fd = _os.open(file, flags, 0o600)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/14/main-config-guh3an57.yaml'
```

It took me a while to understand what's going on, that it was trying to save temporary file in `/tmp/14/` (my cluster name is `14/main`), so I propose this change that would not make it happen.