### PR TITLE
Investigating Flaky Tests in Patroni

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -329,15 +329,14 @@ class TestRestApiHandler(unittest.TestCase):
                                           'tag_key1=true&tag_key2=false&'
                                           'tag_key3=1&tag_key4=1.4&tag_key5=RandomTag&tag_key6=RandomTag2')
 
-    def test_do_OPTIONS(self):
-        if MockPatroni.dcs.cluster:
-           MockPatroni.dcs.cluster.status.last_lsn = 20
+    @patch.object(MockPatroni, 'dcs')
+    def test_do_OPTIONS(self, mock_dcs):
+        mock_dcs.cluster.status.last_lsn = 20
         self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'OPTIONS / HTTP/1.0'))
 
-    def test_do_HEAD(self):
-        if MockPatroni.dcs.cluster:
-           MockPatroni.dcs.cluster.status.last_lsn = 20
-
+    @patch.object(MockPatroni, 'dcs')
+    def test_do_HEAD(self, mock_dcs):
+        mock_dcs.cluster.status.last_lsn = 20
         self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'HEAD / HTTP/1.0'))
 
     @patch.object(MockPatroni, 'dcs')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -330,9 +330,14 @@ class TestRestApiHandler(unittest.TestCase):
                                           'tag_key3=1&tag_key4=1.4&tag_key5=RandomTag&tag_key6=RandomTag2')
 
     def test_do_OPTIONS(self):
+        if MockPatroni.dcs.cluster:
+           MockPatroni.dcs.cluster.status.last_lsn = 20
         self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'OPTIONS / HTTP/1.0'))
 
     def test_do_HEAD(self):
+        if MockPatroni.dcs.cluster:
+           MockPatroni.dcs.cluster.status.last_lsn = 20
+
         self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'HEAD / HTTP/1.0'))
 
     @patch.object(MockPatroni, 'dcs')

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -88,6 +88,14 @@ def mock_load_k8s_config(self, *args, **kwargs):
     self._server = 'http://localhost'
 
 
+config = {
+    "current-context": "local",
+    "contexts": [{"name": "local", "context": {"user": "local", "cluster": "local"}}],
+    "clusters": [{"name": "local", "cluster": {"server": "https://a:1/", "certificate-authority": "a"}}],
+    "users": [{"name": "local", "user": {"username": "a", "password": "b", "client-certificate": "c"}}]
+}
+
+
 class TestK8sConfig(unittest.TestCase):
 
     def test_load_incluster_config(self):
@@ -128,12 +136,6 @@ class TestK8sConfig(unittest.TestCase):
             self.assertEqual(k8s_config.headers.get('authorization'), 'Bearer c')
 
     def test_load_kube_config(self):
-        config = {
-            "current-context": "local",
-            "contexts": [{"name": "local", "context": {"user": "local", "cluster": "local"}}],
-            "clusters": [{"name": "local", "cluster": {"server": "https://a:1/", "certificate-authority": "a"}}],
-            "users": [{"name": "local", "user": {"username": "a", "password": "b", "client-certificate": "c"}}]
-        }
         with patch('builtins.open', mock_open(read_data=json.dumps(config))):
             k8s_config.load_kube_config()
             self.assertEqual(k8s_config.server, 'https://a:1')
@@ -170,6 +172,9 @@ class TestApiClient(unittest.TestCase):
         self.mock_get_ep = MockResponse()
         self.mock_get_ep.content = '{"subsets":[{"ports":[{"name":"https","protocol":"TCP","port":443}],' +\
                                    '"addresses":[{"ip":"127.0.0.1"},{"ip":"127.0.0.2"}]}]}'
+
+        with patch('builtins.open', mock_open(read_data=json.dumps(config))):
+            k8s_config.load_kube_config()
 
     def test__do_http_request(self, mock_request):
         mock_request.side_effect = [self.mock_get_ep] + [socket.timeout]

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -83,6 +83,8 @@ class TestPatroniLogger(unittest.TestCase):
             self.assertRaises(Exception, logger.shutdown)
         self.assertLessEqual(logger.queue_size, 2)  # "Failed to close the old log handler" could be still in the queue
         self.assertEqual(logger.records_lost, 0)
+        del config['log']['traceback_level']
+        logger.reload_config(config)
 
     def test_interceptor(self):
         logger = PatroniLogger()

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -229,11 +229,10 @@ class TestValidator(unittest.TestCase):
         c["kubernetes"]["pod_ip"] = "::1"
         c["consul"]["host"] = "127.0.0.1:50000"
         c["etcd"]["host"] = "127.0.0.1:237"
-        c["postgresql"]["listen"] = "127.0.0.1:5432"
         with patch('patroni.validator.open', mock_open(read_data='9')):
             errors = schema(c)
         output = "\n".join(errors)
-        self.assertEqual(['consul.host', 'etcd.host', 'postgresql.bin_dir', 'postgresql.data_dir', 'postgresql.listen',
+        self.assertEqual(['consul.host', 'etcd.host', 'postgresql.bin_dir', 'postgresql.data_dir',
                           'raft.bind_addr', 'raft.self_addr', 'restapi.connect_address'], parse_output(output))
 
     def test_bin_dir_is_empty_string_executables_in_path(self, mock_out, mock_err):


### PR DESCRIPTION
For a university course, I tested this project for flaky tests, which are tests that can both pass or fail without changes to their code. Identifying and addressing flaky tests is important as they hinder the ability to run smaller test sets or execute tests in random order, which are valuable for faster feedback cycles and uncovering hidden dependencies.

During my investigation, I focused on the following test cases:

- `tests/test_validator.py::TestValidator::test_bin_dir_is_empty`
- `tests/test_api.py::TestRestApiHandler::test_do_HEAD`
- `tests/test_api.py::TestRestApiHandler::test_do_OPTIONS`
- `tests/test_kubernetes.py::TestApiClient::test__do_http_request`
- `tests/test_kubernetes.py::TestApiClient::test__refresh_api_servers_cache`
- `tests/test_kubernetes.py::TestApiClient::test_request`

Reproduction Instructions:
The flaky behavior can be reproduced using the following commands with fixed random seeds, on the current master branch:

- test_kubernetes tests:
```bash
pytest tests/test_kubernetes.py::TestApiClient --randomly-seed=800464
```
- test_api tests:
```bash
pytest tests/test_api.py::TestRestApiHandler --randomly-seed=362961
```
- test_validator test:
```bash
pytest tests/test_validator.py::TestValidator --randomly-seed=863421
```
---

### Additional Findings / Future Work:
I also discovered additional flaky tests that seem to be connected by a shared polluter but could not fully resolve them:

- `tests/test_ha.py::TestHa::test__process_quorum_replication`
- `tests/test_postgresql.py::TestPostgresql::test_stop`
- `tests/test_slots.py::TestSlotsHandler::test_sync_replication_slots`

The smallest test set to reproduce this issue is:
```bash
pytest -x --randomly-seed=871764 tests/test_log.py::TestPatroniLogger::test_patroni_logger tests/test_postgresql.py::TestPostgresql::test_stop
```
I suspect that the logger is not properly shut down at the end of the test_patroni_logger function, which may be causing these flaky tests.