### PR TITLE
Use binary version when PG_VERSION file does not exist

### DIFF
--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -449,11 +449,15 @@ class ConfigHandler(object):
 
     @property
     def pg_version(self) -> int:
-        """Current full postgres version if instance is running, major version otherwise.
+        """Return current postgres version.
 
-        We can only use ``postgres --version`` output if major version there equals to the one
-        in data directory. If it is not the case, we should use major version from the ``PG_VERSION``
-        file.
+        If instance is running, try to get version from the server. If it is not possible, get minor version
+        from the binary.
+        However, we can only use ``postgres --version`` output if major version there equals to the one in data
+        directory. If it is not the case, use major version from the ``PG_VERSION`` file.
+        If ``PG_VERSION`` file is missing, inaccessible, or contains invalid value, use minor version from the binary.
+
+        :returns: integer representation of the current postgres version.
         """
         if self._postgresql.state == PostgresqlState.RUNNING:
             try:
@@ -463,7 +467,7 @@ class ConfigHandler(object):
         bin_minor = postgres_version_to_int(get_postgres_version(bin_name=self._postgresql.pgcommand('postgres')))
         bin_major = get_major_from_minor_version(bin_minor)
         datadir_major = self._postgresql.major_version
-        return datadir_major if bin_major != datadir_major else bin_minor
+        return datadir_major if datadir_major and bin_major != datadir_major else bin_minor
 
     @property
     def _configuration_to_save(self) -> List[str]:

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -549,10 +549,14 @@ class TestPostgresql(BaseTestPostgresql):
 
     def test_pg_version(self):
         self.assertEqual(self.p.config.pg_version, 99999)  # server_version
+
         with patch.object(Postgresql, 'server_version', PropertyMock(side_effect=AttributeError)):
             self.assertEqual(self.p.config.pg_version, 140000)  # PG_VERSION==14, postgres --version == 12.1
             with patch('subprocess.check_output', Mock(return_value=b"postgres (PostgreSQL) 14.1")):
                 self.assertEqual(self.p.config.pg_version, 140001)
+
+            with patch.object(Postgresql, 'major_version', PropertyMock(return_value=0)):  # no PG_VERSION
+                self.assertEqual(self.p.config.pg_version, 120001)
 
     @patch('os.path.isfile', Mock(return_value=True))
     @patch('shutil.copy', Mock(side_effect=IOError))


### PR DESCRIPTION
When data directory does not exist, `datadir_major == 0` and `bin_major != datadir_major`. Patroni used to erroneously return version 0 in such cases, hence version specific features could not work correctly.

ref: https://www.postgresql.org/message-id/CAFh8B=nP+xpSAgA6vMvoLAiowo3zQHtecZn-3VzXNruvx7cUMw@mail.gmail.com