### PR TITLE
Multi citus support + global config

### DIFF
--- a/patroni/config.py
+++ b/patroni/config.py
@@ -702,7 +702,7 @@ class Config(object):
         for name, value in local_configuration.items():
             if name == 'citus':  # remove invalid citus configuration
                 if isinstance(value, dict) and isinstance(cast(Dict[str, Any], value).get('group'), int) \
-                        and isinstance(cast(Dict[str, Any], value).get('database'), str):
+                        and isinstance(cast(Dict[str, Any], value).get('database'), (str, list)):
                     config[name] = value
             elif name == 'postgresql':
                 for name, value in (value or {}).items():

--- a/patroni/global_config.py
+++ b/patroni/global_config.py
@@ -8,7 +8,7 @@ import sys
 import types
 
 from copy import deepcopy
-from typing import Any, cast, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, cast, Dict, List, Optional, TYPE_CHECKING, Union
 
 from .collections import EMPTY_DICT
 from .utils import parse_bool, parse_int
@@ -99,6 +99,12 @@ class GlobalConfig(types.ModuleType):
         :returns: ``True`` if parameter *mode* is enabled in the global configuration.
         """
         return bool(parse_bool(self.__config.get(mode)))
+    
+    
+    @property
+    def citus(self) -> Dict[str, Union[str, int, list]]:
+        return self.__config.get('citus')
+
 
     @property
     def is_paused(self) -> bool:

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -340,6 +340,15 @@ class Postgresql(object):
     def reload_config(self, config: Dict[str, Any], sighup: bool = False) -> None:
         self.config.reload_config(config, sighup)
         self._is_leader_retry.deadline = self.retry.deadline = config['retry_timeout'] / 2.0
+        # We are checking if postgresql instance is primary
+        # and if in global config citus config exists
+        if self.role == PostgresqlRole.PRIMARY:
+            dbconfig = global_config
+            if dbconfig.citus:
+                dbconfig = dbconfig.citus
+            else:
+                dbconfig = config['citus']
+            self.mpp_handler.create_citus_instances(dbconfig)
 
     @property
     def pending_restart_reason(self) -> CaseInsensitiveDict:

--- a/patroni/postgresql/mpp/__init__.py
+++ b/patroni/postgresql/mpp/__init__.py
@@ -7,6 +7,7 @@ import abc
 
 from typing import Any, Dict, Iterator, Optional, Tuple, Type, TYPE_CHECKING, Union
 
+from .. import global_config
 from ...dcs import Cluster
 from ...dynamic_loader import iter_classes
 from ...exceptions import PatroniException
@@ -27,12 +28,16 @@ class AbstractMPP(abc.ABC):
 
     group_re: Any  # re.Pattern[str]
 
-    def __init__(self, config: Dict[str, Union[str, int]]) -> None:
+    def __init__(self, config: Dict[str, Union[str, int, list]]) -> None:
         """Init method for :class:`AbstractMPP`.
 
         :param config: configuration of MPP section.
         """
-        self._config = config
+        dbconfig = global_config
+        if dbconfig.citus:
+            self._config = dbconfig.citus
+        else:
+            self._config = config
 
     def is_enabled(self) -> bool:
         """Check if MPP is enabled for a given MPP.
@@ -129,7 +134,7 @@ class AbstractMPP(abc.ABC):
 class AbstractMPPHandler(AbstractMPP):
     """An abstract class which defines interfaces that should be implemented by real handlers."""
 
-    def __init__(self, postgresql: 'Postgresql', config: Dict[str, Union[str, int]]) -> None:
+    def __init__(self, postgresql: 'Postgresql', config: Dict[str, Union[str, int, list]]) -> None:
         """Init method for :class:`AbstractMPPHandler`.
 
         :param postgresql: a reference to :class:`Postgresql` object.
@@ -231,7 +236,7 @@ class Null(AbstractMPP):
 class NullHandler(Null, AbstractMPPHandler):
     """Dummy implementation of :class:`AbstractMPPHandler`."""
 
-    def __init__(self, postgresql: 'Postgresql', config: Dict[str, Union[str, int]]) -> None:
+    def __init__(self, postgresql: 'Postgresql', config: Dict[str, Union[str, int, list]]) -> None:
         """Init method for :class:`NullHandler`.
 
         :param postgresql: a reference to :class:`Postgresql` object.

--- a/patroni/postgresql/mpp/citus.py
+++ b/patroni/postgresql/mpp/citus.py
@@ -368,7 +368,7 @@ class Citus(AbstractMPP):
         :returns: ``True`` is config passes validation, otherwise ``False``.
         """
         return isinstance(config, dict) \
-            and isinstance(cast(Dict[str, Any], config).get('database'), str) \
+            and isinstance(cast(Dict[str, Any], config).get('database'), (str, list)) \
             and parse_int(cast(Dict[str, Any], config).get('group')) is not None
 
     @property
@@ -766,15 +766,21 @@ class CitusHandler(Citus, AbstractMPPHandler):
         """
         AbstractMPPHandler.__init__(self, postgresql, config)
         self._citus_database_handlers = {}
+        self._postgresql = postgresql
 
-        dbconfig = config.copy()
+        self.create_citus_instances(config)
 
-        if isinstance(config['database'], str):
-            config['database'] = [config['database']]
+       # dbconfig = config.copy()
 
-        for dbname in config['database']:
-            dbconfig['database'] = dbname
-            self._citus_database_handlers[dbname] = CitusDatabaseHandler(postgresql, dbconfig)
+
+        # if isinstance(config['database'], str):
+        #     config['database'] = [config['database']]
+
+        # for dbname in config['database']:
+        #     dbconfig['database'] = dbname
+        #     self._citus_database_handlers[dbname] = CitusDatabaseHandler(postgresql, dbconfig)
+        
+
 
     def schedule_cache_rebuild(self) -> None:
         for handler in self._citus_database_handlers.values():
@@ -783,6 +789,27 @@ class CitusHandler(Citus, AbstractMPPHandler):
     def on_demote(self) -> None:
         for handler in self._citus_database_handlers.values():
             handler.on_demote()
+
+    def add_new_database(self, dbname: str) -> None:
+            try: 
+                self._citus_database_handlers[dbname].bootstrap()
+            except:
+                pass
+
+    def create_citus_instances(self, config: Dict[str, Union[str, int, list]]) -> None:
+        """Creates CitusHandler instances and add them to dict."""
+        AbstractMPPHandler.__init__(self, self._postgresql, config)  
+       
+        dbconfig = config.copy()
+
+        if isinstance(config['database'], str):
+            config['database'] = [config['database']]
+
+        for dbname in config['database']:
+            if not dbname in self._citus_database_handlers.keys():
+                dbconfig['database'] = dbname
+                self._citus_database_handlers[dbname] = CitusDatabaseHandler(self._postgresql, dbconfig)
+                self.add_new_database(dbname)
 
     def sync_meta_data(self, cluster: Cluster) -> None:
         if not self.is_coordinator():
@@ -829,3 +856,10 @@ class CitusHandler(Citus, AbstractMPPHandler):
 
     def ignore_replication_slot(self, slot: Dict[str, str]) -> bool:
         return any(handler.ignore_replication_slot(slot) for handler in self._citus_database_handlers.values())
+
+    def get_citus_database_handlers(self) -> None:
+        return self._citus_database_handlers
+
+    def start(self)-> None:
+        for handler in self._citus_database_handlers.values():
+            handler.start 

--- a/patroni/validator.py
+++ b/patroni/validator.py
@@ -1143,7 +1143,7 @@ schema = Schema({
         },
     }),
     Optional("citus"): {
-        "database": str,
+        "database": Union[str, list],
         "group": IntValidator(min=0, expected_type=int, raise_assert=True),
     },
     "postgresql": {

--- a/tests/test_citus.py
+++ b/tests/test_citus.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from typing import List
 from unittest.mock import Mock, patch, PropertyMock
 
-from patroni.postgresql.mpp.citus import CitusHandler, PgDistGroup, PgDistNode
+from patroni.postgresql.mpp.citus import CitusDatabaseHandler, PgDistGroup, PgDistNode
 from patroni.psycopg import ProgrammingError
 
 from . import BaseTestPostgresql, MockCursor, psycopg_connect, SleepException
@@ -19,6 +19,8 @@ class TestCitus(BaseTestPostgresql):
     def setUp(self):
         super(TestCitus, self).setUp()
         self.c = self.p.mpp_handler
+        handler = self.c.get_citus_database_handlers()
+        self.handler = handler['citus']
         self.cluster = get_cluster_initialized_with_leader()
         self.cluster.workers[1] = self.cluster
 
@@ -26,104 +28,104 @@ class TestCitus(BaseTestPostgresql):
     @patch('patroni.postgresql.mpp.citus.logger.exception', Mock(side_effect=SleepException))
     @patch('patroni.postgresql.mpp.citus.logger.warning')
     @patch('patroni.postgresql.mpp.citus.PgDistTask.wait', Mock())
-    @patch.object(CitusHandler, 'is_alive', Mock(return_value=True))
+    @patch.object(CitusDatabaseHandler, 'is_alive', Mock(return_value=True))
     def test_run(self, mock_logger_warning):
         # `before_demote` or `before_promote` REST API calls starting a
         # transaction. We want to make sure that it finishes during
         # certain timeout. In case if it is not, we want to roll it back
         # in order to not block other workers that want to update
         # `pg_dist_node`.
-        self.c._condition.wait = Mock(side_effect=[Mock(), Mock(), Mock(), SleepException])
+        self.handler._condition.wait = Mock(side_effect=[Mock(), Mock(), Mock(), SleepException])
 
         self.c.handle_event(self.cluster, {'type': 'before_demote', 'group': 1,
                                            'leader': 'leader', 'timeout': 30, 'cooldown': 10})
-        self.c.add_task('after_promote', 2, self.cluster, self.cluster.leader_name, 'postgres://host3:5432/postgres')
-        self.assertRaises(SleepException, self.c.run)
+        self.handler.add_task('after_promote', 2, self.cluster, self.cluster.leader_name, 'postgres://host3:5432/postgres')
+        self.assertRaises(SleepException, self.handler.run)
         mock_logger_warning.assert_called_once()
         self.assertTrue(mock_logger_warning.call_args[0][0].startswith('Rolling back transaction'))
         self.assertTrue(repr(mock_logger_warning.call_args[0][1]).startswith('PgDistTask'))
 
-    @patch.object(CitusHandler, 'is_alive', Mock(return_value=False))
-    @patch.object(CitusHandler, 'start', Mock())
+    @patch.object(CitusDatabaseHandler, 'is_alive', Mock(return_value=False))
+    @patch.object(CitusDatabaseHandler, 'start', Mock())
     def test_sync_meta_data(self):
-        with patch.object(CitusHandler, 'is_enabled', Mock(return_value=False)):
+        with patch.object(CitusDatabaseHandler, 'is_enabled', Mock(return_value=False)):
             self.c.sync_meta_data(self.cluster)
         self.c.sync_meta_data(self.cluster)
 
     def test_handle_event(self):
         self.c.handle_event(self.cluster, {})
-        with patch.object(CitusHandler, 'is_alive', Mock(return_value=True)):
+        with patch.object(CitusDatabaseHandler, 'is_alive', Mock(return_value=True)):
             self.c.handle_event(self.cluster, {'type': 'after_promote', 'group': 2,
                                                'leader': 'leader', 'timeout': 30, 'cooldown': 10})
 
     def test_add_task(self):
         with patch('patroni.postgresql.mpp.citus.logger.error') as mock_logger, \
                 patch('patroni.postgresql.mpp.citus.urlparse', Mock(side_effect=Exception)):
-            self.c.add_task('', 1, self.cluster, '', None)
+            self.handler.add_task('', 1, self.cluster, '', None)
             mock_logger.assert_called_once()
 
         with patch('patroni.postgresql.mpp.citus.logger.debug') as mock_logger:
-            self.c.add_task('before_demote', 1, self.cluster,
+            self.handler.add_task('before_demote', 1, self.cluster,
                             self.cluster.leader_name, 'postgres://host:5432/postgres', 30)
             mock_logger.assert_called_once()
             self.assertTrue(mock_logger.call_args[0][0].startswith('Adding the new task:'))
 
         with patch('patroni.postgresql.mpp.citus.logger.debug') as mock_logger:
-            self.c.add_task('before_promote', 1, self.cluster,
+            self.handler.add_task('before_promote', 1, self.cluster,
                             self.cluster.leader_name, 'postgres://host:5432/postgres', 30)
             mock_logger.assert_called_once()
             self.assertTrue(mock_logger.call_args[0][0].startswith('Overriding existing task:'))
 
         # add_task called from sync_pg_dist_node should not override already scheduled or in flight task until deadline
-        self.assertIsNotNone(self.c.add_task('after_promote', 1, self.cluster,
+        self.assertIsNotNone(self.handler.add_task('after_promote', 1, self.cluster,
                                              self.cluster.leader_name, 'postgres://host:5432/postgres', 30))
-        self.assertIsNone(self.c.add_task('after_promote', 1, self.cluster,
+        self.assertIsNone(self.handler.add_task('after_promote', 1, self.cluster,
                                           self.cluster.leader_name, 'postgres://host:5432/postgres'))
-        self.c._in_flight = self.c._tasks.pop()
-        self.c._in_flight.deadline = self.c._in_flight.timeout + time.time()
-        self.assertIsNone(self.c.add_task('after_promote', 1, self.cluster,
+        self.handler._in_flight = self.handler._tasks.pop()
+        self.handler._in_flight.deadline = self.handler._in_flight.timeout + time.time()
+        self.assertIsNone(self.handler.add_task('after_promote', 1, self.cluster,
                                           self.cluster.leader_name, 'postgres://host:5432/postgres'))
-        self.c._in_flight.deadline = 0
-        self.assertIsNotNone(self.c.add_task('after_promote', 1, self.cluster,
+        self.handler._in_flight.deadline = 0
+        self.assertIsNotNone(self.handler.add_task('after_promote', 1, self.cluster,
                                              self.cluster.leader_name, 'postgres://host:5432/postgres'))
 
         # If there is no transaction in progress and cached pg_dist_node matching desired state task should not be added
-        self.c._schedule_load_pg_dist_node = False
-        self.c._pg_dist_group[self.c._in_flight.groupid] = self.c._in_flight
-        self.c._in_flight = None
-        self.assertIsNone(self.c.add_task('after_promote', 1, self.cluster,
+        self.handler._schedule_load_pg_dist_node = False
+        self.handler._pg_dist_group[self.handler._in_flight.groupid] = self.handler._in_flight
+        self.handler._in_flight = None
+        self.assertIsNone(self.handler.add_task('after_promote', 1, self.cluster,
                                           self.cluster.leader_name, 'postgres://host:5432/postgres'))
 
     def test_pick_task(self):
-        self.c.add_task('after_promote', 0, self.cluster, self.cluster.leader_name, 'postgres://host1:5432/postgres')
-        with patch.object(CitusHandler, 'update_node') as mock_update_node:
-            self.c.process_tasks()
+        self.handler.add_task('after_promote', 0, self.cluster, self.cluster.leader_name, 'postgres://host1:5432/postgres')
+        with patch.object(CitusDatabaseHandler, 'update_node') as mock_update_node:
+            self.handler.process_tasks()
             # process_task() shouldn't be called because pick_task double checks with _pg_dist_group
             mock_update_node.assert_not_called()
 
     def test_process_task(self):
-        self.c.add_task('after_promote', 1, self.cluster, self.cluster.leader_name, 'postgres://host2:5432/postgres')
-        task = self.c.add_task('before_promote', 1, self.cluster,
+        self.handler.add_task('after_promote', 1, self.cluster, self.cluster.leader_name, 'postgres://host2:5432/postgres')
+        task = self.handler.add_task('before_promote', 1, self.cluster,
                                self.cluster.leader_name, 'postgres://host4:5432/postgres', 30)
-        self.c.process_tasks()
+        self.handler.process_tasks()
         self.assertTrue(task._event.is_set())
 
         # the after_promote should result only in COMMIT
-        task = self.c.add_task('after_promote', 1, self.cluster,
+        task = self.handler.add_task('after_promote', 1, self.cluster,
                                self.cluster.leader_name, 'postgres://host4:5432/postgres', 30)
-        with patch.object(CitusHandler, 'query') as mock_query:
-            self.c.process_tasks()
+        with patch.object(CitusDatabaseHandler, 'query') as mock_query:
+            self.handler.process_tasks()
             mock_query.assert_called_once()
             self.assertEqual(mock_query.call_args[0][0], 'COMMIT')
 
     def test_process_tasks(self):
-        self.c.add_task('after_promote', 0, self.cluster, self.cluster.leader_name, 'postgres://host2:5432/postgres')
-        self.c.process_tasks()
+        self.handler.add_task('after_promote', 0, self.cluster, self.cluster.leader_name, 'postgres://host2:5432/postgres')
+        self.handler.process_tasks()
 
-        self.c.add_task('after_promote', 0, self.cluster, self.cluster.leader_name, 'postgres://host3:5432/postgres')
+        self.handler.add_task('after_promote', 0, self.cluster, self.cluster.leader_name, 'postgres://host3:5432/postgres')
         with patch('patroni.postgresql.mpp.citus.logger.error') as mock_logger, \
-                patch.object(CitusHandler, 'query', Mock(side_effect=Exception)):
-            self.c.process_tasks()
+                patch.object(CitusDatabaseHandler, 'query', Mock(side_effect=Exception)):
+            self.handler.process_tasks()
             mock_logger.assert_called_once()
             self.assertTrue(mock_logger.call_args[0][0].startswith('Exception when working with pg_dist_node: '))
 
@@ -134,14 +136,14 @@ class TestCitus(BaseTestPostgresql):
     @patch.object(MockCursor, 'execute', Mock(side_effect=Exception))
     def test_load_pg_dist_group(self, mock_logger):
         # load_pg_dist_group) triggers, query fails and exception is property handled
-        self.c.process_tasks()
-        self.assertTrue(self.c._schedule_load_pg_dist_group)
+        self.handler.process_tasks()
+        self.assertTrue(self.handler._schedule_load_pg_dist_group)
         mock_logger.assert_called_once()
         self.assertTrue(mock_logger.call_args[0][0].startswith('Exception when executing query'))
         self.assertTrue(mock_logger.call_args[0][1].startswith('SELECT groupid, nodename, '))
 
     def test_wait(self):
-        task = self.c.add_task('before_demote', 1, self.cluster,
+        task = self.handler.add_task('before_demote', 1, self.cluster,
                                self.cluster.leader_name, u'postgres://host:5432/postgres', 30)
         task._event.wait = Mock()
         task.wait()


### PR DESCRIPTION
Implemented global_config.citus. Then it can be called from  posgresql\ini.py in function reload_config if its primary postgresql in group. I prioritize configuration stored in global_config else it uses configuration from local yaml file.
That way after we reload we always instantiate new DBs.