### PR TITLE
Fix issue with renaming leader node in sync mode and pause

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -913,6 +913,14 @@ class Ha(object):
         allow_promote = current_state.sync_confirmed
         voters = CaseInsensitiveSet(sync.voters)
 
+        if self.state_handler.name != sync.leader:
+            logger.warning("Inconsistent state of /sync key detected, leader = %s doesn't match %s, "
+                           "updating synchronous replication key", sync.leader, self.state_handler.name)
+            sync = self.dcs.write_sync_state(self.state_handler.name, None, 0, version=sync.version)
+            if not sync:
+                return logger.warning("Updating sync state failed")
+            voters = CaseInsensitiveSet()
+
         if picked == voters and voters != allow_promote:
             logger.warning('Inconsistent state between synchronous_standby_names = %s and /sync = %s key '
                            'detected, updating synchronous replication key...', list(allow_promote), list(voters))

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -1620,16 +1620,19 @@ class TestHa(PostgresInit):
         self.ha.cluster = get_cluster_initialized_without_leader(sync=('leader', 'a'))
         self.p.sync_handler.current_state = Mock(return_value=_SyncState('priority', 0, CaseInsensitiveSet(),
                                                                          CaseInsensitiveSet(), CaseInsensitiveSet('a')))
-        self.ha.dcs.write_sync_state = Mock(return_value=SyncState.empty())
-        mock_set_sync = self.p.sync_handler.set_synchronous_standby_names = Mock()
-        with patch('patroni.ha.logger.warning') as mock_logger:
-            self.ha.run_cycle()
-            mock_set_sync.assert_called_once()
-            self.assertTrue(mock_logger.call_args_list[0][0][0].startswith('Inconsistent state between '))
-        self.ha.dcs.write_sync_state = Mock(return_value=None)
-        with patch('patroni.ha.logger.warning') as mock_logger:
-            self.ha.run_cycle()
-            self.assertEqual(mock_logger.call_args[0][0], 'Updating sync state failed')
+        for leader_name in ('other', 'leader'):
+            with self.subTest(leader_name=leader_name):
+                self.p.name = leader_name
+                self.ha.dcs.write_sync_state = Mock(return_value=SyncState.empty())
+                mock_set_sync = self.p.sync_handler.set_synchronous_standby_names = Mock()
+                with patch('patroni.ha.logger.warning') as mock_logger:
+                    self.ha.run_cycle()
+                    mock_set_sync.assert_called_once()
+                    self.assertTrue(mock_logger.call_args_list[0][0][0].startswith('Inconsistent state '))
+                self.ha.dcs.write_sync_state = Mock(return_value=None)
+                with patch('patroni.ha.logger.warning') as mock_logger:
+                    self.ha.run_cycle()
+                    self.assertEqual(mock_logger.call_args[0][0], 'Updating sync state failed')
 
     def test_effective_tags(self):
         self.ha._disable_sync = True


### PR DESCRIPTION
`/sync` key wasn't updated after renaming the leader node with Patroni restart in pause (without Postgres restart).
It prevented Patroni from promoting after the next restart without pause.

Close #3449