### PR TITLE
Add 'from-leader' parameter for patronictl reinit

### DIFF
--- a/patroni/api.py
+++ b/patroni/api.py
@@ -1002,6 +1002,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
         The request body may contain a JSON dictionary with the following key:
 
             * ``force``: ``True`` if we want to cancel an already running task in order to reinit a replica.
+            * ``from_leader``: ``True`` if we want to reinit a replica and sync wal from the leader node.
 
         Response HTTP status codes:
 
@@ -1014,8 +1015,9 @@ class RestApiHandler(BaseHTTPRequestHandler):
             logger.debug('received reinitialize request: %s', request)
 
         force = isinstance(request, dict) and parse_bool(request.get('force')) or False
+        from_leader = isinstance(request, dict) and parse_bool(request.get('from-leader')) or False
 
-        data = self.server.patroni.ha.reinitialize(force)
+        data = self.server.patroni.ha.reinitialize(force, from_leader)
         if data is None:
             status_code = 200
             data = 'reinitialize started'

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -1168,8 +1168,9 @@ def restart(cluster_name: str, group: Optional[int], member_names: List[str],
 @option_citus_group
 @click.argument('member_names', nargs=-1)
 @option_force
+@click.option('--from-leader', is_flag=True, help='Set to sync wal from leader')
 @click.option('--wait', help='Wait until reinitialization completes', is_flag=True)
-def reinit(cluster_name: str, group: Optional[int], member_names: List[str], force: bool, wait: bool) -> None:
+def reinit(cluster_name: str, group: Optional[int], member_names: List[str], force: bool, from_leader: bool, wait: bool) -> None:
     """Process ``reinit`` command of ``patronictl`` utility.
 
     Reinitialize cluster members based on given filters.
@@ -1181,6 +1182,7 @@ def reinit(cluster_name: str, group: Optional[int], member_names: List[str], for
     :param group: filter which Citus group we should reinit members. Refer to the module note for more details.
     :param member_names: name of the members that should be reinitialized.
     :param force: perform the restart without asking for confirmations.
+    :param from-leader: perform the reinit to sync wal from the leader node.
     :param wait: wait for the operation to complete.
     """
     cluster = get_dcs(cluster_name, group).get_cluster()
@@ -1188,7 +1190,7 @@ def reinit(cluster_name: str, group: Optional[int], member_names: List[str], for
 
     wait_on_members: List[Member] = []
     for member in members:
-        body: Dict[str, bool] = {'force': force}
+        body: Dict[str, bool] = {'force': force, 'from_leader': True }
         while True:
             r = request_patroni(member, 'post', 'reinitialize', body)
             started = check_response(r, member.name, 'reinitialize')

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -937,16 +937,17 @@ class Cluster(NamedTuple('Cluster',
         return next((m for m in self.members if m.name == member_name),
                     self.leader if fallback_to_leader else None)
 
-    def get_clone_member(self, exclude_name: str) -> Union[Member, Leader, None]:
+    def get_clone_member(self, exclude_name: str, from_leader: bool = False) -> Union[Member, Leader, None]:
         """Get member or leader object to use as clone source.
 
         :param exclude_name: name of a member name to exclude.
+        :param from-leader: set reinit to sync wal from the leader node.
 
         :returns: a randomly selected candidate member from available running members that are configured to as viable
                  sources for cloning (has tag ``clonefrom`` in configuration). If no member is appropriate the current
                  leader is used.
         """
-        exclude = [exclude_name] + ([self.leader.name] if self.leader else [])
+        exclude = [exclude_name] + ([self.leader.name] if self.leader and not from_leader else [])
         candidates = [m for m in self.members if m.clonefrom and m.is_running and m.name not in exclude]
         return candidates[randint(0, len(candidates) - 1)] if candidates else self.leader
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -503,7 +503,7 @@ class TestRestApiHandler(unittest.TestCase):
         self.assertIsNotNone(MockRestApiServer(RestApiHandler, request))
 
     def test_do_POST_reinitialize(self):
-        request = 'POST /reinitialize HTTP/1.0' + self._authorization + '\nContent-Length: 15\n\n{"force": true}'
+        request = 'POST /reinitialize HTTP/1.0' + self._authorization + '\nContent-Length: 36\n\n{"force": true, "from-leader": true}'
         MockRestApiServer(RestApiHandler, request)
         with patch.object(MockHa, 'reinitialize', Mock(return_value=None)):
             MockRestApiServer(RestApiHandler, request)


### PR DESCRIPTION
 This merge has add a parameter for `patronictl reinit` command ,which to resolve the question described by: https://github.com/patroni/patroni/issues/3320. Thus we can add the '--from-leader' option when executing the `patronictl reinit` command to synchronize the wal log from the leader node of patroni.