### PR TITLE
Fix signal handler reentrancy deadlock caused by logging

### DIFF
--- a/patroni/__main__.py
+++ b/patroni/__main__.py
@@ -406,6 +406,12 @@ def main() -> None:
         if pid:
             os.kill(pid, signo)
 
+    import multiprocessing
+    patroni = multiprocessing.Process(target=patroni_main, args=(args.configfile,))
+    patroni.start()
+    pid = patroni.pid
+
+    # Set up signal handlers after fork to prevent child from inheriting them
     if os.name != 'nt':
         signal.signal(signal.SIGCHLD, sigchld_handler)
         signal.signal(signal.SIGHUP, passtochild)
@@ -415,11 +421,6 @@ def main() -> None:
     signal.signal(signal.SIGINT, passtochild)
     signal.signal(signal.SIGABRT, passtochild)
     signal.signal(signal.SIGTERM, passtochild)
-
-    import multiprocessing
-    patroni = multiprocessing.Process(target=patroni_main, args=(args.configfile,))
-    patroni.start()
-    pid = patroni.pid
     patroni.join()
 
 


### PR DESCRIPTION
`logger.info` in `sigchld_handler` violates Async-Signal safety which may cause most of patroni threads hangs.

This problem has troubled me for a while, when most patroni threads hangs after demoted current db due to DCS issues.
The root cause of the issue was identified through the thread stack dump from py-spy.
```
py-spy dump -l -p  6201
Process 6201: /usr/bin/python3.6 /usr/local/bin/patroni /tmp/postgres-ha-bootstrap.yaml
Python v3.6.8 (/usr/libexec/platform-python3.6)

Thread 0x7F0C4C8FE100 (active)
    __enter__ (threading.py:240)
        Arguments:
            self: <Condition at 0x7f0c43b753c8>
    put (queue.py:126)
        Arguments:
            self: <Queue at 0x7f0c43b4f390>
            item: <LogRecord at 0x7f0c4021aba8>
            block: False
            timeout: None
    put_nowait (queue.py:184)
        Arguments:
            self: <Queue at 0x7f0c43b4f390>
            item: <LogRecord at 0x7f0c4021aba8>
    _put_record (patroni/log.py:40)
        Arguments:
            self: <QueueHandler at 0x7f0c43b69160>
            record: <LogRecord at 0x7f0c4021aba8>
    emit (patroni/log.py:55)
        Arguments:
            self: <QueueHandler at 0x7f0c43b69160>
            record: <LogRecord at 0x7f0c4021aba8>
    handle (logging/__init__.py:865)
        Arguments:
            self: <QueueHandler at 0x7f0c43b69160>
            record: <LogRecord at 0x7f0c4021aba8>
        Locals:
            rv: True
    callHandlers (logging/__init__.py:1516)
        Arguments:
            self: <Logger at 0x7f0c4a82ff98>
            record: <LogRecord at 0x7f0c4021aba8>
        Locals:
            c: <RootLogger at 0x7f0c4a7967b8>
            found: 1
            hdlr: <QueueHandler at 0x7f0c43b69160>
    handle (logging/__init__.py:1454)
        Arguments:
            self: <Logger at 0x7f0c4a82ff98>
            record: <LogRecord at 0x7f0c4021aba8>
    _log (logging/__init__.py:1444)
        Arguments:
            self: <Logger at 0x7f0c4a82ff98>
            level: 20
            msg: "Reaped pid=%s, exit status=%s"
            args: (3592457, 0)
            exc_info: None
            extra: None
            stack_info: False
        Locals:
            sinfo: None
            fn: "/usr/local/lib/python3.6/site-packages/patroni/__main__.py"
            lno: 157
            func: "sigchld_handler"
            record: <LogRecord at 0x7f0c4021aba8>
    info (logging/__init__.py:1308)
        Arguments:
            self: <Logger at 0x7f0c4a82ff98>
            msg: "Reaped pid=%s, exit status=%s"
        Locals:
            args: (3592457, 0)
            kwargs: {}
    sigchld_handler (patroni/__main__.py:157)
        Arguments:
            signo: 17
            stack_frame: <frame at 0x7f0c1c014ac8>
        Locals:
            ret: (3592457, 0)
    __exit__ (threading.py:243)
        Arguments:
            self: <Condition at 0x7f0c43b753c8>
        Locals:
            args: (None, None, None)
    put (queue.py:145)
        Arguments:
            self: <Queue at 0x7f0c43b4f390>
            item: <LogRecord at 0x7f0c43b59a20>
            block: False
            timeout: None
    put_nowait (queue.py:184)
        Arguments:
            self: <Queue at 0x7f0c43b4f390>
            item: <LogRecord at 0x7f0c43b59a20>
    _put_record (patroni/log.py:40)
        Arguments:
            self: <QueueHandler at 0x7f0c43b69160>
            record: <LogRecord at 0x7f0c43b59a20>
    emit (patroni/log.py:55)
        Arguments:
            self: <QueueHandler at 0x7f0c43b69160>
            record: <LogRecord at 0x7f0c43b59a20>
    handle (logging/__init__.py:865)
        Arguments:
            self: <QueueHandler at 0x7f0c43b69160>
            record: <LogRecord at 0x7f0c43b59a20>
        Locals:
            rv: True
    callHandlers (logging/__init__.py:1516)
        Arguments:
            self: <Logger at 0x7f0c4422c518>
            record: <LogRecord at 0x7f0c43b59a20>
        Locals:
            c: <RootLogger at 0x7f0c4a7967b8>
            found: 1
            hdlr: <QueueHandler at 0x7f0c43b69160>
    handle (logging/__init__.py:1454)
        Arguments:
            self: <Logger at 0x7f0c4422c518>
            record: <LogRecord at 0x7f0c43b59a20>
    _log (logging/__init__.py:1444)
        Arguments:
            self: <Logger at 0x7f0c4422c518>
            level: 20
            msg: "Lock owner: %s; I am %s"
            args: ("postgres-0ec05fe9-1-0", "postgres-0ec05fe9-1-0")
            exc_info: None
            extra: None
            stack_info: False
        Locals:
            sinfo: None
            fn: "/usr/local/lib/python3.6/site-packages/patroni/ha.py"
            lno: 262
            func: "has_lock"
            record: <LogRecord at 0x7f0c43b59a20>
    info (logging/__init__.py:1308)
        Arguments:
            self: <Logger at 0x7f0c4422c518>
            msg: "Lock owner: %s; I am %s"
        Locals:
            args: ("postgres-0ec05fe9-1-0", "postgres-0ec05fe9-1-0")
            kwargs: {}
    has_lock (patroni/ha.py:262)
        Arguments:
            self: <Ha at 0x7f0c42afe780>
            info: True
        Locals:
            lock_owner: "postgres-0ec05fe9-1-0"
    handle_long_action_in_progress (patroni/ha.py:1427)
        Arguments:
            self: <Ha at 0x7f0c42afe780>
    _run_cycle (patroni/ha.py:1592)
        Arguments:
            self: <Ha at 0x7f0c42afe780>
        Locals:
            dcs_failed: False
    run_cycle (patroni/ha.py:1778)
        Arguments:
            self: <Ha at 0x7f0c42afe780>
    _run_cycle (patroni/__main__.py:109)
        Arguments:
            self: <Patroni at 0x7f0c442e9c50>
    run (patroni/daemon.py:126)
        Arguments:
            self: <Patroni at 0x7f0c442e9c50>
    run (patroni/__main__.py:106)
        Arguments:
            self: <Patroni at 0x7f0c442e9c50>
    abstract_main (patroni/daemon.py:181)
        Arguments:
            cls: <ABCMeta at 0x56431949a7e8>
            validator: <Schema at 0x7f0c44968940>
        Locals:
            argparse: <module at 0x7f0c44966188>
            Config: <type at 0x564319364c68>
            ConfigParseError: <type at 0x5643192ba388>
            __version__: "3.0.2-alpha"
            parser: <ArgumentParser at 0x7f0c44987cf8>
            args: <Namespace at 0x7f0c442e9f28>
            validate_config: False
            config: <Config at 0x7f0c442e9f60>
            controller: <Patroni at 0x7f0c442e9c50>
    patroni_main (patroni/__main__.py:136)
        Locals:
            freeze_support: <method at 0x7f0c451f8cc8>
            schema: <Schema at 0x7f0c44968940>
    run (multiprocessing/process.py:93)
        Arguments:
            self: <Process at 0x7f0c4aa98cc0>
    _bootstrap (multiprocessing/process.py:258)
        Arguments:
            self: <Process at 0x7f0c4aa98cc0>
        Locals:
            util: <module at 0x7f0c44940688>
            context: <module at 0x7f0c4497c368>
    _launch (multiprocessing/popen_fork.py:73)
        Arguments:
            self: <Popen at 0x7f0c4a796898>
            process_obj: <Process at 0x7f0c4aa98cc0>
        Locals:
            code: 1
            parent_r: 3
            child_w: 4
            random: <module at 0x7f0c4a2d6598>
    __init__ (multiprocessing/popen_fork.py:19)
        Arguments:
            self: <Popen at 0x7f0c4a796898>
            process_obj: <Process at 0x7f0c4aa98cc0>
    _Popen (multiprocessing/context.py:277)
        Arguments:
            process_obj: <Process at 0x7f0c4aa98cc0>
        Locals:
            Popen: <type at 0x56431949b5c8>
    _Popen (multiprocessing/context.py:223)
        Arguments:
            process_obj: <Process at 0x7f0c4aa98cc0>
    start (multiprocessing/process.py:105)
        Arguments:
            self: <Process at 0x7f0c4aa98cc0>
    main (patroni/__main__.py:177)
        Locals:
            sigchld_handler: <function at 0x7f0c4c805f28>
            passtochild: <function at 0x7f0c4496ed90>
            multiprocessing: <module at 0x7f0c4497c1d8>
            patroni: <Process at 0x7f0c4aa98cc0>
    <module> (patroni:11)
...
```

## The Exact Deadlock Sequence

1. **HA thread starts logging**: `has_lock()` → `logger.info("Lock owner: %s; I am %s")`
2. **Acquires Queue Condition lock**: `<Condition at 0x7f0c43b753c8>`
3. **SIGCHLD signal interrupts** this same thread
4. **Signal handler tries to log**: `logger.info("Reaped pid=%s, exit status=%s")`
5. **Signal handler blocks**: Trying to acquire the **same Condition lock** the interrupted thread already holds
6. **DEADLOCK**: Thread can't proceed because signal handler is running, signal handler can't proceed because thread holds the lock
7. All Threads needs to write logs blocked by Issue above

Compared to the potential impact, not recording the death of each child process seems reasonable.

I am happy to implement other solutions, such as using self-pipe trick, although it would be much more complex in comparison.
