### PR TITLE
Fix potential issue around resolving localhost to IPv6

### DIFF
--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -1102,15 +1102,11 @@ class ConfigHandler(object):
         listen_addresses = self._server_parameters['listen_addresses'].split(',')
 
         for la in listen_addresses:
-            if os.name == 'nt':
-                if la.strip().lower() in ('*', 'localhost'):  # we are listening on '*' or localhost
-                    return 'localhost'  # connection via localhost is preferred
-                if la.strip().lower() in ('0.0.0.0', '127.0.0.1'):  # Postgres listens only on IPv4
-                    return '127.0.0.1'  # localhost, but don't allow Windows to resolve to IPv6
-            else:
-                # we are listening on '*' or localhost
-                if la.strip().lower() in ('*', '0.0.0.0', '127.0.0.1', 'localhost'):
-                    return 'localhost'  # connection via localhost is preferred
+            if la.strip().lower() in ('*', 'localhost'):  # we are listening on '*' or localhost
+                return 'localhost'  # connection via localhost is preferred
+            if la.strip() in ('0.0.0.0', '127.0.0.1'):  # Postgres listens only on IPv4
+                # localhost, but don't allow Windows to resolve to IPv6
+                return '127.0.0.1' if os.name == 'nt' else 'localhost'
         return listen_addresses[0].strip()  # can't use localhost, take first address from listen_addresses
 
     def resolve_connection_addresses(self) -> None:

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -1102,8 +1102,10 @@ class ConfigHandler(object):
         listen_addresses = self._server_parameters['listen_addresses'].split(',')
 
         for la in listen_addresses:
-            if la.strip().lower() in ('*', '0.0.0.0', '127.0.0.1', 'localhost'):  # we are listening on '*' or localhost
+            if la.strip().lower() in ('*', 'localhost'):  # we are listening on '*' or localhost
                 return 'localhost'  # connection via localhost is preferred
+            if la.strip().lower() in ('0.0.0.0', '127.0.0.1'):  # these are treated as IPv4 addresses by getaddrinfo()
+                return '127.0.0.1'  # connection via localhost is preferred, but don't allow Windows to resolve to IPv6
         return listen_addresses[0].strip()  # can't use localhost, take first address from listen_addresses
 
     def resolve_connection_addresses(self) -> None:

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -1105,10 +1105,11 @@ class ConfigHandler(object):
             if os.name == 'nt':
                 if la.strip().lower() in ('*', 'localhost'):  # we are listening on '*' or localhost
                     return 'localhost'  # connection via localhost is preferred
-                if la.strip().lower() in ('0.0.0.0', '127.0.0.1'):  # these are treated as IPv4 addresses by getaddrinfo()
-                    return '127.0.0.1'  # connection via localhost is preferred, but don't allow Windows to resolve to IPv6
+                if la.strip().lower() in ('0.0.0.0', '127.0.0.1'):  # Postgres listens only on IPv4
+                    return '127.0.0.1'  # localhost, but don't allow Windows to resolve to IPv6
             else:
-                if la.strip().lower() in ('*', '0.0.0.0', '127.0.0.1', 'localhost'):  # we are listening on '*' or localhost
+                # we are listening on '*' or localhost
+                if la.strip().lower() in ('*', '0.0.0.0', '127.0.0.1', 'localhost'):
                     return 'localhost'  # connection via localhost is preferred
         return listen_addresses[0].strip()  # can't use localhost, take first address from listen_addresses
 

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -1102,10 +1102,14 @@ class ConfigHandler(object):
         listen_addresses = self._server_parameters['listen_addresses'].split(',')
 
         for la in listen_addresses:
-            if la.strip().lower() in ('*', 'localhost'):  # we are listening on '*' or localhost
-                return 'localhost'  # connection via localhost is preferred
-            if la.strip().lower() in ('0.0.0.0', '127.0.0.1'):  # these are treated as IPv4 addresses by getaddrinfo()
-                return '127.0.0.1'  # connection via localhost is preferred, but don't allow Windows to resolve to IPv6
+            if os.name == 'nt':
+                if la.strip().lower() in ('*', 'localhost'):  # we are listening on '*' or localhost
+                    return 'localhost'  # connection via localhost is preferred
+                if la.strip().lower() in ('0.0.0.0', '127.0.0.1'):  # these are treated as IPv4 addresses by getaddrinfo()
+                    return '127.0.0.1'  # connection via localhost is preferred, but don't allow Windows to resolve to IPv6
+            else:
+                if la.strip().lower() in ('*', '0.0.0.0', '127.0.0.1', 'localhost'):  # we are listening on '*' or localhost
+                    return 'localhost'  # connection via localhost is preferred
         return listen_addresses[0].strip()  # can't use localhost, take first address from listen_addresses
 
     def resolve_connection_addresses(self) -> None:


### PR DESCRIPTION
When specifying `0.0.0.0` or `127.0.0.1` in `listen_addresses`, Postgres won't listen on IPv6 (in other words, these addresses imply IPv4 only).  However, the typical Windows system will have a preference to resolve `localhost` to `::1`.

While one can change these preferences, it's unclear if it has unwanted side effects.  Instead of this, the proposed small change fixes this behaviour.