### PR TITLE
Skip single-user crash recovery when backup_label exists

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -3,6 +3,7 @@ import datetime
 import functools
 import json
 import logging
+import os
 import sys
 import time
 import uuid
@@ -590,6 +591,10 @@ class Ha(object):
         return result
 
     def _handle_crash_recovery(self) -> Optional[str]:
+        if os.path.isfile(os.path.join(self.state_handler.data_dir, 'backup_label')):
+            logger.info('Skipping single-user crash recovery because backup_label exists;'
+                        ' PostgreSQL will handle it during normal startup')
+            return None
         if self._crash_recovery_started == 0 and (self.cluster.is_unlocked() or self._rewind.can_rewind):
             self._crash_recovery_started = time.time()
             msg = 'doing crash recovery in a single user mode'

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -3,7 +3,6 @@ import datetime
 import functools
 import json
 import logging
-import os
 import sys
 import time
 import uuid
@@ -591,10 +590,6 @@ class Ha(object):
         return result
 
     def _handle_crash_recovery(self) -> Optional[str]:
-        if os.path.isfile(os.path.join(self.state_handler.data_dir, 'backup_label')):
-            logger.info('Skipping single-user crash recovery because backup_label exists;'
-                        ' PostgreSQL will handle it during normal startup')
-            return None
         if self._crash_recovery_started == 0 and (self.cluster.is_unlocked() or self._rewind.can_rewind):
             self._crash_recovery_started = time.time()
             msg = 'doing crash recovery in a single user mode'
@@ -678,9 +673,13 @@ class Ha(object):
         self.watchdog.disable()
 
         if data.get('Database cluster state') in ('in production', 'shutting down', 'in crash recovery'):
-            msg = self._handle_crash_recovery()
-            if msg:
-                return msg
+            if self.state_handler.backup_label_exists():
+                logger.info('Skipping single-user crash recovery because backup_label exists;'
+                            ' PostgreSQL will handle it during normal startup')
+            else:
+                msg = self._handle_crash_recovery()
+                if msg:
+                    return msg
 
         self.load_cluster_from_dcs()
 

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -673,7 +673,7 @@ class Ha(object):
         self.watchdog.disable()
 
         if data.get('Database cluster state') in ('in production', 'shutting down', 'in crash recovery'):
-            if self.state_handler.backup_label_exists():
+            if self.state_handler.was_restored_from_backup():
                 logger.info('Skipping single-user crash recovery because backup_label exists;'
                             ' PostgreSQL will handle it during normal startup')
             else:

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -427,6 +427,15 @@ class Postgresql(object):
             raise PostgresConnectionException(str(exc)) from exc
 
     def was_restored_from_backup(self) -> bool:
+        """Check whether the data directory was restored from a base backup.
+
+        The presence of a ``backup_label`` file in the data directory indicates that PostgreSQL has not yet
+        completed recovery from a base backup. It is checked only for PostgreSQL 15+, because earlier versions
+        supported exclusive backups which could leave a stale ``backup_label`` behind after a primary crash.
+
+        :returns: ``True`` if running on PostgreSQL 15 or newer and the ``backup_label`` file exists in the
+            data directory, ``False`` otherwise.
+        """
         return self._major_version >= 150000 and os.path.isfile(os.path.join(self._data_dir, 'backup_label'))
 
     def pg_control_exists(self) -> bool:

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -426,6 +426,9 @@ class Postgresql(object):
         except RetryFailedError as exc:
             raise PostgresConnectionException(str(exc)) from exc
 
+    def backup_label_exists(self) -> bool:
+        return self._major_version >= 150000 and os.path.isfile(os.path.join(self._data_dir, 'backup_label'))
+
     def pg_control_exists(self) -> bool:
         return os.path.isfile(self._pg_control)
 

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -426,7 +426,7 @@ class Postgresql(object):
         except RetryFailedError as exc:
             raise PostgresConnectionException(str(exc)) from exc
 
-    def backup_label_exists(self) -> bool:
+    def was_restored_from_backup(self) -> bool:
         return self._major_version >= 150000 and os.path.isfile(os.path.join(self._data_dir, 'backup_label'))
 
     def pg_control_exists(self) -> bool:

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -335,6 +335,16 @@ class TestHa(PostgresInit):
             self.ha.cluster.config.data.update({'maximum_lag_on_failover': 10})
             self.assertEqual(self.ha.run_cycle(), 'terminated crash recovery because of startup timeout')
 
+    @patch.object(Rewind, 'ensure_clean_shutdown')
+    def test_crash_recovery_skip_when_backup_label_exists(self, mock_ensure_clean_shutdown):
+        self.ha.has_lock = true
+        self.p.is_running = false
+        self.p.controldata = lambda: {'Database cluster state': 'in production', 'Database system identifier': SYSID}
+        with patch('patroni.ha.os.path.isfile', side_effect=lambda path: path.endswith('backup_label')):
+            msg = self.ha.run_cycle()
+            self.assertNotEqual(msg, 'doing crash recovery in a single user mode')
+            mock_ensure_clean_shutdown.assert_not_called()
+
     @patch.object(Rewind, 'ensure_clean_shutdown', Mock())
     @patch.object(Rewind, 'rewind_or_reinitialize_needed_and_possible', Mock(return_value=True))
     @patch.object(Rewind, 'can_rewind', PropertyMock(return_value=True))

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -336,14 +336,14 @@ class TestHa(PostgresInit):
             self.assertEqual(self.ha.run_cycle(), 'terminated crash recovery because of startup timeout')
 
     @patch.object(Rewind, 'ensure_clean_shutdown')
+    @patch.object(Postgresql, 'backup_label_exists', Mock(return_value=True))
     def test_crash_recovery_skip_when_backup_label_exists(self, mock_ensure_clean_shutdown):
         self.ha.has_lock = true
         self.p.is_running = false
         self.p.controldata = lambda: {'Database cluster state': 'in production', 'Database system identifier': SYSID}
-        with patch('patroni.ha.os.path.isfile', side_effect=lambda path: path.endswith('backup_label')):
-            msg = self.ha.run_cycle()
-            self.assertNotEqual(msg, 'doing crash recovery in a single user mode')
-            mock_ensure_clean_shutdown.assert_not_called()
+        msg = self.ha.run_cycle()
+        self.assertNotEqual(msg, 'doing crash recovery in a single user mode')
+        mock_ensure_clean_shutdown.assert_not_called()
 
     @patch.object(Rewind, 'ensure_clean_shutdown', Mock())
     @patch.object(Rewind, 'rewind_or_reinitialize_needed_and_possible', Mock(return_value=True))

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -335,15 +335,16 @@ class TestHa(PostgresInit):
             self.ha.cluster.config.data.update({'maximum_lag_on_failover': 10})
             self.assertEqual(self.ha.run_cycle(), 'terminated crash recovery because of startup timeout')
 
-    @patch.object(Rewind, 'ensure_clean_shutdown')
-    @patch.object(Postgresql, 'backup_label_exists', Mock(return_value=True))
-    def test_crash_recovery_skip_when_backup_label_exists(self, mock_ensure_clean_shutdown):
-        self.ha.has_lock = true
+    @patch('patroni.ha.logger.info')
+    def test_crash_recovery_skip_when_backup_label_exists(self, mock_logger_info):
         self.p.is_running = false
+        self.p.follow = true
+        self.p._major_version = 150000
         self.p.controldata = lambda: {'Database cluster state': 'in production', 'Database system identifier': SYSID}
-        msg = self.ha.run_cycle()
-        self.assertNotEqual(msg, 'doing crash recovery in a single user mode')
-        mock_ensure_clean_shutdown.assert_not_called()
+        with patch('os.path.isfile', return_value=True):
+            self.assertEqual(self.ha.run_cycle(), 'starting as a secondary')
+        mock_logger_info.assert_any_call('Skipping single-user crash recovery because backup_label exists;'
+                                         ' PostgreSQL will handle it during normal startup')
 
     @patch.object(Rewind, 'ensure_clean_shutdown', Mock())
     @patch.object(Rewind, 'rewind_or_reinitialize_needed_and_possible', Mock(return_value=True))


### PR DESCRIPTION
## Summary

- Fix for #3576: `ensure_clean_shutdown()` corrupts WAL chain when starting a replica restored from an external backup
- Check for `backup_label` file at the start of `_handle_crash_recovery()` — if present, skip single-user crash recovery and let PostgreSQL handle it during normal startup