### PR TITLE
Work around mislabeled etcd error

### DIFF
--- a/patroni/dcs/etcd3.py
+++ b/patroni/dcs/etcd3.py
@@ -176,6 +176,11 @@ def _raise_for_data(data: Union[bytes, str, Dict[str, Any]], status_code: Option
     except Exception:
         error = str(data)
         code = GRPCCode.Unknown
+
+    # Workaround for etcd-io/etcd#21671
+    if code == GRPCCode.Unknown and error == 'not a primary lessor':
+        code = GRPCCode.Unavailable
+
     err = errStringToClientError.get(error) or errCodeToClientError.get(code) or Etcd3ClientError
     return err(code, error, status_code)
 

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -233,6 +233,8 @@ class TestPatroniEtcd3Client(BaseTestEtcd3):
         self.assertRaises(Unknown, self.client._handle_server_response, response)
         response.content = '{"error":{"code":14,"message":"","http_code":400}}'
         self.assertRaises(socket.timeout, self.client._handle_server_response, response)
+        response.content = '{"error":{"code":2,"message":"not a primary lessor","http_code":400}}'
+        self.assertRaises(socket.timeout, self.client._handle_server_response, response)
         response.content = '{"error":{"grpc_code":0,"message":"","http_code":400}}'
         try:
             self.client._handle_server_response(response)


### PR DESCRIPTION
Current etcd raises Unknown error when etcd leader is lost while updating the lease. Fixed upstream in etcd-io/etcd#21671, but for older versions we want to override the reported error code. Fixes #3407