### PR TITLE
Make sure CHECKPOINT is execute after promote

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1121,6 +1121,7 @@ class Ha(object):
                 self._failsafe.set_is_active(0)
 
                 def before_promote():
+                    self._rewind.reset_state()  # make sure we will trigger checkpoint after promote
                     self.notify_mpp_coordinator('before_promote')
 
                 with self._async_response:


### PR DESCRIPTION
It was possible that `Rewind._checkpoint_task` wasn't reset on demote if CHECKPOINT wasn't yet finished, what resulted in using stale `result` when the next promote is triggered.

It is not easy to reproduce, but steps are the following:
1. failover to node1.
2. while CHECKPOINT after promote is still running, switchover to node2.
3. next failover/switchover to node1 results in missing CHECKPOINT.

To solve the problem we take following measures:
1. call `Rewind.reset_state()` before promote.
2. reset `Rewind._checkpoint_task` from trigger_check_diverged_lsn().

Besides that, we didn't check that CHECKPOINT during 2 actually finished successfully. If check implemented correctly chances to hit the problem would have been much smaller. However, there was still race condition, if switchover was triggered right after CHECKPOINT task finished.

Close https://github.com/patroni/patroni/issues/3367