### PR TITLE
Fix some errors in patroni_configuration.rst

### DIFF
--- a/docs/patroni_configuration.rst
+++ b/docs/patroni_configuration.rst
@@ -53,6 +53,7 @@ For the parameters below, PostgreSQL does not require equal values among the pri
 - **max_replication_slots**: 10
 - **wal_keep_segments**: 8
 - **wal_keep_size**: 128MB
+- **wal_log_hints**: on
 
 These parameters are validated to ensure they are sane, or meet a minimum value.
 
@@ -63,7 +64,7 @@ There are some other Postgres parameters controlled by Patroni:
 - **cluster_name** - is set either from ``scope`` or from ``PATRONI_SCOPE`` environment variable
 - **hot_standby: on**
 
-To be on the safe side parameters from the above lists are not written into ``postgresql.conf``, but passed as a list of arguments to the ``pg_ctl start`` which gives them the highest precedence, even above `ALTER SYSTEM <https://www.postgresql.org/docs/current/static/sql-altersystem.html>`__
+To be on the safe side parameters from the above lists are written into ``postgresql.conf``, and passed as a list of arguments to the ``postgres`` which gives them the highest precedence (except ``wal_keep_segments`` and ``wal_keep_size``), even above `ALTER SYSTEM <https://www.postgresql.org/docs/current/static/sql-altersystem.html>`__
 
 There also are some parameters like **postgresql.listen**, **postgresql.data_dir** that **can be set only locally**, i.e. in the Patroni :ref:`config file <yaml_configuration>` or via :ref:`configuration <environment>` variable. In most cases the local configuration will override the dynamic configuration.
 


### PR DESCRIPTION
Fix the following errors in section "*PostgreSQL parameters controlled by Patroni*":

1. Supplement the missing parameter `wal_log_hints`.
2. In fact, these controlled parameters are written into `postgresql.conf`.
3. In fact, these controlled parameters are passed as a list of arguments to the `postgres` (not `pg_ctl start`).
4. Add a note about that `wal_keep_segments` and `wal_keep_size` are not passed to the `postgres`.