### PR TITLE
Add support for systemd "notify" unit type

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,8 @@ raft
     `pysyncobj` module in order to use python Raft implementation as DCS
 aws
     `boto3` in order to use AWS callbacks
+systemd
+    `systemd-python` in order to use sd_notify integration
 all
     all of the above (except psycopg family)
 psycopg3

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -62,6 +62,8 @@ aws
     `boto3` in order to use AWS callbacks
 jsonlogger
     `python-json-logger` module in order to enable :ref:`logging <log_settings>` in json format
+systemd
+    `systemd-python` in order to use sd_notify integration
 all
     all of the above (except psycopg family)
 psycopg

--- a/extras/startup-scripts/patroni.service
+++ b/extras/startup-scripts/patroni.service
@@ -6,7 +6,7 @@ Description=Runners to orchestrate a high-availability PostgreSQL
 After=syslog.target network.target
 
 [Service]
-Type=simple
+Type=notify
 
 User=postgres
 Group=postgres

--- a/patroni/daemon.py
+++ b/patroni/daemon.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 
 import abc
 import argparse
+import logging
 import os
 import signal
 import sys
@@ -16,6 +17,8 @@ from typing import Any, Optional, Type, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
     from .config import Config
+
+logger = logging.getLogger(__name__)
 
 
 def get_base_arg_parser() -> argparse.ArgumentParser:
@@ -134,10 +137,10 @@ class AbstractPatroniDaemon(abc.ABC):
         Start the logger thread and keep running execution cycles until a SIGTERM is eventually received. Also reload
         configuration upon receiving SIGHUP.
         """
-        try:
-            from systemd import daemon
-            daemon.notify("READY=1")
-        except ImportError:
+        try:  # pragma: no cover
+            from systemd import daemon  # pyright: ignore
+            daemon.notify("READY=1")  # pyright: ignore
+        except ImportError:  # pragma: no cover
             logger.info("Systemd integration is not supported")
         self.logger.start()
         while not self.received_sigterm:

--- a/patroni/daemon.py
+++ b/patroni/daemon.py
@@ -134,6 +134,11 @@ class AbstractPatroniDaemon(abc.ABC):
         Start the logger thread and keep running execution cycles until a SIGTERM is eventually received. Also reload
         configuration upon receiving SIGHUP.
         """
+        try:
+            from systemd import daemon
+            daemon.notify("READY=1")
+        except ImportError:
+            logger.info("Systemd integration is not supported")
         self.logger.start()
         while not self.received_sigterm:
             if self._received_sighup:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,3 @@ cryptography>=1.4
 psutil>=2.0.0
 ydiff>=1.2.0,<1.5,!=1.4.0,!=1.4.1
 python-json-logger>=2.0.2
-systemd-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ cryptography>=1.4
 psutil>=2.0.0
 ydiff>=1.2.0,<1.5,!=1.4.0,!=1.4.1
 python-json-logger>=2.0.2
+systemd-python

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ KEYWORDS = 'etcd governor patroni postgresql postgres ha haproxy confd' +\
 
 EXTRAS_REQUIRE = {'aws': ['boto3'], 'etcd': ['python-etcd'], 'etcd3': ['python-etcd'],
                   'consul': ['py-consul'], 'exhibitor': ['kazoo'], 'zookeeper': ['kazoo'],
+                  'systemd': ['systemd-python'],
                   'kubernetes': [], 'raft': ['pysyncobj', 'cryptography'], 'jsonlogger': ['python-json-logger']}
 
 # Add here all kinds of additional classifiers as defined under


### PR DESCRIPTION
  Add support for systemd "notify" unit type
    
Without a notify unit type, it is possible to start patroni and
immediately send it a SIGHUP signal using systemd, effectively killing
it before it had time to setup it's signal handlers.

See issue #3300 
