### PR TITLE
Maintain New Invariant For synchronous_mode_strict

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -961,11 +961,17 @@ class Ha(object):
         # update synchronous standby list in dcs temporarily to point to common nodes in current and picked
         sync_common = voters & allow_promote
         if sync_common != voters:
-            logger.info("Updating synchronous privilege temporarily from %s to %s",
-                        list(voters), list(sync_common))
-            sync = self.dcs.write_sync_state(self.state_handler.name, sync_common, 0, version=sync.version)
-            if not sync:
-                return logger.info('Synchronous replication key updated by someone else.')
+            if global_config.is_synchronous_mode_strict and not sync_common:
+                logger.info("Keeping existing sync replicas in /sync to maintain strict mode invariant: %s",
+                            list(voters))
+                if not picked:
+                    return
+            else:
+                logger.info("Updating synchronous privilege temporarily from %s to %s",
+                            list(voters), list(sync_common))
+                sync = self.dcs.write_sync_state(self.state_handler.name, sync_common, 0, version=sync.version)
+                if not sync:
+                    return logger.info('Synchronous replication key updated by someone else.')
 
         # When strict mode and no suitable replication connections put "*" to synchronous_standby_names
         if global_config.is_synchronous_mode_strict and not picked:

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -1511,15 +1511,67 @@ class TestHa(PostgresInit):
         self.ha.run_cycle()
         self.assertEqual(self.ha.dcs.write_sync_state.call_count, 2)
 
-        # Test sync set to '*' when synchronous_mode_strict is enabled
+        # Test do-nothing when strict mode is enabled and the last sync replica is being removed
+        # with no replacement: both /sync and synchronous_standby_names must be left untouched so
+        # commits keep blocking on the lost member and it remains promotable when it returns.
         mock_set_sync.reset_mock()
         mock_cfg_set_sync.reset_mock()
         self.p.sync_handler.current_state = Mock(return_value=_SyncState('priority', 0, CaseInsensitiveSet(),
                                                                          CaseInsensitiveSet(), CaseInsensitiveSet()))
+        self.ha.cluster = get_cluster_initialized_with_leader(sync=('leader', 'other'))
+        self.ha.dcs.write_sync_state = Mock(return_value=SyncState.empty())
         with patch.object(global_config.__class__, 'is_synchronous_mode_strict', PropertyMock(return_value=True)):
             self.ha.run_cycle()
-        mock_set_sync.assert_called_once_with(CaseInsensitiveSet('*'))
+        mock_set_sync.assert_not_called()
         mock_cfg_set_sync.assert_not_called()
+        self.ha.dcs.write_sync_state.assert_not_called()
+
+        # Test strict mode: /sync is updated (not blocked) when a new replica C replaces departed replica B.
+        # Scenario: /sync has ['other'] as voter, 'other' is gone but 'other2' has connected and is confirmed sync.
+        # The fix must NOT block updates when allow_promote has members -- only when it would write an empty set.
+        mock_set_sync.reset_mock()
+        mock_cfg_set_sync.reset_mock()
+        self.p.sync_handler.current_state = Mock(return_value=_SyncState('priority', 1,
+                                                                         CaseInsensitiveSet(['other2']),
+                                                                         CaseInsensitiveSet(['other2']),
+                                                                         CaseInsensitiveSet(['other2'])))
+        self.ha.cluster = get_cluster_initialized_with_leader(sync=('leader', 'other'))
+        self.ha.dcs.write_sync_state = Mock(return_value=SyncState.empty())
+        with patch.object(global_config.__class__, 'is_synchronous_mode_strict', PropertyMock(return_value=True)):
+            self.ha.run_cycle()
+        # sync_common = {'other'} & {'other2'} = {} but allow_promote = {'other2'} is not empty,
+        # so we skip the empty DCS write but later write allow_promote={'other2'} to /sync.
+        # synchronous_standby_names should be updated to include 'other2'.
+        mock_set_sync.assert_called_once_with(CaseInsensitiveSet(['other2']))
+        # The DCS should be written once with allow_promote='other2' (the final write at the end of the method)
+        self.assertEqual(self.ha.dcs.write_sync_state.call_count, 1)
+
+        # Test non-strict mode still clears /sync normally when sync_common is empty
+        mock_set_sync.reset_mock()
+        mock_cfg_set_sync.reset_mock()
+        self.p.sync_handler.current_state = Mock(return_value=_SyncState('priority', 0, CaseInsensitiveSet(),
+                                                                         CaseInsensitiveSet(), CaseInsensitiveSet()))
+        self.ha.cluster = get_cluster_initialized_with_leader(sync=('leader', 'other'))
+        self.ha.dcs.write_sync_state = Mock(return_value=SyncState.empty())
+        self.ha.run_cycle()
+        # Without strict mode, the DCS write should happen to clear /sync (write empty sync_common)
+        self.ha.dcs.write_sync_state.assert_called()
+        mock_set_sync.assert_called_once_with(CaseInsensitiveSet())
+
+        # Test strict mode with multiple voters: some overlap exists, should update normally
+        mock_set_sync.reset_mock()
+        mock_cfg_set_sync.reset_mock()
+        self.p.sync_handler.current_state = Mock(return_value=_SyncState('priority', 1,
+                                                                         CaseInsensitiveSet(['other']),
+                                                                         CaseInsensitiveSet(['other']),
+                                                                         CaseInsensitiveSet(['other'])))
+        self.ha.cluster = get_cluster_initialized_with_leader(sync=('leader', 'other,other2'))
+        self.ha.dcs.write_sync_state = Mock(return_value=SyncState.empty())
+        with patch.object(global_config.__class__, 'is_synchronous_mode_strict', PropertyMock(return_value=True)):
+            self.ha.run_cycle()
+        # sync_common = {'other', 'other2'} & {'other'} = {'other'}, which is not empty.
+        # So the DCS write should happen (narrow from 2 voters to 1), not be blocked.
+        self.ha.dcs.write_sync_state.assert_called()
 
         # Test the value configured by the user for synchronous_standby_names is used when synchronous mode is disabled
         self.ha.is_synchronous_mode = false


### PR DESCRIPTION
This patch adds a new DCS update rule to maintain at least one synchronous replica in /sync. Prevent updates with an empty set by keeping the last known synchronous replica. This increases the chances of being able to elect a new leader. For example, if there are three nodes A, B and C (where A is the leader) then the following sequence prevents electing a new leader:

1. Shutdown B
2. Shutdown C
3. Shutdown A
4. Start B
5. Start C

If /sync is set '*' after step #2 then a new leader cannot be elected when B and C are up despite one of them being a synchronous replica. This patch skips updating the DCS such that sync_standby will still contain C, which will allow the cluster to recover correctly by promoting node C if A never joins back.

Addresses #3327