### PR TITLE
When failsafe mode ends on the leader, write an explicit log message.

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -2239,6 +2239,8 @@ class Ha(object):
         finally:
             if not dcs_failed:
                 if self.is_leader():
+                    if self._failsafe.is_active():
+                        logger.info('DCS recovered, failsafe mode ending and we remain the leader')
                     self._failsafe.set_is_active(0)
                 self.touch_member()
 


### PR DESCRIPTION
A few days ago, my DCS (k8s API server) went down. This engaged failsafe mode, and separately, caused [a replication issue](https://github.com/patroni/patroni/issues/3248). While failsafe mode started and ended as designed, the replication issue did not resolve automatically. Before trying to resolve the replication issue, I was looking for a clue that failsafe mode ended (so as to prevent leader demotion if I restart the replica), but this clue is implicit and not explicit. Aggravated by log messages for other issues, this makes it hard for someone unfamiliar with the inner workings of Patroni, to understand the current state of Patroni from the logs.

This PR adds a single log message. When (1) we are currently leader, (2) failsafe mode is active, and (3) DCS is responding again, we write a message saying DCS recovered and failsafe mode is ending.

Notably this does not write the message on the replicas, only on the leader. This is analogous to the "failsafe mode enabled" message also only appearing on the leader. If there is no leader anymore, then DCS recovering will clearly perform a leader election and promotion of a new leader, so the message is not necessary.

I also considered adding a prefix to log messages as long as failsafe mode is active, similarly to the PAUSE prefix, but in fact this only prepends the periodic "failsafe mode enabled" message with a "FAILSAFE" prefix and therefore does not add any clarity. Ending of the failsafe mode is still implicit in this case.