### PR TITLE
Properly handle Unavailable exception raised by Etcd v3

### DIFF
--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -1,4 +1,5 @@
 import json
+import socket
 import unittest
 
 from threading import Thread
@@ -184,6 +185,8 @@ class TestPatroniEtcd3Client(BaseTestEtcd3):
         self.assertRaises(etcd.EtcdException, self.client._handle_server_response, response)
         response.status_code = 400
         self.assertRaises(Unknown, self.client._handle_server_response, response)
+        response.content = '{"error":{"grpc_code":14,"message":"","http_code":400}}'
+        self.assertRaises(socket.timeout, self.client._handle_server_response, response)
         response.content = '{"error":{"grpc_code":0,"message":"","http_code":400}}'
         try:
             self.client._handle_server_response(response)


### PR DESCRIPTION
Patroni used to retry such requests on the same Etcd node, while switching to the other Etcd node is a better strategy for it.

Close https://github.com/patroni/patroni/issues/3335