### PR TITLE
Introduce Jepsen tests

### DIFF
--- a/.github/workflows/jepsen.yaml
+++ b/.github/workflows/jepsen.yaml
@@ -1,0 +1,59 @@
+name: Jepsen tests
+
+on:
+#  schedule:
+#  - cron: '0 0 * * *'
+
+  # Allow manual triggering with a branch input
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to run Jepsen tests on'
+        required: true
+        default: 'master'
+
+jobs:
+  jepsen:
+    runs-on: ubuntu-latest
+    env:
+      BRANCH: ${{ github.event.inputs.branch || 'master' }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+
+    - name: Validate branch
+      run: git ls-remote --exit-code origin "refs/heads/$BRANCH" || (echo "Branch $BRANCH does not exist" && exit 1)
+
+    - name: Run test
+      run: |
+        cd jepsen
+        docker compose build --build-arg "BRANCH=$BRANCH"
+        docker compose up -d
+        mkdir -p logs
+        (
+          cd logs
+          if ! docker exec jepsen-test bash run.sh > jepsen.log 2>&1; then
+            tail -n 18 jepsen.log
+            for name in $(docker ps --filter "name=jepsen-[^t]" --format "{{.Names}}"); do
+              docker logs "$name" > "${name#jepsen-}.log"
+            done
+            for name in $(docker ps --filter "name=jepsen-patroni" --format "{{.Names}}"); do
+              docker exec "$name" sh -c 'cat $PGDATA/log/postgres.log' > "${name#jepsen-}-postgres.log"
+              docker exec "$name" sh -c 'cat $PGDATA/log/postgres.csv' > "${name#jepsen-}-postgres.csv"
+            done
+            docker exec "$name" patronictl list > patronictl.log
+            docker exec "$name" patronictl history >> patronictl.log
+            exit 1
+          fi
+          tail -n 4 jepsen.log
+        )
+        docker compose down --rmi all
+
+    - name: Upload logs if Jepsen test failed
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: jepsen-logs
+        path: jepsen/logs
+        if-no-files-found: error
+        retention-days: 5

--- a/jepsen/Dockerfile
+++ b/jepsen/Dockerfile
@@ -1,0 +1,72 @@
+ARG PG_MAJOR=17
+ARG PGHOME=/home/postgres
+ARG DEBIAN_FRONTEND=noninteractive
+ARG BRANCH=master
+
+FROM postgres:$PG_MAJOR AS base
+
+ARG PGHOME DEBIAN_FRONTEND
+RUN echo 'APT::Install-Recommends "0";\n\
+APT::Get::Assume-Yes "true";\n\
+APT::Get::allow-downgrades "true";\n\
+APT::Install-Suggests "0";' > /etc/apt/apt.conf.d/01buildconfig && \
+    apt-get update -y && \
+    apt-get upgrade -y && \
+    # allow starting sshd
+    echo '#!/bin/sh' > /usr/sbin/policy-rc.d && \
+    apt-get install -y etcd-client runit vim curl ca-certificates jq git less locales rsync \
+        iptables bind9-host net-tools iputils-ping sudo telnet openssh-server coreutils && \
+    # Make sure we have a en_US.UTF-8 locale available
+    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
+    # vim config
+    echo 'syntax on\nfiletype plugin indent on\nset mouse-=a\nautocmd FileType yaml setlocal ts=2 sts=2 sw=2 expandtab' > /etc/vim/vimrc.local && \
+    mkdir -p $PGHOME/archive && \
+    mkdir -p $PGHOME/.ssh && \
+    sed -i "s|/var/lib/postgresql.*|$PGHOME:/bin/bash|" /etc/passwd && \
+    # jsch does not support rsa-sha2, we have to use the insecure ssh-rsa
+    echo 'HostKeyAlgorithms +ssh-rsa\nPubkeyAcceptedKeyTypes +ssh-rsa' >> /etc/ssh/sshd_config && \
+    # generate ssh key
+    mkdir -p /root/.ssh && \
+    chmod 700 /root/.ssh && \
+    cd /root/.ssh && \
+    yes | ssh-keygen -m PEM -t rsa -N '' -f id_rsa -C jepsen || true && \
+    cp id_rsa.pub authorized_keys && \
+    cp -a ./* $PGHOME/.ssh/ && \
+    chown -R postgres:postgres $PGHOME
+
+ENTRYPOINT ["/usr/bin/runsvdir", "-P", "/etc/service"]
+
+FROM base AS etcd
+RUN apt-get install -y etcd-server
+COPY runit/etcd /etc/service/etcd
+
+
+FROM base AS patroni
+
+ARG BRANCH PGHOME PG_MAJOR DEBIAN_FRONTEND
+ARG PGBIN=/usr/lib/postgresql/$PG_MAJOR/bin
+
+RUN apt-cache depends patroni | sed -n -e 's/.* Depends: \(python3-.\+\)$/\1/p' \
+            | grep -Ev '^python3-(sphinx|etcd|consul|kazoo|kubernetes|psycopg)' \
+            | xargs apt-get install -y  python3-pip python3-wheel python3-setuptools python3-etcd \
+    && pip3 install --break-system-packages "git+https://github.com/patroni/patroni.git@${BRANCH}#egg=patroni[psycopg3]" && \
+    mkdir -p ~/.config/patroni && \
+    ln -s /home/postgres/patroni.yml ~/.config/patroni/patronictl.yaml
+
+COPY runit/patroni /etc/service/patroni
+
+ENV PGHOME=$PGHOME PGDATA=$PGHOME/data PATH=$PATH:$PGBIN
+ENV LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 EDITOR=/usr/bin/editor
+
+
+FROM base AS jepsen
+
+RUN apt-get install -y libjna-java default-jre-headless && \
+    curl -sL https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein > /usr/bin/lein && \
+    chmod +x /usr/bin/lein
+
+COPY jepsen /root/jepsen
+WORKDIR /root/jepsen
+
+ENV LEIN_ROOT=1
+RUN lein install && lein deps

--- a/jepsen/docker-compose.yml
+++ b/jepsen/docker-compose.yml
@@ -1,0 +1,60 @@
+networks:
+  jepsen:
+
+services:
+  test: &test
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: jepsen
+    networks: [ jepsen ]
+    environment: &env
+      ETCDCTL_ENDPOINTS: http://etcd1:2379,http://etcd2:2379,http://etcd3:2379
+    container_name: jepsen-test
+    hostname: test
+
+  etcd1: &etcd
+    <<: *test
+    build:
+      target: etcd
+    image: jepsen-etcd:latest
+    privileged: true
+    environment:
+      ETCD_INITIAL_CLUSTER: etcd1=http://etcd1:2380,etcd2=http://etcd2:2380,etcd3=http://etcd3:2380
+      ETCD_INITIAL_CLUSTER_TOKEN: jepsen
+      ETCD_UNSUPPORTED_ARCH: arm64
+    container_name: jepsen-etcd1
+    hostname: etcd1
+
+  etcd2:
+    <<: *etcd
+    container_name: jepsen-etcd2
+    hostname: etcd2
+
+  etcd3:
+    <<: *etcd
+    container_name: jepsen-etcd3
+    hostname: etcd3
+
+  patroni1: &patroni
+    <<: *test
+    build:
+      target: patroni
+    image: jepsen-patroni:latest
+    privileged: true
+    environment:
+      <<: *env
+      PATRONI_ETCD3_HOSTS: "'etcd1:2379','etcd2:2379','etcd3:2379'"
+      PATRONI_SCOPE: jepsen
+    container_name: jepsen-patroni1
+    hostname: patroni1
+
+  patroni2:
+    <<: *patroni
+    hostname: patroni2
+    container_name: jepsen-patroni2
+
+  patroni3:
+    <<: *patroni
+    container_name: jepsen-patroni3
+    hostname: patroni3

--- a/jepsen/jepsen/project.clj
+++ b/jepsen/jepsen/project.clj
@@ -1,0 +1,11 @@
+(defproject jepsen.patroni "0.1.0-SNAPSHOT"
+  :description "Patroni tests"
+  :url "https://github.com/patroni/patroni"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.10.3"]
+                 [org.clojure/tools.nrepl "0.2.13"]
+                 [clojure-complete "0.2.5"]
+                 [jepsen "0.2.6"]
+                 [org.clojure/java.jdbc "0.7.12"]
+                 [org.postgresql/postgresql "42.3.2"]])

--- a/jepsen/jepsen/run.sh
+++ b/jepsen/jepsen/run.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -ex
+
+cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
+
+for n in {1..3}; do
+    ssh-keyscan -t rsa "patroni$n" >> /root/.ssh/known_hosts
+    ssh-keyscan -t rsa "etcd$n" >> /root/.ssh/known_hosts
+done
+
+wait_timeout=60
+for (( n=1; n <= wait_timeout; n++ )); do
+    leader=$(ssh patroni1 "patronictl list -f json | jq -r '.[] | select(.Role==\"Leader\") | .Member'")
+    [ -n "$leader" ] && break
+    [ "$n" -eq $wait_timeout ] && exit 1
+    sleep 1
+done
+
+ssh "$leader" "psql -U postgres -c 'CREATE TABLE IF NOT EXISTS set (value integer primary key)'"
+
+for member in $(ssh "$leader" "patronictl list -f json | jq -r '.[] | select(.Role!=\"Leader\") | .Member'"); do
+    for (( n=1; n <= wait_timeout; n++ )); do
+        ssh "$member" "psql -U postgres -tAc 'SELECT * FROM set'" && break
+        [ "$n" -eq $wait_timeout ] && exit 1
+        sleep 1
+    done
+done
+
+timeout 10800 lein test

--- a/jepsen/jepsen/src/jepsen/patroni.clj
+++ b/jepsen/jepsen/src/jepsen/patroni.clj
@@ -1,0 +1,264 @@
+(ns jepsen.patroni
+  "Tests for Patroni"
+  (:require [clojure.tools.logging :refer :all]
+            [clojure.core.reducers :as r]
+            [clojure.set :as set]
+            [clojure.string :as string]
+            [jepsen [tests :as tests]
+                    [os :as os]
+                    [db :as db]
+                    [client :as client]
+                    [control :as control]
+                    [nemesis :as nemesis]
+                    [generator :as gen]
+                    [checker :as checker]
+                    [util :as util :refer [timeout]]
+                    [net :as net]]
+            [knossos [op :as op]]
+            [clojure.java.jdbc :as j]))
+
+(def register (atom 0))
+
+(defn open-conn
+  "Given a JDBC connection spec, opens a new connection unless one already
+  exists. JDBC represents open connections as a map with a :connection key.
+  Won't open if a connection is already open."
+  [spec]
+  (if (:connection spec)
+    spec
+    (j/add-connection spec (j/get-connection spec))))
+
+(defn close-conn
+  "Given a spec with JDBC connection, closes connection and returns the spec w/o connection."
+  [spec]
+  (when-let [conn (:connection spec)]
+    (.close conn))
+  {:classname   (:classname spec)
+   :subprotocol (:subprotocol spec)
+   :subname     (:subname spec)
+   :user        (:user spec)
+   :password    (:password spec)})
+
+(defmacro with-conn
+  "This macro takes that atom and binds a connection for the duration of
+  its body, automatically reconnecting on any
+  exception."
+  [[conn-sym conn-atom] & body]
+  `(let [~conn-sym (locking ~conn-atom
+                     (swap! ~conn-atom open-conn))]
+     (try
+       ~@body
+       (catch Throwable t#
+         (locking ~conn-atom
+           (swap! ~conn-atom (comp open-conn close-conn)))
+         (throw t#)))))
+
+(defn conn-spec
+  "Return postgresql connection spec for given node name"
+  [node]
+  {:classname   "org.postgresql.Driver"
+   :subprotocol "postgresql"
+   :subname     (str "//" (name node) ":5432/postgres?prepareThreshold=0")
+   :user        "postgres"
+   :password    "postgres"})
+
+(defn noop-client
+  "Noop client"
+  []
+  (reify client/Client
+    (setup! [_ test]
+      (info "noop-client setup"))
+    (invoke! [this test op]
+      (assoc op :type :info, :error "noop"))
+    (close! [_ test])
+    (teardown! [_ test] (info "teardown"))
+    client/Reusable
+    (reusable? [_ test] true)))
+
+(defn pg-client
+  "PostgreSQL client"
+  [conn]
+  (reify client/Client
+    (setup! [_ test]
+      (info "pg-client setup"))
+    (open! [_ test node]
+      (let [conn (atom (conn-spec node))]
+        (cond (string/includes? (name node) "patroni")
+              (pg-client conn)
+              true
+              (noop-client))))
+    (invoke! [this test op]
+      (try
+          (timeout 5000 (assoc op :type :info, :error "timeout")
+            (with-conn [c conn]
+              (case (:f op)
+                :read (assoc op :type :ok,
+                                :value (->> (j/query c ["select value from set for update"]
+                                                     {:row-fn :value})
+                                            (vec)
+                                            (set)))
+                :add (do (j/execute! c [(str "insert into set values ("
+                                                (get op :value) ")")])
+                            (assoc op :type :ok)))))
+        (catch Throwable t#
+          (let [m# (.getMessage t#)]
+            (cond (re-find #"ERROR: cannot execute .* in a read-only transaction" m#)
+                  (assoc op :type :info, :error "read-only")
+                  true
+                  (assoc op :type :info, :error m#))))))
+    (close! [_ test] (close-conn conn))
+    (teardown! [_ test])
+    client/Reusable
+    (reusable? [_ test] true)))
+
+(defn db
+  "PostgreSQL database"
+  []
+  (reify db/DB
+    (setup! [_ test node]
+      (info (str (name node) " setup")))
+
+    (teardown! [_ test node]
+      (info (str (name node) " teardown")))))
+
+(defn r [_ _] {:type :invoke, :f :read, :value nil})
+(defn a [_ _] {:type :invoke, :f :add, :value (swap! register (fn [current-state] (+ current-state 1)))})
+
+(def patroni-set
+  "Given a set of :add operations followed by a final :read, verifies that
+  every successfully added element is present in the read, and that the read
+  contains only elements for which an add was attempted."
+  (reify checker/Checker
+    (check [this test history opts]
+      (let [attempts (->> history
+                          (r/filter op/invoke?)
+                          (r/filter #(= :add (:f %)))
+                          (r/map :value)
+                          (into #{}))
+            adds (->> history
+                      (r/filter op/ok?)
+                      (r/filter #(= :add (:f %)))
+                      (r/map :value)
+                      (into #{}))
+            final-read (->> history
+                          (r/filter op/ok?)
+                          (r/filter #(= :read (:f %)))
+                          (r/map :value)
+                          (reduce (fn [_ x] x) nil))]
+        (if-not final-read
+          {:valid? false
+           :error  "Set was never read"}
+
+          (let [; The OK set is every read value which we tried to add
+                ok          (set/intersection final-read attempts)
+
+                ; Unexpected records are those we *never* attempted.
+                unexpected  (set/difference final-read attempts)
+
+                ; Lost records are those we definitely added but weren't read
+                lost        (set/difference adds final-read)
+
+                ; Recovered records are those where we didn't know if the add
+                ; succeeded or not, but we found them in the final set.
+                recovered   (set/difference ok adds)]
+
+            {:valid?          (and (empty? lost) (empty? unexpected))
+             :ok              (util/integer-interval-set-str ok)
+             :lost            (util/integer-interval-set-str lost)
+             :unexpected      (util/integer-interval-set-str unexpected)
+             :recovered       (util/integer-interval-set-str recovered)
+             :ok-frac         (util/fraction (count ok) (count attempts))
+             :unexpected-frac (util/fraction (count unexpected) (count attempts))
+             :lost-frac       (util/fraction (count lost) (count attempts))
+             :recovered-frac  (util/fraction (count recovered) (count attempts))}))))))
+
+(defn killer
+  "Executes pkill -9 `procname`"
+  []
+  (reify nemesis/Nemesis
+    (setup! [this test]
+      this)
+    (invoke! [this test op]
+             (case (:f op)
+               :kill (assoc op :value
+                            (try
+                              (let [procname (rand-nth [:postgres
+                                                        :patroni])
+                                    node (rand-nth (filter (fn [x] (string/includes? (name x) "patroni"))
+                                                           (:nodes test)))]
+                                (control/on node
+                                  (control/exec :pkill :-9 :-f procname))
+                                (assoc op :value [:killed procname :on node]))
+                              (catch Throwable t#
+                                (let [m# (.getMessage t#)]
+                                  (do (warn (str "Unable to run pkill: "
+                                                 m#))
+                                      m#)))))))
+    (teardown! [this test]
+      (info (str "Stopping killer")))
+    nemesis/Reflection
+    (fs [this] #{})))
+
+(defn switcher
+  "Executes switchover"
+  []
+  (reify nemesis/Nemesis
+    (setup! [this test]
+      this)
+    (invoke! [this test op]
+             (case (:f op)
+               :switch (assoc op :value
+                          (try
+                              (let [node (rand-nth (filter (fn [x] (string/includes? (name x) "patroni"))
+                                                           (:nodes test)))]
+                                (control/on node
+                                  (control/exec :timeout :10 :patronictl :switchover :--force))
+                                (assoc op :value [:switchover :on node]))
+                            (catch Throwable t#
+                              (let [m# (.getMessage t#)]
+                                (do (warn (str "Unable to run switch: "
+                                               m#))
+                                    m#)))))))
+    (teardown! [this test]
+      (info (str "Stopping switcher")))
+    nemesis/Reflection
+    (fs [this] #{})))
+
+(def nemesis-starts [:start-halves :start-ring :start-one :switch :kill])
+
+(defn patroni-test
+  [patroni-nodes etcd-nodes]
+  {:nodes     (concat patroni-nodes etcd-nodes)
+   :name      "patroni"
+   :os        os/noop
+   :db        (db)
+   :ssh       {:private-key-path "/root/.ssh/id_rsa"}
+   :net       net/iptables
+   :client    (pg-client nil)
+   :nemesis   (nemesis/compose {{:start-halves :start} (nemesis/partition-random-halves)
+                                {:start-ring   :start} (nemesis/partition-majorities-ring)
+                                {:start-one    :start
+                                 ; All partitioners heal all nodes on stop so we define stop once
+                                 :stop         :stop} (nemesis/partition-random-node)
+                                #{:switch} (switcher)
+                                #{:kill} (killer)})
+   :generator (gen/phases
+                (->> a
+                     (gen/stagger 1/50)
+                     (gen/nemesis
+                       (fn [] (map gen/once
+                                    [{:type :info, :f (rand-nth nemesis-starts)}
+                                     {:type :info, :f (rand-nth nemesis-starts)}
+                                     {:type :sleep, :value 60}
+                                     {:type :info, :f :stop}
+                                     {:type :sleep, :value 60}])))
+                     (gen/time-limit 7200))
+                (->> r
+                     (gen/stagger 1)
+                     (gen/nemesis
+                       (fn [] (map gen/once
+                                    [{:type :info, :f :stop}
+                                     {:type :sleep, :value 60}])))
+                     (gen/time-limit 600)))
+   :checker   patroni-set
+   :remote    control/ssh})

--- a/jepsen/jepsen/test/jepsen/patroni_test.clj
+++ b/jepsen/jepsen/test/jepsen/patroni_test.clj
@@ -1,0 +1,11 @@
+(ns jepsen.patroni-test
+  (:require [clojure.test :refer :all]
+            [jepsen.core :as jepsen]
+            [jepsen.patroni :as patroni]))
+
+(def patroni_nodes ["patroni1" "patroni2" "patroni3"])
+
+(def etcd_nodes ["etcd1" "etcd2" "etcd3"])
+
+(deftest patroni-test
+  (is (:valid? (:results (jepsen/run! (patroni/patroni-test patroni_nodes etcd_nodes))))))

--- a/jepsen/runit/etcd/run
+++ b/jepsen/runit/etcd/run
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+exec 2>&1
+cd /home/postgres
+exec chpst -u postgres \
+    /usr/bin/etcd --auto-compaction-retention=1 \
+    --name "$HOSTNAME" \
+    --initial-advertise-peer-urls "http://$HOSTNAME:2380" \
+    --advertise-client-urls "http://$HOSTNAME:2379" \
+    --listen-peer-urls http://0.0.0.0:2380 \
+    --listen-client-urls http://0.0.0.0:2379 \
+    --initial-cluster-state new

--- a/jepsen/runit/patroni/run
+++ b/jepsen/runit/patroni/run
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+exec 2>&1
+
+PATRONI_RESTAPI_USERNAME="${PATRONI_RESTAPI_USERNAME:-admin}"
+PATRONI_RESTAPI_PASSWORD="${PATRONI_RESTAPI_PASSWORD:-admin}"
+PATRONI_REPLICATION_USERNAME="${PATRONI_REPLICATION_USERNAME:-replicator}"
+PATRONI_REPLICATION_PASSWORD="${PATRONI_REPLICATION_PASSWORD:-replicate}"
+PATRONI_REWIND_USERNAME="${PATRONI_REWIND_USERNAME:-rewind}"
+PATRONI_REWIND_PASSWORD="${PATRONI_REWIND_PASSWORD:-rewind}"
+PATRONI_SUPERUSER_USERNAME="${PATRONI_SUPERUSER_USERNAME:-postgres}"
+PATRONI_SUPERUSER_PASSWORD="${PATRONI_SUPERUSER_PASSWORD:-postgres}"
+
+DOCKER_IP=$(hostname --ip-address)
+readonly DOCKER_IP
+
+cat > "$PGHOME/patroni.yml" <<__EOF__
+name: '$HOSTNAME'
+bootstrap:
+  dcs:
+    failsafe_mode: on
+    synchronous_mode: quorum
+    synchronous_mode_strict: on
+    check_timeline: on
+    postgresql:
+      use_pg_rewind: true
+      parameters:
+        wal_sender_timeout: 30000
+  initdb:
+  - auth-host: md5
+  - auth-local: trust
+  - encoding: UTF8
+  - locale: en_US.UTF-8
+  - data-checksums
+restapi:
+  connect_address: $DOCKER_IP:8008
+  listen: '*:8008'
+  authentication:
+    username: '$PATRONI_RESTAPI_USERNAME'
+    password: '$PATRONI_RESTAPI_PASSWORD'
+postgresql:
+  connect_address: $DOCKER_IP:5432
+  listen: '*:5432'
+  data_dir: '${PATRONI_POSTGRESQL_DATA_DIR:-$PGDATA}'
+  use_unix_socket: true
+  use_unix_socket_repl: true
+  authentication:
+    superuser:
+      username: '$PATRONI_SUPERUSER_USERNAME'
+      password: '$PATRONI_SUPERUSER_PASSWORD'
+    replication:
+      username: '$PATRONI_REPLICATION_USERNAME'
+      password: '$PATRONI_REPLICATION_PASSWORD'
+    rewind:
+      username: '$PATRONI_REWIND_USERNAME'
+      password: '$PATRONI_REWIND_PASSWORD'
+  basebackup:
+    checkpoint: fast
+  parameters:
+    shared_buffers: 4MB
+    logging_collector: 'on'
+    log_destination: csvlog
+    log_directory: log
+    log_filename: postgres.log
+    archive_mode: 'on'
+    archive_timeout: 30
+    archive_command: 'rsync -e "ssh -o ConnectTimeout=1" --timeout=3 -a %p test:$PGHOME/archive/%f'
+    restore_command: 'rsync -a test:$PGHOME/archive/%f %p'
+  pg_hba:
+  - local all all trust
+  - local replication all trust
+  - host all all all md5
+  - host replication ${PATRONI_REPLICATION_USERNAME} all md5
+__EOF__
+
+unset PATRONI_RESTAPI_USERNAME PATRONI_RESTAPI_PASSWORD PATRONI_SUPERUSER_USERNAME PATRONI_SUPERUSER_PASSWORD PATRONI_REPLICATION_USERNAME PATRONI_REPLICATION_PASSWORD PATRONI_REWIND_USERNAME PATRONI_REWIND_PASSWORD
+
+# save DCS related environment variables so that they are available in ssh sessions
+export PATRONI_SCOPE="${PATRONI_SCOPE:-demo}"
+PATRONI_NAMESPACE="${PATRONI_NAMESPACE:-/service}"
+export PATRONI_NAMESPACE="${PATRONI_NAMESPACE%/}"
+export -p | grep '^declare -x PATRONI_' > /root/.bashrc
+
+if [ ! -s "$PGHOME/.ssh/known_hosts" ]; then
+    for _ in {1..10}; do
+        ssh-keyscan -t rsa test > "$PGHOME/.ssh/known_hosts" && break
+        sleep 1
+    done
+fi
+[ -s "$PGHOME/.ssh/known_hosts" ] || exit 1
+chown postgres:postgres "$PGHOME/.ssh/known_hosts"
+
+exec chpst -u postgres env HOME="$PGHOME" \
+    /usr/bin/python3 /usr/local/bin/patroni "$PGHOME/patroni.yml"


### PR DESCRIPTION
Actual Clojure implementation is borrowed from https://github.com/yandex/pgconsul/tree/main/docker/jepsen/jepsen

For tests we start Etcd v3 cluster consisting of 3 nodes and Patroni cluster consisting of 3 nodes and configured to use quorum strict replication.
Everything is started in privileged docker containers using docker-compose.yml file. In addition to Etcd and Patroni in every container we run sshd, because Jepsen is relying on it to create iptables rules to emulate partitioned networks, to kill Patroni/Postgres processes, and to run `patronictl switchover`.