### PR TITLE
Compatibility with 18 beta1

### DIFF
--- a/patroni/postgresql/available_parameters/0_postgres.yml
+++ b/patroni/postgresql/available_parameters/0_postgres.yml
@@ -1426,6 +1426,7 @@ parameters:
   ssl_ecdh_curve:
   - type: String
     version_from: 90400
+    version_till: 180000
   ssl_groups:
   - type: String
     version_from: 180000


### PR DESCRIPTION
ssl_ecdh_curve was removed.

Followup on #3394