### PR TITLE
Resolve inconsistency in docs for patronictl restart

### DIFF
--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -1452,7 +1452,7 @@ Parameters
 ``--pending``
     Select only members which are flagged as ``Pending restart``.
 
-``timeout``
+``--timeout``
     Abort the restart if it takes more than the specified timeout, and fail over to a replica if the issue is on the primary.
 
     ``TIMEOUT`` is the amount of seconds to wait before aborting the restart.


### PR DESCRIPTION
Change 'timeout' to '--timeout' to match the other options.