### PR TITLE
fix(validator): allow synchronous_mode: quorum, in addition to T/F

### DIFF
--- a/patroni/global_config.py
+++ b/patroni/global_config.py
@@ -108,13 +108,36 @@ class GlobalConfig(types.ModuleType):
     @property
     def is_quorum_commit_mode(self) -> bool:
         """:returns: ``True`` if quorum commit replication is requested"""
-        return str(self.get('synchronous_mode')).lower() == 'quorum'
+        value = self.get('synchronous_mode')
+        return isinstance(value, str) and value.lower() == 'quorum'
 
     @property
     def is_synchronous_mode(self) -> bool:
-        """``True`` if synchronous replication is requested and it is not a standby cluster config."""
-        return (self.check_mode('synchronous_mode') is True or self.is_quorum_commit_mode) \
-            and not self.is_standby_cluster
+        """``True`` if synchronous replication is requested and it is not a standby cluster config.
+
+        Synchronous replication is enabled when ``synchronous_mode`` is set to:
+        - ``True`` or ``"on"`` (standard synchronous mode)
+        - ``"quorum"`` (quorum-based synchronous mode)
+
+        It is disabled when set to ``False`` or ``"off"``.
+        """
+        if self.is_standby_cluster:
+            return False
+
+        value = self.get('synchronous_mode')
+
+        # Handle explicit boolean values
+        if isinstance(value, bool):
+            return value
+
+        # Handle string values
+        if isinstance(value, str):
+            if value.lower() == 'quorum':
+                return True
+            # parse_bool handles 'on'/'true'/'yes' -> True, 'off'/'false'/'no' -> False
+            return parse_bool(value) is True
+
+        return False
 
     @property
     def is_synchronous_mode_strict(self) -> bool:

--- a/patroni/validator.py
+++ b/patroni/validator.py
@@ -971,6 +971,15 @@ def validate_watchdog_mode(value: Any) -> None:
     assert_(value in (False, "off", "automatic", "required"))
 
 
+def validate_synchronous_mode(value: Any) -> None:
+    """Validate ``synchronous_mode`` configuration option.
+
+    :param value: value of ``synchronous_mode`` to be validated.
+    """
+    assert_(isinstance(value, (str, bool)), "expected type is not a string or boolean")
+    assert_(value in (True, False, "quorum"))
+
+
 userattributes = {"username": "", Optional("password"): ""}
 available_dcs = [m.split(".")[-1] for m in dcs_modules()]
 setattr(validate_host_port_list, 'expected_type', list)
@@ -1087,7 +1096,7 @@ schema = Schema({
                 Optional("archive_cleanup_command"): str,
                 Optional("recovery_min_apply_delay"): str
             },
-            Optional("synchronous_mode"): bool,
+            Optional("synchronous_mode"): validate_synchronous_mode,
             Optional("synchronous_mode_strict"): bool,
             Optional("synchronous_node_count"): IntValidator(min=1, raise_assert=True),
         },

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -298,6 +298,48 @@ class TestConfig(unittest.TestCase):
         test_config = global_config.from_cluster(cluster)
         self.assertFalse(test_config.is_synchronous_mode)
 
+        # Test with boolean True
+        config = {'synchronous_mode': True}
+        cluster = get_cluster_initialized_with_only_leader(cluster_config=ClusterConfig(1, config, 1))
+        test_config = global_config.from_cluster(cluster)
+        self.assertTrue(test_config.is_synchronous_mode)
+        self.assertFalse(test_config.is_quorum_commit_mode)
+
+        # Test with boolean False
+        config = {'synchronous_mode': False}
+        cluster = get_cluster_initialized_with_only_leader(cluster_config=ClusterConfig(1, config, 1))
+        test_config = global_config.from_cluster(cluster)
+        self.assertFalse(test_config.is_synchronous_mode)
+        self.assertFalse(test_config.is_quorum_commit_mode)
+
+        # Test with string "quorum"
+        config = {'synchronous_mode': 'quorum'}
+        cluster = get_cluster_initialized_with_only_leader(cluster_config=ClusterConfig(1, config, 1))
+        test_config = global_config.from_cluster(cluster)
+        self.assertTrue(test_config.is_synchronous_mode)
+        self.assertTrue(test_config.is_quorum_commit_mode)
+
+        # Test with string "on"
+        config = {'synchronous_mode': 'on'}
+        cluster = get_cluster_initialized_with_only_leader(cluster_config=ClusterConfig(1, config, 1))
+        test_config = global_config.from_cluster(cluster)
+        self.assertTrue(test_config.is_synchronous_mode)
+        self.assertFalse(test_config.is_quorum_commit_mode)
+
+        # Test with string "off"
+        config = {'synchronous_mode': 'off'}
+        cluster = get_cluster_initialized_with_only_leader(cluster_config=ClusterConfig(1, config, 1))
+        test_config = global_config.from_cluster(cluster)
+        self.assertFalse(test_config.is_synchronous_mode)
+        self.assertFalse(test_config.is_quorum_commit_mode)
+
+        # Test with invalid string (should be treated as False)
+        config = {'synchronous_mode': 'invalid'}
+        cluster = get_cluster_initialized_with_only_leader(cluster_config=ClusterConfig(1, config, 1))
+        test_config = global_config.from_cluster(cluster)
+        self.assertFalse(test_config.is_synchronous_mode)
+        self.assertFalse(test_config.is_quorum_commit_mode)
+
     def test_build_effective_postgresql_configuration(self):
         """Test role-based configuration assembly."""
         # Set up config with role-based overrides

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -435,3 +435,32 @@ class TestValidator(unittest.TestCase):
 
         self.assertEqual(['postgresql.bin_dir'],
                          parse_output(output))
+
+    def test_synchronous_mode_validation(self, *args):
+        """Test that synchronous_mode accepts true, false, or 'quorum'."""
+        c = copy.deepcopy(config)
+
+        # Test with True
+        c['bootstrap'] = {'dcs': {'synchronous_mode': True}}
+        errors = schema(c)
+        self.assertNotIn('bootstrap.dcs.synchronous_mode', "\n".join(errors))
+
+        # Test with False
+        c['bootstrap'] = {'dcs': {'synchronous_mode': False}}
+        errors = schema(c)
+        self.assertNotIn('bootstrap.dcs.synchronous_mode', "\n".join(errors))
+
+        # Test with "quorum"
+        c['bootstrap'] = {'dcs': {'synchronous_mode': 'quorum'}}
+        errors = schema(c)
+        self.assertNotIn('bootstrap.dcs.synchronous_mode', "\n".join(errors))
+
+        # Test with invalid string value
+        c['bootstrap'] = {'dcs': {'synchronous_mode': 'invalid'}}
+        errors = schema(c)
+        self.assertTrue(any('bootstrap.dcs.synchronous_mode' in error for error in errors))
+
+        # Test with invalid numeric value
+        c['bootstrap'] = {'dcs': {'synchronous_mode': 1}}
+        errors = schema(c)
+        self.assertTrue(any('bootstrap.dcs.synchronous_mode' in error for error in errors))


### PR DESCRIPTION
`synchronous_mode` allows three values as per the [documentation](https://patroni.readthedocs.io/en/latest/dynamic_configuration.html#dynamic-configuration):

`on`
`off`
`quorum`

This updates `patroni --validate-config` to correctly accept `quorum` in addition to the existing boolean.

Fixes issue #3606 