### PR TITLE
Fix permissions of out-of-PGDATA created postgresql.conf

### DIFF
--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -477,16 +477,19 @@ class ConfigHandler(object):
         return configuration
 
     def set_file_permissions(self, filename: str) -> None:
-        """Set permissions of file *filename* according to the expected permissions if it resides under PGDATA.
+        """Set permissions of file *filename* according to the expected permissions.
 
         .. note::
-            Do nothing if the file is not under PGDATA.
+            Use original umask if the file is not under PGDATA, use PGDATA
+            permissions otherwise.
 
         :param filename: path to a file which permissions might need to be adjusted.
         """
         if is_subpath(self._postgresql.data_dir, filename):
             pg_perm.set_permissions_from_data_directory(self._postgresql.data_dir)
             os.chmod(filename, pg_perm.file_create_mode)
+        else:
+            os.chmod(filename, 0o666 & ~pg_perm.orig_umask)
 
     @contextmanager
     def config_writer(self, filename: str) -> Iterator[ConfigWriter]:


### PR DESCRIPTION
Since 01d07f86c, the permissions of `postgresql.conf` created in PGDATA was explicitly set. However, the umask of the Patroni process was adjusted as well and as a result of this, Patroni would write `postgresql.conf` with 600 permissions if the configuration files are outside PGDATA.

Fix this by using the original umask as mode for files created outside PGDATA.

Fixes: #3302