### PR TITLE
Do not parse the port as an int for replication connection

### DIFF
--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -1107,7 +1107,7 @@ class Postgresql(object):
     def get_replication_connection_cursor(self, host: Optional[str] = None, port: Union[int, str] = 5432,
                                           **kwargs: Any) -> Generator[Union['cursor', 'Cursor[Any]'], None, None]:
         conn_kwargs = self.config.replication.copy()
-        conn_kwargs.update(host=host, port=int(port) if port else None, user=conn_kwargs.pop('username'),
+        conn_kwargs.update(host=host, port=port if port else None, user=conn_kwargs.pop('username'),
                            connect_timeout=3, replication=1, options='-c statement_timeout=2000')
         with get_connection_cursor(**conn_kwargs) as cur:
             yield cur


### PR DESCRIPTION
Standby clusters support listing several hosts and several ports. If we do, we must accept the port not being an int but a comma separated list of ints.

This breaks when trying to open a replication connection using pg_rewind.