### PR TITLE
Write pg_ident.conf during initdb post-bootstrap

### DIFF
--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -423,6 +423,7 @@ END;$$""".format(f, quote_ident(rewind['username'], postgresql.connection()))
                             time.sleep(1)  # give a time to postgres to "reload" configuration files
                             postgresql.connection().close()  # close connection to reconnect with a new password
                 else:  # initdb
+                    postgresql.config.replace_pg_ident()
                     # We may want create database and extension for some MPP clusters
                     self._postgresql.mpp_handler.bootstrap()
         except Exception:

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -259,6 +259,22 @@ class TestBootstrap(BaseTestPostgresql):
             self.b.post_bootstrap({}, task)
             mock_restart.assert_called_once()
 
+    @patch('time.sleep', Mock())
+    @patch('patroni.psycopg.__quote_ident', Mock(), create=True)
+    @patch.object(Bootstrap, 'call_post_bootstrap', Mock(return_value=True))
+    @patch.object(Postgresql, 'start', Mock(return_value=True))
+    @patch.object(Postgresql, 'get_major_version', Mock(return_value=110000))
+    def test_post_bootstrap_initdb_writes_pg_ident(self):
+        # Regression test: the initdb branch of post_bootstrap must flush
+        # configured pg_ident entries to pg_ident.conf, mirroring the
+        # custom bootstrap branch.
+        self.assertFalse(self.b.running_custom_bootstrap)
+        task = CriticalTask()
+        with patch.object(ConfigHandler, 'replace_pg_ident') as mock_replace_pg_ident, \
+                patch.object(self.p.mpp_handler, 'bootstrap', Mock()):
+            self.b.post_bootstrap({}, task)
+            mock_replace_pg_ident.assert_called_once()
+
     @patch.object(CancellableSubprocess, 'call')
     def test_call_post_bootstrap(self, mock_cancellable_subprocess_call):
         mock_cancellable_subprocess_call.return_value = 1


### PR DESCRIPTION
### Problem

`Bootstrap.post_bootstrap` has two branches: custom bootstrap and initdb. The custom bootstrap branch calls `postgresql.config.replace_pg_ident()` to flush configured `pg_ident` entries to `pg_ident.conf`. The initdb branch does not.

As a result, on a freshly initdb-bootstrapped cluster, any `pg_ident` entries defined in the Patroni config are silently dropped. `pg_ident.conf` is never written until something else triggers a reload that calls `replace_pg_ident()`.

### Fix

Add the missing `replace_pg_ident()` call in the initdb branch, mirroring the custom bootstrap branch.

### Test

Added `test_post_bootstrap_initdb_writes_pg_ident` in `tests/test_bootstrap.py`, which asserts `replace_pg_ident()` is called on the initdb path. Verified it catches the regression by reverting the one-line fix locally: test fails without the fix, passes with it.