### PR TITLE
Take into account version-specific auth params in config generation

### DIFF
--- a/patroni/config_generator.py
+++ b/patroni/config_generator.py
@@ -21,7 +21,7 @@ from .collections import EMPTY_DICT
 from .config import Config
 from .exceptions import PatroniException
 from .log import PatroniLogger
-from .postgresql.config import ConfigHandler, parse_dsn
+from .postgresql.config import AUTH_ALLOWED_PARAMETERS_VERSIONS, ConfigHandler, parse_dsn
 from .postgresql.misc import postgres_major_version_to_int
 from .utils import get_major_version, parse_bool, patch_config, read_stripped
 
@@ -481,6 +481,10 @@ class RunningClusterConfigGenerator(AbstractConfigGenerator):
 
         with self._get_connection_cursor() as cur:
             self.pg_major = getattr(cur.connection, 'server_version', 0)
+            # Adjust version-specific allowed parameters
+            for param, min_version in AUTH_ALLOWED_PARAMETERS_VERSIONS.items():
+                if self.pg_major < min_version and param in self.config['postgresql']['authentication']['superuser']:
+                    del self.config['postgresql']['authentication']['superuser'][param]
 
             if not parse_bool(getattr(cur.connection, 'get_parameter_status')('is_superuser')):
                 raise PatroniException('The provided user does not have superuser privilege')

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -28,6 +28,14 @@ if TYPE_CHECKING:  # pragma: no cover
 
 logger = logging.getLogger(__name__)
 
+AUTH_ALLOWED_PARAMETERS_VERSIONS = {
+    'gssencmode': 120000,
+    'channel_binding': 130000,
+    'sslpassword': 130000,
+    'sslcrldir': 140000,
+    'sslnegotiation': 170000
+}
+
 PARAMETER_RE = re.compile(r'([a-z_]+)\s*=\s*')
 
 
@@ -633,11 +641,11 @@ class ConfigHandler(object):
         ret = member.conn_kwargs(self.replication)
         ret['application_name'] = self._postgresql.name
         ret.setdefault('sslmode', 'prefer')
-        if self._postgresql.major_version >= 120000:
+        if self._postgresql.major_version >= AUTH_ALLOWED_PARAMETERS_VERSIONS['gssencmode']:
             ret.setdefault('gssencmode', 'prefer')
-        if self._postgresql.major_version >= 130000:
+        if self._postgresql.major_version >= AUTH_ALLOWED_PARAMETERS_VERSIONS['channel_binding']:
             ret.setdefault('channel_binding', 'prefer')
-        if self._postgresql.major_version >= 170000:
+        if self._postgresql.major_version >= AUTH_ALLOWED_PARAMETERS_VERSIONS['sslnegotiation']:
             ret.setdefault('sslnegotiation', 'postgres')
         if self._krbsrvname:
             ret['krbsrvname'] = self._krbsrvname
@@ -664,8 +672,7 @@ class ConfigHandler(object):
         def escape(value: Any) -> str:
             return re.sub(r'([\'\\ ])', r'\\\1', str(value))
 
-        key_ver = {'target_session_attrs': 100000, 'gssencmode': 120000, 'channel_binding': 130000,
-                   'sslpassword': 130000, 'sslcrldir': 140000, 'sslnegotiation': 170000}
+        key_ver = dict({'target_session_attrs': 100000}, **AUTH_ALLOWED_PARAMETERS_VERSIONS)
         return ' '.join('{0}={1}'.format(kw, escape(params[kw])) for kw in keywords
                         if params.get(kw) is not None and self._postgresql.major_version >= key_ver.get(kw, 0))
 

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -672,7 +672,7 @@ class ConfigHandler(object):
         def escape(value: Any) -> str:
             return re.sub(r'([\'\\ ])', r'\\\1', str(value))
 
-        key_ver = dict({'target_session_attrs': 100000}, **AUTH_ALLOWED_PARAMETERS_VERSIONS)
+        key_ver = {'target_session_attrs': 100000, **AUTH_ALLOWED_PARAMETERS_VERSIONS}
         return ' '.join('{0}={1}'.format(kw, escape(params[kw])) for kw in keywords
                         if params.get(kw) is not None and self._postgresql.major_version >= key_ver.get(kw, 0))
 

--- a/tests/test_config_generator.py
+++ b/tests/test_config_generator.py
@@ -215,6 +215,23 @@ class TestGenerateConfig(unittest.TestCase):
 
     @patch('os.makedirs', Mock())
     @patch('sys.stdout')
+    @patch.object(MockConnect, 'server_version', PropertyMock(return_value=140000))
+    def test_generate_config_running_instance_14(self, mock_sys_stdout):
+        self._set_running_instance_config_vals()
+
+        with patch('builtins.open', Mock(side_effect=self._get_running_instance_open_res())), \
+             patch('sys.argv', ['patroni.py', '--generate-config',
+                                '--dsn', 'host=foo port=bar user=foobar password=qwerty']), \
+                self.assertRaises(SystemExit) as e:
+            _main()
+        self.assertEqual(e.exception.code, 0)
+        config = deepcopy(self.config)
+        del config['postgresql']['authentication']['superuser']['sslnegotiation']
+        self.assertEqual(config, yaml.safe_load(mock_sys_stdout.write.call_args_list[0][0][0]))
+
+    @patch('os.makedirs', Mock())
+    @patch('sys.stdout')
+    @patch.object(MockConnect, 'server_version', PropertyMock(return_value=170000))
     def test_generate_config_running_instance_17(self, mock_sys_stdout):
         self._set_running_instance_config_vals()
 
@@ -228,6 +245,7 @@ class TestGenerateConfig(unittest.TestCase):
 
     @patch('os.makedirs', Mock())
     @patch('sys.stdout')
+    @patch.object(MockConnect, 'server_version', PropertyMock(return_value=170000))
     def test_generate_config_running_instance_17_connect_from_env(self, mock_sys_stdout):
         self._set_running_instance_config_vals()
         # su auth params and connect host from env


### PR DESCRIPTION
After getting the version from connection, remove all auth params not applicable if they were accidentally picked from for environment