### PR TITLE
synchronous replica switchover feature

### DIFF
--- a/patroni/api.py
+++ b/patroni/api.py
@@ -1264,6 +1264,120 @@ class RestApiHandler(BaseHTTPRequestHandler):
         """
         self.do_POST_failover(action='switchover')
 
+    def poll_sync_switchover_result(self, candidates: Optional[List[str]]) -> Tuple[int, str]:
+        """Poll sync switchover operation until it finishes or times out.
+
+        :param candidates: names of the Patroni node to be promoted to synchronous replica.
+
+        :returns: a tuple composed of 2 items:
+
+            * Response HTTP status codes:
+
+                * ``200``: if the operation succeeded; or
+                * ``503``: if the operation failed or timed out.
+
+            * A status message about the operation.
+
+        """
+        timeout = max(10, self.server.patroni.dcs.loop_wait)
+        for _ in range(0, timeout * 2):
+            time.sleep(1)
+            try:
+                cluster = self.server.patroni.dcs.get_cluster()
+                sync = cluster.sync.sync_standby.split(',')
+                if sync and set(sync) == set(candidates):
+                    return 200, f'Successfully switched synchronous replicas to {candidates}'
+                if not cluster.sync_switchover:
+                    return 503, 'sync switchover failed'
+            except Exception as e:
+                logger.debug('Exception occurred during polling sync switchover result: %s', e)
+        return 503, 'sync switchover status unknown'
+
+    @check_access
+    def do_POST_sync_switchover(self) -> None:
+        """Handle a ``POST`` request to ``/sync_switchover`` path.
+        """
+        request = self._read_json_content()
+        if not request:
+            return
+
+        cluster = self.server.patroni.dcs.get_cluster()
+        leader = request.get('leader')
+        scheduled_at = request.get('scheduled_at')
+
+        err = self.validate_sync_switchover(request)
+        if err:
+            self.write_response(400, err)
+            return
+
+        candidates = list(set(request.get('candidates')))
+
+        if scheduled_at:
+            status_code, err, scheduled_at = self.parse_schedule(scheduled_at, 'sync_switchover')
+            if err:
+                self.write_response(status_code if status_code else 400, err)
+                return
+
+        err = self.is_sync_switchover_possible(cluster, leader, candidates)
+        if err:
+            self.write_response(412, err)
+            return
+
+        if self.server.patroni.dcs.manual_switch_sync(leader, candidates, scheduled_at):
+            self.server.patroni.ha.wakeup()
+            if scheduled_at:
+                self.write_response(202, 'sync switchover scheduled')
+                return
+            code, body = self.poll_sync_switchover_result(candidates)
+            self.write_response(code, body)
+            return
+        else:
+            self.write_response(503, 'failed to write sync_switchover key into DCS')
+            return
+
+    @staticmethod
+    def validate_sync_switchover(request: Dict) -> Optional[str]:
+
+        leader = request.get('leader')
+        candidates = request.get('candidates')
+
+        if not leader or type(leader) is not str:
+            return 'Sync switchover could be performed only from a specific leader'
+        if not candidates:
+            return 'Sync switchover could be performed only to a specific candidates'
+        if type(candidates) is not list:
+            if type(candidates) is str:
+                request['candidates'] = [candidates]
+            else:
+                return 'Sync switchover candidates type unknown'
+        if leader in candidates:
+            return 'Leader cannot be chosen as a synchronous replica'
+
+
+    @staticmethod
+    def is_sync_switchover_possible(cluster: Cluster, leader: Optional[str],
+                                    candidates: Optional[List[str]]) -> Optional[str]:
+        config = global_config.from_cluster(cluster)
+        if leader and (not cluster.leader or cluster.leader.name != leader):
+            return 'leader name does not match'
+        if config.is_paused:
+            # conservative way
+            return 'Sync switchover is unavailable is paused state'
+        if not config.is_synchronous_mode:
+            return 'Synchronous mode disabled'
+        if config.is_quorum_commit_mode:
+            return 'Sync switchover is unavailable is quorum commit mode'
+
+        if config.synchronous_node_count != len(candidates):
+            return (f'Synchronous node count is {config.synchronous_node_count}'
+                    f' but requested count is  {len(candidates)}.')
+
+        allowed_candidates = [str(m.name) for m in cluster.members if m.name != leader and not m.nofailover and
+                                not m.nosync and not m.nostream and not m.noloadbalance]
+        for candidate in candidates:
+            if candidate not in allowed_candidates:
+                return f"Candidate {candidate} either doesn't exist in cluster or has denying tags"
+
     @check_access
     def do_POST_citus(self) -> None:
         """Handle a ``POST`` request to ``/citus`` path.

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -1409,6 +1409,146 @@ def _do_failover_or_switchover(action: str, cluster_name: str, group: Optional[i
     output_members(cluster, cluster_name, group=group)
 
 
+def _do_sync_switchover(cluster_name: str, candidates: Optional[List[str]],
+                               force: bool, switchover_leader: Optional[str] = None,
+                               switchover_scheduled: Optional[str] = None) -> None:
+
+    if type(candidates) is str:
+        candidates = candidates,
+
+    dcs = get_dcs(cluster_name, None)
+    cluster = dcs.get_cluster()
+    click.echo('Current cluster topology')
+    output_members(cluster, cluster_name, group=None)
+    cluster_sync = cluster.sync.sync_standby.split(',')
+    cluster_leader = cluster.leader and cluster.leader.name
+
+    config = global_config.from_cluster(cluster)
+
+    if not config.is_synchronous_mode:
+        raise PatroniCtlException('Cluster is not in synchronous mode')
+
+    # leader has to be be defined for switchover only
+    if not cluster_leader:
+        raise PatroniCtlException('This cluster has no leader')
+
+    if switchover_leader is None:
+        if force:
+            switchover_leader = cluster_leader
+        else:
+            switchover_leader = click.prompt('Primary', type=str, default=cluster_leader)
+
+    if cluster_leader != switchover_leader:
+        raise PatroniCtlException(f'Member {switchover_leader} is not the leader of cluster {cluster_name}')
+
+    # excluding members with nofailover tag
+    candidate_names = [str(m.name) for m in cluster.members if m.name != cluster_leader and not m.nofailover and
+                       not m.nosync and not m.nostream and not m.noloadbalance]
+    # We sort the names for consistent output to the client
+    candidate_names.sort()
+
+    if not candidate_names:
+        raise PatroniCtlException('No candidates found to perform synchronous replica switchover to')
+    if not candidates and force:
+        raise PatroniCtlException('No candidates provided to perform synchronous replica switchover in force mode')
+
+    if candidates:
+        for candidate in candidates:
+            if candidate not in candidate_names:
+                if candidate == cluster_leader:
+                    raise PatroniCtlException(
+                        f'Member {cluster_leader} is the leader of cluster {cluster_name} and cannot be assigned to synchronous stadby')
+                raise PatroniCtlException(
+                    f'Member {candidate} does not exist in cluster {cluster_name} or is tagged as nofailover or nosync or nostream or noloadbalance')
+    else:
+        allowed_candidates = [c for c in candidate_names if c != cluster_sync]
+        candidates = click.prompt(f'Choose allowed candidates to become synchronous standby (if multiple use comma) {allowed_candidates}', type=str, default=None).split(',')
+        for candidate in candidates:
+            if candidate not in allowed_candidates:
+                raise PatroniCtlException(f'Candidate {candidate} is not in suggested list candidates list')
+
+    scheduled_at_str = None
+    scheduled_at = None
+
+    if switchover_scheduled is None and not force:
+        next_hour = (datetime.datetime.now() + datetime.timedelta(hours=1)).strftime('%Y-%m-%dT%H:%M')
+        switchover_scheduled = click.prompt('When should the switchover take place (e.g. ' + next_hour + ' ) ',
+                                            type=str, default='now')
+
+    scheduled_at = parse_scheduled(switchover_scheduled)
+    if scheduled_at:
+        if config.is_paused:
+            raise PatroniCtlException("Can't schedule switchover in the paused state")
+        scheduled_at_str = scheduled_at.isoformat()
+
+    payload = {
+        'candidates': candidates,
+        'leader': switchover_leader
+    }
+    if scheduled_at_str:
+        payload['scheduled_at'] = scheduled_at_str
+
+    logging.debug(payload)
+
+    # By now we have established that the leader exists and the candidates exists
+    if not force:
+        demote_msg = f', switching current synchronous replica {cluster_sync}' if cluster_sync else ''
+        if scheduled_at_str:
+            if not click.confirm(f'Are you sure you want to schedule synchronous replica switchover of cluster '
+                                 f'{cluster_name} at {scheduled_at_str}{demote_msg}?'):
+                raise PatroniCtlException('Aborting scheduled')
+        else:
+            if not click.confirm(f'Are you sure you want to switchover synchronous replica for cluster {cluster_name}{demote_msg}?'):
+                raise PatroniCtlException('Aborting')
+
+    request = None
+    action = 'sync_switchover'
+    try:
+        member = cluster.leader.member
+        if TYPE_CHECKING:  # pragma: no cover
+            assert isinstance(member, Member)
+        request = request_patroni(member, 'post', action, payload)
+
+        if request.status in (200, 202):
+            logging.debug(request)
+            cluster = dcs.get_cluster()
+            logging.debug(cluster)
+            click.echo('{0} {1}'.format(timestamp(), request.data.decode('utf-8')))
+        elif request.status == 501:
+            click.echo(f'sync_switchover is not supported by {member.name} patroni version, details {request.status}, {request.data.decode("utf-8")}')
+            return
+        else:
+            click.echo('{0} failed, details: {1}, {2}'.format(action.title(), request.status, request.data.decode('utf-8')))
+            return
+    except Exception:
+        logging.exception(request)
+
+    if not scheduled_at_str:
+        output_members(cluster, cluster_name, group=None)
+
+
+@ctl.command('sync_switchover', help='Synchronous standby switchover')
+@arg_cluster_name
+@click.option('--leader', '--primary', 'leader', help='The name of the current leader', default=None)
+@click.option('--candidate', help='Names of the candidates', default=None, multiple=True)
+@click.option('--scheduled', help='Timestamp of a scheduled switchover in unambiguous format (e.g. ISO 8601)',
+              default=None)
+@option_force
+def sync_switchover(cluster_name: str, leader: Optional[str], candidate: Optional[str], force: bool, scheduled: Optional[str]) -> None:
+    """Process ``sync_switchover`` command of ``patronictl`` utility.
+
+    .. seealso::
+        Refer to :func:`_do_sync_switchover` for details.
+
+    :param cluster_name: name of the Patroni cluster.
+    :param candidate: names of a replicas to be promoted to synchronous stadby. Nodes that are tagged with ``nofailover`` cannot be used.
+    :param force: perform the failover or switchover without asking for confirmations.
+    :param leader: name of the current leader member.
+    :param scheduled: timestamp when the switchover should be scheduled to occur. If ``now`` perform immediately.
+    """
+    _do_sync_switchover(cluster_name, candidate, force, leader, scheduled)
+
+
 @ctl.command('failover', help='Failover to a replica')
 @arg_cluster_name
 @option_citus_group

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -539,6 +539,37 @@ class Failover(NamedTuple):
         return int(bool(self.leader)) + int(bool(self.candidate))
 
 
+class SyncSwitchover(NamedTuple):
+
+    version: _Version
+    leader: Optional[str]
+    candidates: Optional[List[str]]
+    scheduled_at: Optional[datetime.datetime]
+
+    @staticmethod
+    def from_node(version: _Version, value: Union[str, Dict[str, str]]) -> 'SyncSwitchover':
+        if isinstance(value, dict):
+            data: Dict[str, Any] = value
+        elif value:
+            try:
+                data = json.loads(value)
+                assert isinstance(data, dict)
+            except AssertionError or ValueError:
+                return SyncSwitchover(version=version, leader='', candidates=[], scheduled_at=None)
+        else:
+            data = {}
+
+        if data.get('scheduled_at'):
+            data['scheduled_at'] = dateutil.parser.parse(data['scheduled_at'])
+
+        return SyncSwitchover(version=version, leader=data.get('leader'), candidates=data.get('candidates'),
+                              scheduled_at=data.get('scheduled_at'))
+
+    def __len__(self) -> int:
+        return int(bool(self.leader)) + int(bool(self.candidates))
+
+
+
 class ClusterConfig(NamedTuple):
     """Immutable object (namedtuple) which represents cluster configuration.
 
@@ -852,6 +883,7 @@ class Cluster(NamedTuple('Cluster',
                           ('status', Status),
                           ('members', List[Member]),
                           ('failover', Optional[Failover]),
+                          ('sync_switchover', Optional[SyncSwitchover]),
                           ('sync', SyncState),
                           ('history', Optional[TimelineHistory]),
                           ('failsafe', Optional[Dict[str, str]]),
@@ -895,7 +927,7 @@ class Cluster(NamedTuple('Cluster',
     @staticmethod
     def empty() -> 'Cluster':
         """Produce an empty :class:`Cluster` instance."""
-        return Cluster(None, None, None, Status.empty(), [], None, SyncState.empty(), None, None, {})
+        return Cluster(None, None, None, Status.empty(), [], None, None, SyncState.empty(), None, None, {})
 
     def is_empty(self):
         """Validate definition of all attributes of this :class:`Cluster` instance.
@@ -903,7 +935,7 @@ class Cluster(NamedTuple('Cluster',
         :returns: ``True`` if all attributes of the current :class:`Cluster` are unpopulated.
         """
         return all((self.initialize is None, self.config is None, self.leader is None, self.status.is_empty(),
-                    self.members == [], self.failover is None, self.sync.version is None,
+                    self.members == [], self.failover is None, self.sync_switchover is None, self.sync.version is None,
                     self.history is None, self.failsafe is None, self.workers == {}))
 
     def __len__(self) -> int:
@@ -919,7 +951,7 @@ class Cluster(NamedTuple('Cluster',
            >>> assert bool(cluster) is False
 
            >>> status = Status(0, None, [])
-           >>> cluster = Cluster(None, None, None, status, [1, 2, 3], None, SyncState.empty(), None, None, {})
+           >>> cluster = Cluster(None, None, None, status, [1, 2, 3], None, None, SyncState.empty(), None, None, {})
            >>> len(cluster)
            1
 
@@ -1523,6 +1555,7 @@ class AbstractDCS(abc.ABC):
     _LEADER_OPTIME = _OPTIME + '/' + _LEADER  # legacy
     _SYNC = 'sync'
     _FAILSAFE = 'failsafe'
+    _SYNC_SWITCHOVER = 'sync_switchover'
 
     def __init__(self, config: Dict[str, Any], mpp: 'AbstractMPP') -> None:
         """Prepare DCS paths, MPP object, initial values for state information and processing dependencies.
@@ -1594,6 +1627,11 @@ class AbstractDCS(abc.ABC):
     def failover_path(self) -> str:
         """Get the client path for ``failover``."""
         return self.client_path(self._FAILOVER)
+
+    @property
+    def sync_switchover_path(self) -> str:
+        """Get the client path for ``sync_switchover_path``."""
+        return self.client_path(self._SYNC_SWITCHOVER)
 
     @property
     def history_path(self) -> str:
@@ -1997,6 +2035,16 @@ class AbstractDCS(abc.ABC):
         :returns: ``True`` if successfully committed to DCS.
         """
 
+    @abc.abstractmethod
+    def set_sync_switchover_value(self, value: str, version: Optional[Any] = None) -> bool:
+        """Create or update ``/sync_switchover`` key.
+
+        :param value: value to set.
+        :param version: for conditional update of the key/object.
+
+        :returns: ``True`` if successfully committed to DCS.
+        """
+
     def manual_failover(self, leader: Optional[str], candidate: Optional[str],
                         scheduled_at: Optional[datetime.datetime] = None, version: Optional[Any] = None) -> bool:
         """Prepare dictionary with given values and set ``/failover`` key in DCS.
@@ -2018,6 +2066,29 @@ class AbstractDCS(abc.ABC):
         if scheduled_at:
             failover_value['scheduled_at'] = scheduled_at.isoformat()
         return self.set_failover_value(json.dumps(failover_value, separators=(',', ':')), version)
+
+    def manual_switch_sync(self, leader: Optional[str], candidate: Optional[str],
+                           scheduled_at: Optional[datetime.datetime] = None, version: Optional[Any] = None) -> bool:
+        """Prepare dictionary with given values and set ``/sync_switchover`` key in DCS.
+
+        :param leader: value to set for ``leader``.
+        :param candidate: value to set for ``member``.
+        :param scheduled_at: value converted to ISO date format for ``scheduled_at``.
+        :param version: for conditional update of the key/object.
+
+        :returns: ``True`` if successfully committed to DCS.
+        """
+        sync_switchover_value = {}
+        if leader:
+            sync_switchover_value['leader'] = leader
+
+        if candidate:
+            sync_switchover_value['candidates'] = candidate
+
+        if scheduled_at:
+            sync_switchover_value['scheduled_at'] = scheduled_at.isoformat()
+
+        return self.set_sync_switchover_value(json.dumps(sync_switchover_value, separators=(',', ':')), version)
 
     @abc.abstractmethod
     def set_config_value(self, value: str, version: Optional[Any] = None) -> bool:

--- a/patroni/dcs/etcd.py
+++ b/patroni/dcs/etcd.py
@@ -27,7 +27,7 @@ from ..postgresql.mpp import AbstractMPP
 from ..request import get as requests_get
 from ..utils import Retry, RetryFailedError, split_host_port, uri, USER_AGENT
 from . import AbstractDCS, catch_return_false_exception, Cluster, ClusterConfig, \
-    Failover, Leader, Member, ReturnFalseException, Status, SyncState, TimelineHistory
+    Failover, Leader, Member, ReturnFalseException, Status, SyncState, TimelineHistory, SyncSwitchover
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..config import Config
@@ -754,6 +754,11 @@ class Etcd(AbstractEtcd):
         if failover:
             failover = Failover.from_node(failover.modifiedIndex, failover.value)
 
+        # sync switchover key
+        sync_switch = nodes.get(self._SYNC_SWITCHOVER)
+        if sync_switch:
+            sync_switch = SyncSwitchover.from_node(sync_switch.modifiedIndex, sync_switch.value)
+
         # get synchronization state
         sync = nodes.get(self._SYNC)
         sync = SyncState.from_node(sync and sync.modifiedIndex, sync and sync.value)
@@ -765,7 +770,7 @@ class Etcd(AbstractEtcd):
         except Exception:
             failsafe = None
 
-        return Cluster(initialize, config, leader, status, members, failover, sync, history, failsafe)
+        return Cluster(initialize, config, leader, status, members, failover, sync_switch, sync, history, failsafe)
 
     def _postgresql_cluster_loader(self, path: str) -> Cluster:
         """Load and build the :class:`Cluster` object from DCS, which represents a single PostgreSQL cluster.
@@ -832,6 +837,10 @@ class Etcd(AbstractEtcd):
     @catch_return_false_exception
     def attempt_to_acquire_leader(self) -> bool:
         return self._run_and_handle_exceptions(self._do_attempt_to_acquire_leader, retry=None)
+
+    @catch_etcd_errors
+    def set_sync_switchover_value(self, value: str, version: Optional[int] = None) -> bool:
+        return bool(self._client.write(self.sync_switchover_path, value, prevIndex=version or 0))
 
     @catch_etcd_errors
     def set_failover_value(self, value: str, version: Optional[int] = None) -> bool:

--- a/patroni/dcs/etcd3.py
+++ b/patroni/dcs/etcd3.py
@@ -925,6 +925,10 @@ class Etcd3(AbstractEtcd):
         return ret
 
     @catch_etcd_errors
+    def set_sync_switchover_value(self, value: str, version: Optional[str] = None) -> bool:
+        return bool(self._client.put(self.sync_switchover_path, value, mod_revision=version))
+
+    @catch_etcd_errors
     def set_failover_value(self, value: str, version: Optional[str] = None) -> bool:
         return bool(self._client.put(self.failover_path, value, mod_revision=version))
 

--- a/patroni/dcs/kubernetes.py
+++ b/patroni/dcs/kubernetes.py
@@ -1340,6 +1340,10 @@ class Kubernetes(AbstractDCS):
         """Unused"""
         raise NotImplementedError  # pragma: no cover
 
+    def set_sync_switchover_value(self, value: str, version: Optional[str] = None) -> bool:
+        """Unused"""
+        raise NotImplementedError # pragma: no cover
+
     def manual_failover(self, leader: Optional[str], candidate: Optional[str],
                         scheduled_at: Optional[datetime.datetime] = None, version: Optional[str] = None) -> bool:
         annotations = {'leader': leader or None, 'member': candidate or None,

--- a/patroni/dcs/raft.py
+++ b/patroni/dcs/raft.py
@@ -430,6 +430,9 @@ class Raft(AbstractDCS):
         return self._sync_obj.set(self.leader_path, self._name, ttl=self._ttl,
                                   handle_raft_error=False, prevExist=False) is not False
 
+    def set_sync_switchover_value(self, value: str, version: Optional[int] = None) -> bool:
+        return self._sync_obj.set(self.sync_switchover_path, value, prevIndex=version) is not False
+
     def set_failover_value(self, value: str, version: Optional[int] = None) -> bool:
         return self._sync_obj.set(self.failover_path, value, prevIndex=version) is not False
 

--- a/patroni/dcs/zookeeper.py
+++ b/patroni/dcs/zookeeper.py
@@ -340,6 +340,9 @@ class ZooKeeper(AbstractDCS):
             logger.exception('Failed to update %s', key)
         return False
 
+    def set_sync_switchover_value(self, value: str, version: Optional[int] = None) -> bool:
+        return self._set_or_create(self.sync_switchover_path, value, version) is not False
+
     def set_failover_value(self, value: str, version: Optional[int] = None) -> bool:
         return self._set_or_create(self.failover_path, value, version) is not False
 

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1731,6 +1731,45 @@ class Ha(object):
                 cleanup_fn()
         return False
 
+    def process_manual_sync_switchover(self) -> Optional[str]:
+        """Checks if manual sync switchover is requested and takes action if appropriate
+
+        Cleans up sync switchover key if conditions are not matched
+
+        """
+        if not self.has_lock():
+            return
+
+        sync_switchover = self.cluster.sync_switchover
+        if not sync_switchover or self.is_paused() or not self.state_handler.is_primary():
+            return
+
+        msg = self.do_process_manual_sync_switchover()
+        logger.info('Cleaning up sync switchover key')
+        self.dcs.manual_switch_sync('', '', version=sync_switchover.version)
+
+        # reload cluster from dsc to fetch changed sync replica state
+        self.load_cluster_from_dcs()
+        return msg
+
+    def do_process_manual_sync_switchover(self) -> Optional[str]:
+        sync_switchover = self.cluster.sync_switchover
+        if not sync_switchover.leader or sync_switchover.leader != self.state_handler.name:
+            logger.warning('sync switchover: leader name does not match: %s != %s', sync_switchover.leader,
+                           self.state_handler.name)
+            return
+        sync_confirmed = self.state_handler.sync_handler.current_state(self.cluster).sync_confirmed
+        if sync_confirmed == CaseInsensitiveSet(sync_switchover.candidates):
+            logger.info('sync switchover: candidates are already synchronous replicas')
+            return
+        logger.info("Assigning synchronous standby status to %s", str(sync_switchover.candidates))
+        self.state_handler.sync_handler.set_synchronous_standby_names(sync_switchover.candidates)
+
+        if self.dcs.write_sync_state(self.state_handler.name, sync_switchover.candidates, self.cluster.sync.version):
+            logger.info("Synchronous standby status assigned to %s", sync_switchover.candidates)
+        else:
+            return logger.info("Synchronous replication key updated by someone else")
+
     def process_manual_failover_from_leader(self) -> Optional[str]:
         """Checks if manual failover is requested and takes action if appropriate.
 
@@ -1828,6 +1867,9 @@ class Ha(object):
             # update lock to avoid split-brain
             if self.update_lock(True):
                 msg = self.process_manual_failover_from_leader()
+                if msg is not None:
+                    return msg
+                msg = self.process_manual_sync_switchover()
                 if msg is not None:
                     return msg
 


### PR DESCRIPTION
## Hi, I would like to propose a new synchronous replica switchover feature. 

As master switchover it might be helpfull to control cluster topology. Feature is desined as much simillar to master switchover as possible.

### Why is it needed:
- to easily handle replicas affinity issues 
- to avoid hacks with manually set `synchronous_standby_names`

### Key changes:
- **API**: new `/sync_switchover` handler. 
- **ETCD**: API request stores new config key `sync_switchover` 
- **daemon**: handels `sync_switchover` key and performs synchronous replica switchover reusing existed methods
- **patronictl**: provides cli interface for the command

Guess tests and documentation are also needed, but want to discuss the feature first. Feature was tested manually and now succesfully works in environment with lots of clusters.