### PR TITLE
fix up 2264190e (`ExecStartPre` commands)

### DIFF
--- a/extras/startup-scripts/patroni.service
+++ b/extras/startup-scripts/patroni.service
@@ -23,8 +23,8 @@ EnvironmentFile=-/etc/patroni_env.conf
 
 # Pre-commands to start watchdog device
 # Uncomment if watchdog is part of your patroni setup
-#ExecStartPre=-/usr/bin/sudo /sbin/modprobe softdog
-#ExecStartPre=-/usr/bin/sudo /bin/chown postgres /dev/watchdog
+#ExecStartPre=-+/sbin/modprobe softdog
+#ExecStartPre=-+/bin/chown postgres /dev/watchdog
 
 # Start the patroni process
 ExecStart=/bin/patroni /etc/patroni.yml


### PR DESCRIPTION
The ExecStartPre commands in the systemd service file don't work well with sudo, it seems better to use the "+" modfier.

fix #3387