### PR TITLE
Don't use `assert` for production validation

### DIFF
--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -18,7 +18,7 @@ import dateutil.parser
 
 from .. import global_config
 from ..dynamic_loader import iter_classes, iter_modules
-from ..exceptions import PatroniFatalException
+from ..exceptions import PatroniAssertionError, PatroniFatalException
 from ..tags import Tags
 from ..utils import deep_compare, parse_int, uri
 
@@ -199,10 +199,13 @@ class Member(Tags, NamedTuple('Member',
             data = {'conn_url': conn_url, 'api_url': api_url}
         else:
             try:
-                data = json.loads(value)
-                assert isinstance(data, dict)
-            except (AssertionError, TypeError, ValueError):
-                data: Dict[str, Any] = {}
+                json_data = json.loads(value)
+                if isinstance(json_data, dict):
+                    data = cast(Dict[str, Any], json_data)
+                else:
+                    raise PatroniAssertionError('not a dict')
+            except (PatroniAssertionError, TypeError, ValueError):
+                data = {}
         return Member(version, name, session, data)
 
     @property
@@ -494,9 +497,12 @@ class Failover(NamedTuple):
             data: Dict[str, Any] = value
         elif value:
             try:
-                data = json.loads(value)
-                assert isinstance(data, dict)
-            except AssertionError:
+                json_data = json.loads(value)
+                if isinstance(json_data, dict):
+                    data = cast(Dict[str, Any], json_data)
+                else:
+                    raise PatroniAssertionError('not a dict')
+            except PatroniAssertionError:
                 data = {}
             except ValueError:
                 t = [a.strip() for a in value.split(':')]
@@ -561,10 +567,13 @@ class ClusterConfig(NamedTuple):
             False
         """
         try:
-            data = json.loads(value)
-            assert isinstance(data, dict)
-        except (AssertionError, TypeError, ValueError):
-            data: Dict[str, Any] = {}
+            json_data = json.loads(value)
+            if isinstance(json_data, dict):
+                data = cast(Dict[str, Any], json_data)
+            else:
+                raise PatroniAssertionError('not a dict')
+        except (PatroniAssertionError, TypeError, ValueError):
+            data = {}
             modify_version = 0
         return ClusterConfig(version, data, version if modify_version is None else modify_version)
 
@@ -617,11 +626,12 @@ class SyncState(NamedTuple):
         try:
             if value and isinstance(value, str):
                 value = json.loads(value)
-            assert isinstance(value, dict)
+            if not isinstance(value, dict):
+                raise PatroniAssertionError('not a dict')
             leader = value.get('leader')
             quorum = value.get('quorum')
             return SyncState(version, leader, value.get('sync_standby'), int(quorum) if leader and quorum else 0)
-        except (AssertionError, TypeError, ValueError):
+        except (PatroniAssertionError, TypeError, ValueError):
             return SyncState.empty(version)
 
     @staticmethod
@@ -751,10 +761,13 @@ class TimelineHistory(NamedTuple):
             []
         """
         try:
-            lines = json.loads(value)
-            assert isinstance(lines, list)
-        except (AssertionError, TypeError, ValueError):
-            lines: List[_HistoryTuple] = []
+            json_lines = json.loads(value)
+            if isinstance(json_lines, list):
+                lines = cast(List[_HistoryTuple], json_lines)
+            else:
+                raise PatroniAssertionError('not a list')
+        except (PatroniAssertionError, TypeError, ValueError):
+            lines = []
         return TimelineHistory(version, value, lines)
 
 

--- a/patroni/exceptions.py
+++ b/patroni/exceptions.py
@@ -53,3 +53,9 @@ class ConfigParseError(PatroniException):
     """Any issue identified while loading or validating the Patroni configuration."""
 
     pass
+
+
+class PatroniAssertionError(PatroniException):
+    """Any issue related to type/value validation."""
+
+    pass

--- a/patroni/validator.py
+++ b/patroni/validator.py
@@ -13,7 +13,7 @@ from typing import Any, cast, Dict, Iterator, List, Optional as OptionalType, Tu
 
 from .collections import CaseInsensitiveSet, EMPTY_DICT
 from .dcs import dcs_modules
-from .exceptions import ConfigParseError
+from .exceptions import ConfigParseError, PatroniAssertionError
 from .log import type_logformat
 from .utils import data_directory_is_empty, get_major_version, parse_int, split_host_port
 
@@ -173,9 +173,12 @@ def validate_host_port_list(value: List[str]) -> bool:
     :param value: list of host(s) and port items to be validated.
 
     :returns: ``True`` if all items are valid.
+
+    .. note::
+        :func:`validate_host_port` will raise an exception if validation failed.
     """
-    assert all([validate_host_port(v) for v in value]), "didn't pass the validation"
-    return True
+
+    return all(validate_host_port(v) for v in value)
 
 
 def comma_separated_host_port(string: str) -> bool:
@@ -870,7 +873,8 @@ def assert_(condition: bool, message: str = "Wrong value") -> None:
     :param condition: result of a condition to be asserted.
     :param message: message to be thrown if the condition is ``False``.
     """
-    assert condition, message
+    if not condition:
+        raise PatroniAssertionError(message)
 
 
 class IntValidator(object):

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -24,7 +24,7 @@ from . import MockResponse, SleepException
 def mock_list_namespaced_config_map(*args, **kwargs):
     k8s_group_label = get_mpp({'citus': {'group': 0, 'database': 'postgres'}}).k8s_group_label
     metadata = {'resource_version': '1', 'labels': {'f': 'b'}, 'name': 'test-config',
-                'annotations': {'initialize': '123', 'config': '{}'}}
+                'annotations': {'initialize': '123', 'config': '[]', 'history': '{}'}}
     items = [k8s_client.V1ConfigMap(metadata=k8s_client.V1ObjectMeta(**metadata))]
     metadata.update({'name': 'test-leader',
                      'annotations': {'optime': '1234x', 'leader': 'p-0', 'ttl': '30s',


### PR DESCRIPTION
Replace it with `PatroniAssertionError` where it is possible.

Close https://github.com/patroni/patroni/pull/3421