### PR TITLE
Refactor logger initialization

### DIFF
--- a/patroni/__main__.py
+++ b/patroni/__main__.py
@@ -13,12 +13,14 @@ from argparse import Namespace
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 from patroni import global_config, MIN_PSYCOPG2, MIN_PSYCOPG3, parse_version
+from patroni.collections import EMPTY_DICT
 from patroni.daemon import abstract_main, AbstractPatroniDaemon, get_base_arg_parser
 from patroni.tags import Tags
 
 if TYPE_CHECKING:  # pragma: no cover
     from .config import Config
     from .dcs import Cluster
+    from .log import PatroniLogger
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +41,7 @@ class Patroni(AbstractPatroniDaemon, Tags):
         * ``postmaster_start_time``: timestamp when Postgres was last started.
     """
 
-    def __init__(self, config: 'Config') -> None:
+    def __init__(self, config: 'Config', patroni_logger: 'PatroniLogger') -> None:
         """Create a :class:`Patroni` instance with the given *config*.
 
         Get a connection to the DCS, configure watchdog (if required), set up Patroni interface with Postgres, configure
@@ -49,6 +51,7 @@ class Patroni(AbstractPatroniDaemon, Tags):
             Expected to be instantiated and run through :func:`~patroni.daemon.abstract_main`.
 
         :param config: Patroni configuration.
+        :param patroni_logger: the logging handler for this daemon.
         """
         from patroni import thread_pool
         from patroni.api import RestApiServer
@@ -67,7 +70,7 @@ class Patroni(AbstractPatroniDaemon, Tags):
         logger.info('Patroni global thread_pool_size = %d', thread_pool_size)
         thread_pool.configure_global_pool(thread_pool_size)
 
-        super(Patroni, self).__init__(config)
+        super(Patroni, self).__init__(config, patroni_logger)
 
         self.version = __version__
         self.dcs = get_dcs(self.config)
@@ -141,15 +144,15 @@ class Patroni(AbstractPatroniDaemon, Tags):
         member = cluster.get_member(self.config['name'], False)
         if not isinstance(member, Member):
             return
+        # Silence annoying WARNING: Retrying (...) messages when Patroni is quickly restarted.
+        configured_loggers: Dict[str, Any] = (self.config.get('log') or EMPTY_DICT).get('loggers') or {}
         try:
-            # Silence annoying WARNING: Retrying (...) messages when Patroni is quickly restarted.
-            # At this moment we don't have custom log levels configured and hence shouldn't lose anything useful.
-            self.logger.update_loggers({'urllib3.connectionpool': 'ERROR'})
+            self.logger.update_loggers({**configured_loggers, 'urllib3.connectionpool': 'ERROR'})
             _ = self.request(member, endpoint="/liveness", timeout=3)
             logger.fatal("Can't start; there is already a node named '%s' running", self.config['name'])
             sys.exit(1)
         except Exception:
-            self.logger.update_loggers({})
+            self.logger.update_loggers(configured_loggers)
 
     def _get_tags(self) -> Dict[str, Any]:
         """Get tags configured for this node, if any.

--- a/patroni/daemon.py
+++ b/patroni/daemon.py
@@ -15,6 +15,7 @@ from typing import Any, Optional, Type, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
     from .config import Config
+    from .log import PatroniLogger
 
 logger = logging.getLogger(__name__)
 
@@ -60,18 +61,16 @@ class AbstractPatroniDaemon(abc.ABC):
     :ivar config: configuration options for this daemon.
     """
 
-    def __init__(self, config: 'Config') -> None:
+    def __init__(self, config: 'Config', patroni_logger: 'PatroniLogger') -> None:
         """Set up signal handlers, logging handler and configuration.
 
         :param config: configuration options for this daemon.
+        :param patroni_logger: the logging handler for this daemon.
         """
-        from patroni.log import PatroniLogger
-
         self.setup_signal_handlers()
 
-        self.logger = PatroniLogger()
+        self.logger = patroni_logger
         self.config = config
-        AbstractPatroniDaemon.reload_config(self, local=True)
 
     def sighup_handler(self, *_: Any) -> None:
         """Handle SIGHUP signals.
@@ -181,11 +180,15 @@ def abstract_main(cls: Type[AbstractPatroniDaemon], configfile: str) -> None:
     :param configfile:
     """
     from .config import Config, ConfigParseError
+    from .log import PatroniLogger
     from .utils import parse_int
+
+    patroni_logger = PatroniLogger()
     try:
         config = Config(configfile)
     except ConfigParseError as e:
         sys.exit(e.value)
+    patroni_logger.reload_config(config.get('log', {}))
 
     thread_stack_size = None
     if 'thread_stack_size' in config:
@@ -195,7 +198,7 @@ def abstract_main(cls: Type[AbstractPatroniDaemon], configfile: str) -> None:
 
     if thread_stack_size is None:
         thread_stack_size = 524288
-        logger.info('Using default value thread_stack_size=%s', thread_stack_size)
+        logger.info('Using default value thread_stack_size = %s', thread_stack_size)
 
     thread_stack_size = max(65536, thread_stack_size)
     try:
@@ -203,7 +206,7 @@ def abstract_main(cls: Type[AbstractPatroniDaemon], configfile: str) -> None:
     except Exception as e:
         logger.warning('Failed to set threading.stack_size(%s): %r', thread_stack_size, e)
 
-    controller = cls(config)
+    controller = cls(config, patroni_logger)
     try:
         controller.run()
     except KeyboardInterrupt:

--- a/patroni/raft_controller.py
+++ b/patroni/raft_controller.py
@@ -3,14 +3,15 @@ import logging
 from .config import Config
 from .daemon import abstract_main, AbstractPatroniDaemon, get_base_arg_parser
 from .dcs.raft import KVStoreTTL
+from .log import PatroniLogger
 
 logger = logging.getLogger(__name__)
 
 
 class RaftController(AbstractPatroniDaemon):
 
-    def __init__(self, config: Config) -> None:
-        super(RaftController, self).__init__(config)
+    def __init__(self, config: Config, patroni_logger: PatroniLogger) -> None:
+        super(RaftController, self).__init__(config, patroni_logger)
 
         kvstore_config = self.config.get('raft')
         assert 'self_addr' in kvstore_config

--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -18,6 +18,7 @@ from patroni.async_executor import AsyncExecutor
 from patroni.dcs import Cluster, ClusterConfig, Member
 from patroni.dcs.etcd import AbstractEtcdClientWithFailover
 from patroni.exceptions import DCSError
+from patroni.log import PatroniLogger
 from patroni.postgresql import Postgresql
 from patroni.postgresql.config import ConfigHandler
 from patroni.postgresql.misc import PostgresqlRole, PostgresqlState
@@ -96,7 +97,7 @@ class TestPatroni(unittest.TestCase):
         RestApiServer.socket = 0
         os.environ['PATRONI_POSTGRESQL_DATA_DIR'] = 'data/test0'
         conf = config.Config('postgres0.yml')
-        self.p = Patroni(conf)
+        self.p = Patroni(conf, PatroniLogger())
 
     def tearDown(self):
         logging.getLogger().handlers[:] = self._handlers

--- a/tests/test_raft_controller.py
+++ b/tests/test_raft_controller.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 from pysyncobj import SyncObj
 
 from patroni.config import Config
+from patroni.log import PatroniLogger
 from patroni.raft_controller import main as _main, RaftController
 
 from . import SleepException
@@ -26,7 +27,7 @@ class TestPatroniRaftController(unittest.TestCase):
         self.remove_files()
         os.environ['PATRONI_RAFT_SELF_ADDR'] = self.SELF_ADDR
         config = Config('postgres0.yml', validator=None)
-        self.rc = RaftController(config)
+        self.rc = RaftController(config, PatroniLogger())
 
     def tearDown(self):
         logging.getLogger().handlers[:] = self._handlers


### PR DESCRIPTION
Create `PatroniLogger` before loading `Config` to capture early log messages.

Previously it was created inside `AbstractPatroniDaemon.__init__()`. This caused some INFO messages to be lost.