### PR TITLE
Distinguish patronictl lag columns

### DIFF
--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -192,8 +192,8 @@ class PatronictlPrettyTable(PrettyTable):
     def _validate_field_names(self, *args: Any, **kwargs: Any) -> None:
         """Validate field names.
 
-        Remove uniqueness constraint for field names from the original implementation.
-        Required for having shorter ``Lag`` columns without specifying lag's type after ``LSN`` column already did so.
+        Remove uniqueness constraint for field names from the original implementation for backwards compatibility with
+        table layouts that intentionally reuse display names.
         """
         try:
             super(PatronictlPrettyTable, self)._validate_field_names(*args, **kwargs)
@@ -1673,10 +1673,9 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
         title_details = f' ({initialize})'
 
     title = f' {title}: {name}{title_details} '
-    if fmt in ('pretty', 'topology'):
-        columns[columns.index('Replay Lag')] = columns[columns.index('Receive Lag')] = 'Lag'
     print_output(columns, rows,
-                 {'Group': 'r', 'Receive LSN': 'r', 'Replay LSN': 'r', 'Lag': 'r', 'TL': 'r'}, fmt, title)
+                 {'Group': 'r', 'Receive LSN': 'r', 'Receive Lag': 'r', 'Replay LSN': 'r', 'Replay Lag': 'r',
+                  'TL': 'r'}, fmt, title)
 
     if fmt not in ('pretty', 'topology'):  # Omit service info when using machine-readable formats
         return

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -139,6 +139,12 @@ class TestCtl(unittest.TestCase):
                 self.assertIsNone(output_members(cluster, name='abc', fmt=fmt))
 
             with patch('click.echo') as mock_echo:
+                self.assertIsNone(output_members(cluster, name='abc', fmt='pretty'))
+                header = '\n'.join(call[0][0] for call in mock_echo.call_args_list if 'Receive LSN' in call[0][0])
+                self.assertIn('Receive Lag', header)
+                self.assertIn('Replay Lag', header)
+
+            with patch('click.echo') as mock_echo:
                 self.assertIsNone(output_members(cluster, name='abc', fmt='tsv'))
                 self.assertEqual(mock_echo.call_args_list[3][0][0],
                                  'abc\tother\t\tReplica\tstreaming\t\t0/3\t0\tunknown\t')


### PR DESCRIPTION
## Summary

- keep the `Receive Lag` and `Replay Lag` column labels in human-readable `patronictl list` output
- update the pretty-table alignment map for the distinct lag columns
- add a regression assertion that the pretty output header includes both lag labels

## Related issue

Closes #3619

## Validation

- [x] `git diff --check`
- [x] `git diff --cached --check`
- Not run locally