### PR TITLE
Make CaseInsensitiveDict repr deterministic

### DIFF
--- a/patroni/collections.py
+++ b/patroni/collections.py
@@ -204,10 +204,10 @@ class CaseInsensitiveDict(MutableMapping[str, Any]):
 
         :Example:
 
-            >>> repr(CaseInsensitiveDict({'a': 'b', 'A': 'B', 'c': 'd'}))  # doctest: +ELLIPSIS
-            "<CaseInsensitiveDict{'A': 'B', 'c': 'd'} at ..."
+            >>> repr(CaseInsensitiveDict({'a': 'b', 'A': 'B', 'c': 'd'}))
+            "<CaseInsensitiveDict{'A': 'B', 'c': 'd'}>"
         """
-        return '<{0}{1} at {2:x}>'.format(type(self).__name__, dict(self.items()), id(self))
+        return '<{0}{1}>'.format(type(self).__name__, dict(self.items()))
 
 
 class _FrozenDict(Mapping[str, Any]):

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -836,6 +836,7 @@ class TestPostgresql(BaseTestPostgresql):
                 self.p.config.get_server_parameters(config)
                 self.p.config.set_synchronous_standby_names('foo')
                 self.assertTrue(str(self.p.config.get_server_parameters(config)).startswith('<CaseInsensitiveDict'))
+                self.assertNotIn(' at ', repr(self.p.config.get_server_parameters(config)))
 
     @patch('time.sleep', Mock())
     def test__wait_for_connection_close(self):


### PR DESCRIPTION
## Summary

- remove the object address from `CaseInsensitiveDict.__repr__`
- keep the representation useful by showing the preserved-case dictionary contents
- add a regression assertion that server parameter repr output no longer includes a memory address marker

## Related issue

Closes #3611

## Validation

- [x] `git diff --check`
- [x] `git diff --cached --check`
- Not run locally