### PR TITLE
Fix typo in docs/installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -66,7 +66,7 @@ systemd
     `systemd-python` in order to use sd_notify integration
 all
     all of the above (except psycopg family)
-psycopg
+psycopg3
     `psycopg[binary]>=3.0.0` module
 psycopg2
     `psycopg2>=2.5.4` module

--- a/features/permanent_slots.feature
+++ b/features/permanent_slots.feature
@@ -79,7 +79,7 @@ Feature: permanent slots
     And postgres-1 has a physical replication slot named postgres_0 after 10 seconds
     And postgres-1 has a physical replication slot named postgres_3 after 10 seconds
 
-  @slot-advance
+  @pg110000
   Scenario: check permanent physical replication slot on replica after failover
     Given I start postgres-0
     Then postgres-0 role is the replica after 20 seconds


### PR DESCRIPTION
extra is called psycopg3, not psycopg