### PR TITLE
Enable PATRONI_POSTGRESQL_CONNECT_ADDRESS

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,6 +10,7 @@ fi
 readonly PATRONI_SCOPE="${PATRONI_SCOPE:-batman}"
 PATRONI_NAMESPACE="${PATRONI_NAMESPACE:-/service}"
 readonly PATRONI_NAMESPACE="${PATRONI_NAMESPACE%/}"
+
 DOCKER_IP=$(hostname --ip-address)
 readonly DOCKER_IP
 
@@ -38,7 +39,7 @@ EOT
         exec dumb-init "$@"
         ;;
     etcd)
-        exec "$@" --auto-compaction-retention=1 -advertise-client-urls "http://$DOCKER_IP:2379"
+        exec "$@" --auto-compaction-retention=1 -advertise-client-urls "http://${ADVERTISE-CLIENT-URLS:-$DOCKER_IP}:2379"
         ;;
     zookeeper)
         exec /usr/share/zookeeper/bin/zkServer.sh start-foreground
@@ -54,11 +55,11 @@ fi
 export PATRONI_SCOPE
 export PATRONI_NAMESPACE
 export PATRONI_NAME="${PATRONI_NAME:-$(hostname)}"
-export PATRONI_RESTAPI_CONNECT_ADDRESS="$DOCKER_IP:8008"
+export PATRONI_RESTAPI_CONNECT_ADDRESS="${PATRONI_RESTAPI_CONNECT_ADDRESS:-$DOCKER_IP}:8008"
 export PATRONI_RESTAPI_LISTEN="0.0.0.0:8008"
 export PATRONI_admin_PASSWORD="${PATRONI_admin_PASSWORD:-admin}"
 export PATRONI_admin_OPTIONS="${PATRONI_admin_OPTIONS:-createdb, createrole}"
-export PATRONI_POSTGRESQL_CONNECT_ADDRESS="$DOCKER_IP:5432"
+export PATRONI_POSTGRESQL_CONNECT_ADDRESS="${PATRONI_POSTGRESQL_CONNECT_ADDRESS:-$DOCKER_IP}:5432"
 export PATRONI_POSTGRESQL_LISTEN="0.0.0.0:5432"
 export PATRONI_POSTGRESQL_DATA_DIR="${PATRONI_POSTGRESQL_DATA_DIR:-$PGDATA}"
 export PATRONI_REPLICATION_USERNAME="${PATRONI_REPLICATION_USERNAME:-replicator}"


### PR DESCRIPTION
Override DOCKER_IP with PATRONI_POSTGRESQL_CONNECT_ADDRESS

I ran into an issue where when I used network_mode: host, I got the wrong IPS.
Implemented a small fix so the DOCKER_IP can be overridden a described in the docs