### PR TITLE
Make unit tests pass with click==8.2.1

### DIFF
--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -243,7 +243,7 @@ class TestCtl(unittest.TestCase):
     @patch('patroni.dcs.AbstractDCS.set_failover_value', Mock())
     def test_failover(self):
         # No candidate specified
-        result = self.runner.invoke(ctl, ['failover', 'dummy'], input='0\n')
+        result = self.runner.invoke(ctl, ['failover', 'dummy'], input='0\n\n')
         self.assertIn('Failover could be performed only to a specific candidate', result.output)
 
         # Candidate is the same as the leader
@@ -362,7 +362,7 @@ class TestCtl(unittest.TestCase):
     @patch('patroni.ctl.request_patroni')
     def test_restart_reinit(self, mock_post):
         mock_post.return_value.status = 503
-        result = self.runner.invoke(ctl, ['restart', 'alpha'], input='now\ny\n')
+        result = self.runner.invoke(ctl, ['restart', 'alpha'], input='now\ny\n\n')
         assert 'Failed: restart for' in result.output
         assert result.exit_code == 0
 
@@ -370,7 +370,7 @@ class TestCtl(unittest.TestCase):
         assert result.exit_code == 1
 
         # successful reinit
-        result = self.runner.invoke(ctl, ['reinit', 'alpha', 'other'], input='y\ny')
+        result = self.runner.invoke(ctl, ['reinit', 'alpha', 'other'], input='y\ny\nn')
         assert result.exit_code == 0
 
         # Aborted restart


### PR DESCRIPTION
I know, ctl.py unit tests are crap, but rewriting them will be a separate task.