### PR TITLE
Failsafe mode wasn't always triggered in case of Etcd unavailability

### DIFF
--- a/tests/test_etcd.py
+++ b/tests/test_etcd.py
@@ -211,6 +211,9 @@ class TestClient(unittest.TestCase):
                 patch.object(EtcdClient, '_load_machines_cache', Mock(return_value=True)):
             self.assertRaises(etcd.EtcdException, rtry, self.client.api_execute, '/', 'GET', params={'retry': rtry})
 
+        with patch.object(EtcdClient, '_get_machines_list', Mock(side_effect=etcd.EtcdConnectionFailed)):
+            self.assertRaises(etcd.EtcdConnectionFailed, self.client.api_execute, '/', 'GET')
+
         with patch.object(EtcdClient, '_do_http_request', Mock(side_effect=etcd.EtcdException)):
             self.client._read_timeout = 0.01
             self.assertRaises(etcd.EtcdException, self.client.api_execute, '/', 'GET')


### PR DESCRIPTION
During heartbeat cycle Patroni does two requests to Etcd:
1. get_cluster()
2. update_lock()

If request fails with one Etcd node Patroni switches to another node and retries. At the same time it sets a flag that Etcd topology must be rediscovered. Rediscovery happens either after successfully completing current request or before executing the next request.

In the second case etcd.EtcdException raised by topology discovery functions wasn't handled and as a result of that failsafe_mode wasn't triggered.

Close https://github.com/patroni/patroni/issues/3403