### PR TITLE
Implement --print option for --validate-config

### DIFF
--- a/docs/patroni_configuration.rst
+++ b/docs/patroni_configuration.rst
@@ -253,3 +253,6 @@ Parameters
 
 ``--ignore-listen-port | -i``
     Optional flag to ignore bind failures for ``listen`` ports that are already in use when validating the ``configfile``.
+
+``--print | -p``
+    Optional flag to print out local configuration (including environment configuration overrides) after it has been successfully validated.

--- a/patroni/__main__.py
+++ b/patroni/__main__.py
@@ -254,7 +254,7 @@ def process_arguments() -> Namespace:
       * ``--generate-sample-config`` -- used to generate a sample Patroni configuration
       * ``--ignore-listen-port`` | ``-i`` -- used to ignore ``listen`` ports already in use.
           Can be used only with ``--validate-config``
-      * ``--print`` -- used to print out local configuration (incl. environment configuration overrides).
+      * ``--print`` | ``-p`` -- used to print out local configuration (incl. environment configuration overrides).
           Can be used only with ``--validate-config``
 
     .. note::
@@ -277,7 +277,7 @@ def process_arguments() -> Namespace:
     parser.add_argument('--ignore-listen-port', '-i', action='store_true',
                         help='Ignore `listen` ports already in use.\
                               Can only be used with --validate-config')
-    parser.add_argument('--print', action='store_true',
+    parser.add_argument('--print', '-p', action='store_true',
                         help='Print out local configuration (incl. environment configuration overrides).\
                               Can only be used with --validate-config')
     args = parser.parse_args()

--- a/patroni/__main__.py
+++ b/patroni/__main__.py
@@ -12,8 +12,6 @@ import time
 from argparse import Namespace
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
-import yaml
-
 from patroni import MIN_PSYCOPG2, MIN_PSYCOPG3, parse_version
 from patroni.daemon import abstract_main, AbstractPatroniDaemon, get_base_arg_parser
 from patroni.tags import Tags
@@ -302,6 +300,7 @@ def process_arguments() -> Namespace:
             sys.exit(e.value)
 
         if args.print:
+            import yaml
             yaml.safe_dump(config.local_configuration, sys.stdout, default_flow_style=False, allow_unicode=True)
         sys.exit()
 

--- a/patroni/__main__.py
+++ b/patroni/__main__.py
@@ -12,6 +12,8 @@ import time
 from argparse import Namespace
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
+import yaml
+
 from patroni import MIN_PSYCOPG2, MIN_PSYCOPG3, parse_version
 from patroni.daemon import abstract_main, AbstractPatroniDaemon, get_base_arg_parser
 from patroni.tags import Tags
@@ -254,6 +256,8 @@ def process_arguments() -> Namespace:
       * ``--generate-sample-config`` -- used to generate a sample Patroni configuration
       * ``--ignore-listen-port`` | ``-i`` -- used to ignore ``listen`` ports already in use.
           Can be used only with ``--validate-config``
+      * ``--print`` -- used to print out local configuration (incl. environment configuration overrides).
+          Can be used only with ``--validate-config``
 
     .. note::
         If running with ``--generate-config``, ``--generate-sample-config`` or ``--validate-flag`` will exit
@@ -275,6 +279,9 @@ def process_arguments() -> Namespace:
     parser.add_argument('--ignore-listen-port', '-i', action='store_true',
                         help='Ignore `listen` ports already in use.\
                               Can only be used with --validate-config')
+    parser.add_argument('--print', action='store_true',
+                        help='Print out local configuration (incl. environment configuration overrides).\
+                              Can only be used with --validate-config')
     args = parser.parse_args()
 
     if args.generate_sample_config:
@@ -290,10 +297,13 @@ def process_arguments() -> Namespace:
         populate_validate_params(ignore_listen_port=args.ignore_listen_port)
 
         try:
-            Config(args.configfile, validator=schema)
-            sys.exit()
+            config = Config(args.configfile, validator=schema)
         except ConfigParseError as e:
             sys.exit(e.value)
+
+        if args.print:
+            yaml.safe_dump(config.local_configuration, sys.stdout, default_flow_style=False, allow_unicode=True)
+        sys.exit()
 
     return args
 

--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -64,11 +64,12 @@ class TestPatroni(unittest.TestCase):
     def test_no_config(self):
         self.assertRaises(SystemExit, _main)
 
-    @patch('sys.argv', ['patroni.py', '--validate-config', 'postgres0.yml'])
+    @patch('sys.argv', ['patroni.py', '--print', '--validate-config', 'postgres0.yml'])
     @patch('socket.socket.connect_ex', Mock(return_value=1))
     def test_validate_config(self):
         self.assertRaises(SystemExit, _main)
-        with patch.object(config.Config, '__init__', Mock(return_value=None)):
+        with patch.object(config.Config, '__init__', Mock(return_value=None)), \
+             patch.object(config.Config, 'local_configuration', PropertyMock(return_value={})):
             self.assertRaises(SystemExit, _main)
 
     @patch('pkgutil.iter_importers', Mock(return_value=[MockFrozenImporter()]))


### PR DESCRIPTION
to get the resulting yaml file+env override configuration after it has been successfully validated 

wip: docs