### PR TITLE
Warn when running under systemd without python-systemd package

### DIFF
--- a/patroni/daemon.py
+++ b/patroni/daemon.py
@@ -25,11 +25,12 @@ try:  # pragma: no cover
     def notify_systemd(msg: str) -> None:
         daemon.notify(msg)  # pyright: ignore
 
+    __systemd_available = True
 except ImportError:  # pragma: no cover
-    logger.info("Systemd integration is not supported")
-
     def notify_systemd(msg: str) -> None:
         pass
+
+    __systemd_available = False
 
 
 def get_base_arg_parser() -> argparse.ArgumentParser:
@@ -189,6 +190,9 @@ def abstract_main(cls: Type[AbstractPatroniDaemon], configfile: str) -> None:
     except ConfigParseError as e:
         sys.exit(e.value)
     patroni_logger.reload_config(config.get('log', {}))
+
+    if not __systemd_available and os.environ.get('NOTIFY_SOCKET'):
+        logger.warning('Running under systemd but python-systemd package is not installed')
 
     thread_stack_size = None
     if 'thread_stack_size' in config:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ cryptography>=1.4
 psutil>=2.0.0
 ydiff>=1.2.0,<1.5,!=1.4.0,!=1.4.1
 python-json-logger>=2.0.2
+# systemd-python is an optional dependency for systemd notification support.
+# OS package maintainers should add something like python3-systemd as a dependency to patroni package.

--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -128,15 +128,17 @@ class TestPatroni(unittest.TestCase):
     @patch.object(Postgresql, '_wait_for_connection_close', Mock())
     def test_patroni_patroni_main(self):
         with patch('subprocess.call', Mock(return_value=1)):
-            with patch.object(Patroni, 'run', Mock(side_effect=SleepException)):
-                os.environ['PATRONI_THREAD_STACK_SIZE'] = 'a'
-                os.environ['PATRONI_THREAD_POOL_SIZE'] = 'a'
-                os.environ['PATRONI_POSTGRESQL_DATA_DIR'] = 'data/test0'
+            with patch.object(Patroni, 'run', Mock(side_effect=SleepException)), \
+                patch('patroni.daemon.__systemd_available', False), \
+                patch.dict(os.environ, {'PATRONI_THREAD_STACK_SIZE': 'a',
+                                        'PATRONI_THREAD_POOL_SIZE': 'a',
+                                        'PATRONI_POSTGRESQL_DATA_DIR': 'data/test0',
+                                        'NOTIFY_SOCKET': '/run/systemd/notify'}):
                 self.assertRaises(SleepException, _main)
-            with patch.object(Patroni, 'run', Mock(side_effect=KeyboardInterrupt())):
-                with patch('patroni.ha.Ha.is_paused', Mock(return_value=True)):
-                    os.environ['PATRONI_POSTGRESQL_DATA_DIR'] = 'data/test0'
-                    _main()
+            with patch.object(Patroni, 'run', Mock(side_effect=KeyboardInterrupt())), \
+                    patch.dict(os.environ, {'PATRONI_POSTGRESQL_DATA_DIR': 'data/test0'}), \
+                    patch('patroni.ha.Ha.is_paused', Mock(return_value=True)):
+                _main()
 
     @patch('os.getpid')
     @patch('multiprocessing.Process')


### PR DESCRIPTION
Instead of logging at startup that systemd integration is not supported, check for NOTIFY_SOCKET and warn only when actually running under systemd without the python-systemd package installed.