### PR TITLE
docs: improve planning section with 2-node cluster guidance

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -34,6 +34,10 @@ Patroni/PostgreSQL nodes are decoupled from DCS nodes (except when Patroni imple
 there is no requirement on the minimal number of nodes. Running a cluster consisting of one primary and one standby is
 perfectly fine. You can add more standby nodes later.
 
+**2-node clusters** (primary + standby) are common and provide automatic failover with high availability. Note that during failover, you'll temporarily have no redundancy until the failed node rejoins.
+
+**DCS requirements**: Your DCS (etcd, ZooKeeper, Consul) should run with **3 or 5 nodes** for proper consensus and fault tolerance. A single DCS cluster can store information for hundreds or thousands of Patroni clusters using different namespace/scope combinations.
+
 Running and Configuring
 -----------------------
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -36,7 +36,7 @@ perfectly fine. You can add more standby nodes later.
 
 **2-node clusters** (primary + standby) are common and provide automatic failover with high availability. Note that during failover, you'll temporarily have no redundancy until the failed node rejoins.
 
-**DCS requirements**: Your DCS (etcd, ZooKeeper, Consul) should run with **3 or 5 nodes** for proper consensus and fault tolerance. A single DCS cluster can store information for hundreds or thousands of Patroni clusters using different namespace/scope combinations.
+**DCS requirements**: Your DCS (etcd, ZooKeeper, Consul) has to run with **3 or 5 nodes** for proper consensus and fault tolerance. A single DCS cluster can store information for hundreds or thousands of Patroni clusters using different namespace/scope combinations.
 
 Running and Configuring
 -----------------------


### PR DESCRIPTION
- Add clarification about 2-node cluster behavior during failover
- Emphasize DCS requirements (3 or 5 nodes) for proper consensus
- Mention scaling capability: one DCS can handle thousands of Patroni clusters