### PR TITLE
Include MONOTONIC_USEC in RELOADING=1 systemd notification

### DIFF
--- a/patroni/daemon.py
+++ b/patroni/daemon.py
@@ -13,6 +13,31 @@ import sys
 from threading import Lock, stack_size
 from typing import Any, Optional, Type, TYPE_CHECKING
 
+try:  # pragma: no cover
+    from time import monotonic_ns
+
+    def monotonic_us() -> int:
+        """Return the current monotonic clock value in microseconds.
+
+        .. note::
+            Uses :func:`time.monotonic_ns` available since Python 3.7.
+
+        :returns: monotonic time in microseconds.
+        """
+        return monotonic_ns() // 1000
+except ImportError:  # pragma: no cover
+    from time import monotonic
+
+    def monotonic_us() -> int:
+        """Return the current monotonic clock value in microseconds.
+
+        .. note::
+            Fallback for Python 3.6 where :func:`time.monotonic_ns` is not available.
+
+        :returns: monotonic time in microseconds.
+        """
+        return int(monotonic() * 1000000)
+
 if TYPE_CHECKING:  # pragma: no cover
     from .config import Config
     from .log import PatroniLogger
@@ -78,7 +103,7 @@ class AbstractPatroniDaemon(abc.ABC):
         Flag the daemon as "SIGHUP received".
         """
         self._received_sighup = True
-        notify_systemd("RELOADING=1")
+        notify_systemd("RELOADING=1\nMONOTONIC_USEC={0}".format(monotonic_us()))
 
     def api_sigterm(self) -> bool:
         """Guarantee only a single SIGTERM is being processed.

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -184,6 +184,7 @@ def run_async(self, func, args=()):
 @patch.object(Postgresql, '_cluster_info_state_get', Mock(return_value=10))
 @patch.object(Postgresql, 'slots', Mock(return_value={'l': 100}))
 @patch.object(Postgresql, 'data_directory_empty', Mock(return_value=False))
+@patch.object(Postgresql, '_wait_for_connection_close', Mock())
 @patch.object(Postgresql, 'controldata', Mock(return_value={
     'Database system identifier': SYSID,
     'Database cluster state': 'shut down',
@@ -479,7 +480,6 @@ class TestHa(PostgresInit):
         self.ha.has_lock = true
         self.assertEqual(self.ha.run_cycle(), 'no action. I am (postgresql0), the leader with the lock')
 
-    @patch.object(Postgresql, '_wait_for_connection_close', Mock())
     @patch.object(Cluster, 'is_unlocked', Mock(return_value=False))
     def test_demote_because_not_having_lock(self):
         with patch.object(Watchdog, 'is_running', PropertyMock(return_value=True)):
@@ -669,7 +669,6 @@ class TestHa(PostgresInit):
     @patch('patroni.postgresql.mpp.citus.connect', psycopg_connect)
     @patch('patroni.postgresql.mpp.citus.quote_ident', Mock())
     @patch.object(Postgresql, 'connection', Mock(return_value=None))
-    @patch.object(Postgresql, '_wait_for_connection_close', Mock())
     def test_bootstrap_release_initialize_key_on_watchdog_failure(self):
         self.ha.cluster = get_cluster_not_initialized_without_leader()
         self.e.initialize = true
@@ -683,7 +682,6 @@ class TestHa(PostgresInit):
                                                                    ' watchdog activation failed'))
 
     @patch('patroni.psycopg.connect', psycopg_connect)
-    @patch.object(Postgresql, '_wait_for_connection_close', Mock())
     def test_reinitialize(self):
         self.assertIsNotNone(self.ha.reinitialize())
 
@@ -1823,7 +1821,6 @@ class TestHa(PostgresInit):
     @patch('builtins.open', mock_open())
     @patch.object(ConfigHandler, 'check_recovery_conf', Mock(return_value=(False, False)))
     @patch.object(Postgresql, 'major_version', PropertyMock(return_value=130000))
-    @patch.object(Postgresql, '_wait_for_connection_close', Mock())
     @patch.object(SlotsHandler, 'sync_replication_slots', Mock(return_value=['ls']))
     def test_follow_copy(self):
         self.ha.cluster.config.data['slots'] = {'ls': {'database': 'a', 'plugin': 'b'}}


### PR DESCRIPTION
systemd 257+ requires MONOTONIC_USEC alongside RELOADING=1 for Type=notify-reload services. Without it, `systemctl reload` hangs indefinitely.

Close https://github.com/patroni/patroni/issues/3594