### PR TITLE
Warn about CVE-2026-6475 in pg_basebackup and pg_rewind

### DIFF
--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -10,8 +10,8 @@ from ..async_executor import CriticalTask
 from ..collections import EMPTY_DICT
 from ..dcs import Leader, Member, RemoteMember
 from ..psycopg import quote_ident, quote_literal
-from ..utils import deep_compare, process_user_options
-from .misc import PostgresqlState
+from ..utils import deep_compare, get_postgres_version, process_user_options
+from .misc import is_cve_2026_6475_vulnerable, postgres_version_to_int, PostgresqlState
 
 if TYPE_CHECKING:  # pragma: no cover
     from . import Postgresql
@@ -250,6 +250,19 @@ class Bootstrap(object):
         self._postgresql.set_state(PostgresqlState.STOPPED)
         return ret
 
+    def _maybe_warn_about_vulnerable_basebackup(self) -> None:
+        try:
+            version = get_postgres_version(bin_name=self._postgresql.pgcommand('pg_basebackup'))
+            is_vulnerable = is_cve_2026_6475_vulnerable(postgres_version_to_int(version))
+        except Exception as e:
+            logger.warning('Could not determine pg_basebackup version while checking CVE-2026-6475: %s', e)
+            return
+
+        if is_vulnerable:
+            logger.warning('pg_basebackup version %s is vulnerable to CVE-2026-6475 and may overwrite files outside '
+                           'PGDATA when cloning from a malicious or compromised source server. Upgrade PostgreSQL '
+                           'client binaries to 14.23, 15.18, 16.14, 17.10, 18.4, or newer.', version)
+
     def basebackup(self, conn_url: str, env: Dict[str, str], options: Dict[str, Any]) -> Optional[int]:
         # creates a replica data dir using pg_basebackup.
         # this is the default, built-in create_replica_methods
@@ -284,6 +297,8 @@ class Bootstrap(object):
             "stream",
             "--dbname=" + conn_url,
         ] + user_options
+
+        self._maybe_warn_about_vulnerable_basebackup()
 
         for bbfailures in range(0, maxfailures):
             if self._postgresql.cancellable.is_cancelled:

--- a/patroni/postgresql/misc.py
+++ b/patroni/postgresql/misc.py
@@ -135,6 +135,29 @@ def get_major_from_minor_version(version: int) -> int:
     return version // 100 * 100
 
 
+_CVE_2026_6475_FIXED_VERSIONS = {
+    140000: 140023,
+    150000: 150018,
+    160000: 160014,
+    170000: 170010,
+    180000: 180004,
+}
+
+
+def is_cve_2026_6475_vulnerable(version: int) -> bool:
+    """Check whether a PostgreSQL client binary is vulnerable to CVE-2026-6475.
+
+    CVE-2026-6475 affects ``pg_basebackup`` plain format and ``pg_rewind`` in
+    PostgreSQL 14 through 18 before 14.23, 15.18, 16.14, 17.10, and 18.4.
+
+    :param version: integer representation of PostgreSQL full version.
+
+    :returns: ``True`` if the version is known to be vulnerable.
+    """
+    fixed_version = _CVE_2026_6475_FIXED_VERSIONS.get(get_major_from_minor_version(version))
+    return fixed_version is not None and version < fixed_version
+
+
 def parse_lsn(lsn: str) -> int:
     t = lsn.split('/')
     return int(t[0], 16) * 0x100000000 + int(t[1], 16)

--- a/patroni/postgresql/rewind.py
+++ b/patroni/postgresql/rewind.py
@@ -16,8 +16,8 @@ from ..dcs import Leader, RemoteMember
 from ..utils import get_postgres_version, process_user_options
 from . import Postgresql
 from .connection import get_connection_cursor
-from .misc import (format_lsn, fsync_dir, is_cve_2026_6475_vulnerable, parse_history, parse_lsn,
-                   postgres_version_to_int, PostgresqlRole)
+from .misc import format_lsn, fsync_dir, is_cve_2026_6475_vulnerable, \
+    parse_history, parse_lsn, postgres_version_to_int, PostgresqlRole
 
 logger = logging.getLogger(__name__)
 

--- a/patroni/postgresql/rewind.py
+++ b/patroni/postgresql/rewind.py
@@ -13,10 +13,11 @@ from .. import thread_pool
 from ..async_executor import CriticalTask
 from ..collections import EMPTY_DICT
 from ..dcs import Leader, RemoteMember
-from ..utils import process_user_options
+from ..utils import get_postgres_version, process_user_options
 from . import Postgresql
 from .connection import get_connection_cursor
-from .misc import format_lsn, fsync_dir, parse_history, parse_lsn, PostgresqlRole
+from .misc import (format_lsn, fsync_dir, is_cve_2026_6475_vulnerable, parse_history, parse_lsn,
+                   postgres_version_to_int, PostgresqlRole)
 
 logger = logging.getLogger(__name__)
 
@@ -447,6 +448,19 @@ class Rewind(object):
             except Exception as e:
                 logger.warning('Unable to clean %s: %r', replslot_dir, e)
 
+    def _maybe_warn_about_vulnerable_pg_rewind(self) -> None:
+        try:
+            version = get_postgres_version(bin_name=self._postgresql.pgcommand('pg_rewind'))
+            is_vulnerable = is_cve_2026_6475_vulnerable(postgres_version_to_int(version))
+        except Exception as e:
+            logger.warning('Could not determine pg_rewind version while checking CVE-2026-6475: %s', e)
+            return
+
+        if is_vulnerable:
+            logger.warning('pg_rewind version %s is vulnerable to CVE-2026-6475 and may overwrite files outside '
+                           'PGDATA when rewinding from a malicious or compromised source server. Upgrade PostgreSQL '
+                           'client binaries to 14.23, 15.18, 16.14, 17.10, 18.4, or newer.', version)
+
     def pg_rewind(self, conn_kwargs: Dict[str, Any]) -> bool:
         """Do pg_rewind.
 
@@ -477,6 +491,8 @@ class Rewind(object):
                                                      or (self._postgresql.major_version >= 130000
                                                          and self._postgresql.config.config_dir
                                                          == self._postgresql.data_dir))
+
+        self._maybe_warn_about_vulnerable_pg_rewind()
 
         cmd = [self._postgresql.pgcommand('pg_rewind')]
         if pg_rewind_can_restore:

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -135,6 +135,24 @@ class TestBootstrap(BaseTestPostgresql):
             # compress is in not_allowed_options for PG < 15, error logged via process_user_options
             mock_error.assert_any_call('compress option for basebackup is not allowed')
 
+    def test_maybe_warn_about_vulnerable_basebackup(self):
+        with patch('patroni.postgresql.bootstrap.get_postgres_version', Mock(return_value='17.9')), \
+                patch('patroni.postgresql.bootstrap.logger.warning') as mock_warning:
+            self.b._maybe_warn_about_vulnerable_basebackup()
+            mock_warning.assert_called_once()
+
+        with patch('patroni.postgresql.bootstrap.get_postgres_version', Mock(return_value='17.10')), \
+                patch('patroni.postgresql.bootstrap.logger.warning') as mock_warning:
+            self.b._maybe_warn_about_vulnerable_basebackup()
+            mock_warning.assert_not_called()
+
+        with patch('patroni.postgresql.bootstrap.get_postgres_version', Mock(side_effect=Exception('boom'))), \
+                patch('patroni.postgresql.bootstrap.logger.warning') as mock_warning:
+            self.b._maybe_warn_about_vulnerable_basebackup()
+            mock_warning.assert_called_once()
+            self.assertEqual('Could not determine pg_basebackup version while checking CVE-2026-6475: %s',
+                             mock_warning.call_args[0][0])
+
     def test__initdb(self):
         self.assertRaises(Exception, self.b.bootstrap, {'initdb': [{'pgdata': 'bar'}]})
         self.assertRaises(Exception, self.b.bootstrap, {'initdb': [{'foo': 'bar', 1: 2}]})

--- a/tests/test_rewind.py
+++ b/tests/test_rewind.py
@@ -89,6 +89,24 @@ class TestRewind(BaseTestPostgresql):
             mock_debug.assert_any_call('not checking diverged timeline: pg_rewind is not possible'
                                        ' and remove_data_directory_on_diverged_timelines is not enabled')
 
+    def test_maybe_warn_about_vulnerable_pg_rewind(self):
+        with patch('patroni.postgresql.rewind.get_postgres_version', Mock(return_value='17.9')), \
+                patch('patroni.postgresql.rewind.logger.warning') as mock_warning:
+            self.r._maybe_warn_about_vulnerable_pg_rewind()
+            mock_warning.assert_called_once()
+
+        with patch('patroni.postgresql.rewind.get_postgres_version', Mock(return_value='17.10')), \
+                patch('patroni.postgresql.rewind.logger.warning') as mock_warning:
+            self.r._maybe_warn_about_vulnerable_pg_rewind()
+            mock_warning.assert_not_called()
+
+        with patch('patroni.postgresql.rewind.get_postgres_version', Mock(side_effect=Exception('boom'))), \
+                patch('patroni.postgresql.rewind.logger.warning') as mock_warning:
+            self.r._maybe_warn_about_vulnerable_pg_rewind()
+            mock_warning.assert_called_once()
+            self.assertEqual('Could not determine pg_rewind version while checking CVE-2026-6475: %s',
+                             mock_warning.call_args[0][0])
+
     def test_pg_rewind(self):
         r = {'user': '', 'host': '', 'port': '', 'database': '', 'password': ''}
         with patch.object(Postgresql, 'major_version', PropertyMock(return_value=150000)), \

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ import unittest
 from unittest.mock import Mock, patch
 
 from patroni.exceptions import PatroniException
+from patroni.postgresql.misc import is_cve_2026_6475_vulnerable
 from patroni.utils import apply_keepalive_limit, enable_keepalive, get_major_version, get_postgres_version, \
     polling_loop, process_user_options, Retry, RetryFailedError, unquote, validate_directory
 
@@ -95,6 +96,21 @@ class TestUtils(unittest.TestCase):
             self.assertEqual(get_postgres_version(), '10.0')
         with patch('subprocess.check_output', Mock(side_effect=OSError)):
             self.assertRaises(PatroniException, get_postgres_version, 'postgres')
+
+    def test_is_cve_2026_6475_vulnerable(self):
+        self.assertTrue(is_cve_2026_6475_vulnerable(140022))
+        self.assertTrue(is_cve_2026_6475_vulnerable(150017))
+        self.assertTrue(is_cve_2026_6475_vulnerable(160013))
+        self.assertTrue(is_cve_2026_6475_vulnerable(170009))
+        self.assertTrue(is_cve_2026_6475_vulnerable(180003))
+
+        self.assertFalse(is_cve_2026_6475_vulnerable(140023))
+        self.assertFalse(is_cve_2026_6475_vulnerable(150018))
+        self.assertFalse(is_cve_2026_6475_vulnerable(160014))
+        self.assertFalse(is_cve_2026_6475_vulnerable(170010))
+        self.assertFalse(is_cve_2026_6475_vulnerable(180004))
+        self.assertFalse(is_cve_2026_6475_vulnerable(130020))
+        self.assertFalse(is_cve_2026_6475_vulnerable(190000))
 
     def test_get_major_version(self):
         with patch('subprocess.check_output', Mock(return_value=b'postgres (PostgreSQL) 9.6.24\n')):


### PR DESCRIPTION
PostgreSQL 14.23, 15.18, 16.14, 17.10, and 18.4 fix CVE-2026-6475, where vulnerable pg_basebackup plain-format and pg_rewind clients may overwrite files outside PGDATA when cloning/rewinding from a malicious or compromised source server.\n\nPatroni invokes both tools in the affected workflows. It cannot safely mitigate the client-side symlink handling bug itself, so this adds a version check before running the tools and emits a clear warning when the local PostgreSQL client binary is known vulnerable.\n\nChanges:\n- add a helper for CVE-2026-6475 vulnerable PostgreSQL client versions\n- warn before built-in basebackup with vulnerable pg_basebackup\n- warn before rewind with vulnerable pg_rewind\n- cover the version helper and warning paths with tests\n\nTested locally:\n\n```\npytest -q tests/test_utils.py::TestUtils::test_is_cve_2026_6475_vulnerable tests/test_bootstrap.py::TestBootstrap::test_basebackup tests/test_bootstrap.py::TestBootstrap::test_maybe_warn_about_vulnerable_basebackup tests/test_rewind.py::TestRewind::test_pg_rewind_user_options tests/test_rewind.py::TestRewind::test_maybe_warn_about_vulnerable_pg_rewind\n# 5 passed in 1.18s\n\npython -m isort --check-only --diff patroni tests features setup.py\nflake8 patroni/postgresql/bootstrap.py patroni/postgresql/rewind.py patroni/postgresql/misc.py tests/test_utils.py tests/test_bootstrap.py tests/test_rewind.py\n```\n\nSupersedes #3615; GitHub did not attach the source branch update to that PR.