### PR TITLE
Add leader annotation to prevent endpoints being cleaned

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -32,7 +32,6 @@ Example session:
     Image: "" with ID "sha256:e9bfe69c5d2b319dec0cf564fb895484537664775e18f37f9b707914cc5537e6" not yet present on node "kind-control-plane", loading...
 
     $ kubectl apply -f patroni_k8s.yaml
-    service/patronidemo-config created
     statefulset.apps/patronidemo created
     endpoints/patronidemo created
     service/patronidemo created

--- a/kubernetes/patroni_k8s.yaml
+++ b/kubernetes/patroni_k8s.yaml
@@ -1,15 +1,3 @@
-# headless service to avoid deletion of patronidemo-config endpoint
-apiVersion: v1
-kind: Service
-metadata:
-  name: patronidemo-config
-  labels:
-    application: patroni
-    cluster-name: patronidemo
-spec:
-  clusterIP: None
-
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -222,16 +210,6 @@ rules:
   - patch
   - update
   - watch
-# The following privilege is only necessary for creation of headless service
-# for patronidemo-config endpoint, in order to prevent cleaning it up by the
-# k8s master. You can avoid giving this privilege by explicitly creating the
-# service like it is done in this manifest (lines 2..10)
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - create
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -483,36 +483,6 @@ class TestKubernetesEndpoints(BaseTestKubernetes):
     def test_write_sync_state(self):
         self.assertIsNotNone(self.k.write_sync_state('a', ['b'], 0, 1))
 
-    @patch.object(k8s_client.CoreV1Api, 'patch_namespaced_pod', mock_namespaced_kind, create=True)
-    @patch.object(k8s_client.CoreV1Api, 'create_namespaced_endpoints', mock_namespaced_kind, create=True)
-    @patch.object(k8s_client.CoreV1Api, 'create_namespaced_service',
-                  Mock(side_effect=[True,
-                                    False,
-                                    k8s_client.rest.ApiException(409, ''),
-                                    k8s_client.rest.ApiException(403, ''),
-                                    k8s_client.rest.ApiException(500, ''),
-                                    Exception("Unexpected")
-                                    ]), create=True)
-    @patch('patroni.dcs.kubernetes.logger.exception')
-    def test__create_config_service(self, mock_logger_exception):
-        self.assertIsNotNone(self.k.patch_or_create_config({'foo': 'bar'}))
-        self.assertIsNotNone(self.k.patch_or_create_config({'foo': 'bar'}))
-
-        self.k.patch_or_create_config({'foo': 'bar'})
-        mock_logger_exception.assert_not_called()
-
-        self.k.patch_or_create_config({'foo': 'bar'})
-        mock_logger_exception.assert_not_called()
-
-        self.k.patch_or_create_config({'foo': 'bar'})
-        mock_logger_exception.assert_called_once()
-        self.assertEqual(('create_config_service failed',), mock_logger_exception.call_args[0])
-        mock_logger_exception.reset_mock()
-
-        self.k.touch_member({'state': PostgresqlState.RUNNING, 'role': PostgresqlRole.REPLICA})
-        mock_logger_exception.assert_called_once()
-        self.assertEqual(('create_config_service failed',), mock_logger_exception.call_args[0])
-
     @patch.object(k8s_client.CoreV1Api, 'patch_namespaced_endpoints', mock_namespaced_kind, create=True)
     def test_write_leader_optime(self):
         self.k.write_leader_optime(12345)


### PR DESCRIPTION
Endpoints-controller in kube-controller-manager[ checks for endpoints that are not associated with any service during program startup and deletes them](https://github.com/kubernetes/kubernetes/blob/b35c5c0a301d326fdfa353943fca077778544ac6/pkg/controller/endpoint/endpoints_controller.go#L557). 

We can add a specific annotation `control-plane.alpha.kubernetes.io/leader='{}'` to the config/sync/failover endpoints to totally prevent this kind of cleanup. Then there is no need to creating a config service.