### PR TITLE
Ensure 'failover' and 'synced' fields are always in place for logical slots

### DIFF
--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -241,12 +241,17 @@ class Postgresql(object):
                         and self.role in (PostgresqlRole.PRIMARY, PostgresqlRole.PROMOTED) else "'on', '', NULL")
 
         if self._major_version >= 90600:
-            filter_failover = ' WHERE NOT failover' if self._major_version >= 170000 else ''
+            filter_columns = ["NOT temporary"] if self._major_version >= 100000 else []
+            filter_columns += ["(NOT failover OR NOT synced)"] if self._major_version >= 170000 else []
+            where_filter = ' AND '.join(filter_columns)
+            where_condition = f' WHERE {where_filter}' if where_filter else ''
             extra = ("pg_catalog.current_setting('restore_command')" if self._major_version >= 120000 else "NULL") +\
                 ", " + ("(SELECT pg_catalog.json_agg(s.*) FROM (SELECT slot_name, slot_type as type, datoid::bigint, "
                         "plugin, catalog_xmin, pg_catalog.pg_wal_lsn_diff(confirmed_flush_lsn, '0/0')::bigint"
                         " AS confirmed_flush_lsn, pg_catalog.pg_wal_lsn_diff(restart_lsn, '0/0')::bigint"
-                        f" AS restart_lsn, xmin FROM pg_catalog.pg_get_replication_slots(){filter_failover}) AS s)"
+                        " AS restart_lsn, xmin"
+                        + (", failover, synced" if self._major_version >= 170000 else "")
+                        + f" FROM pg_catalog.pg_get_replication_slots(){where_condition}) AS s)"
                         if self._should_query_slots and self.can_advance_slots else "NULL") + extra
 
             written_lsn = ("pg_catalog.pg_wal_lsn_diff(written_lsn, '0/0')::bigint"

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -241,17 +241,9 @@ class Postgresql(object):
                         and self.role in (PostgresqlRole.PRIMARY, PostgresqlRole.PROMOTED) else "'on', '', NULL")
 
         if self._major_version >= 90600:
-            filter_columns = ["NOT temporary"] if self._major_version >= 100000 else []
-            filter_columns += ["(NOT failover OR NOT synced)"] if self._major_version >= 170000 else []
-            where_filter = ' AND '.join(filter_columns)
-            where_condition = f' WHERE {where_filter}' if where_filter else ''
+            pg_replication_slots_query = self.slots_handler.pg_replication_slots_query(True)
             extra = ("pg_catalog.current_setting('restore_command')" if self._major_version >= 120000 else "NULL") +\
-                ", " + ("(SELECT pg_catalog.json_agg(s.*) FROM (SELECT slot_name, slot_type as type, datoid::bigint, "
-                        "plugin, catalog_xmin, pg_catalog.pg_wal_lsn_diff(confirmed_flush_lsn, '0/0')::bigint"
-                        " AS confirmed_flush_lsn, pg_catalog.pg_wal_lsn_diff(restart_lsn, '0/0')::bigint"
-                        " AS restart_lsn, xmin"
-                        + (", failover, synced" if self._major_version >= 170000 else "")
-                        + f" FROM pg_catalog.pg_get_replication_slots(){where_condition}) AS s)"
+                ", " + (f"(SELECT pg_catalog.json_agg(s.*) FROM ({pg_replication_slots_query}) AS s)"
                         if self._should_query_slots and self.can_advance_slots else "NULL") + extra
 
             written_lsn = ("pg_catalog.pg_wal_lsn_diff(written_lsn, '0/0')::bigint"

--- a/patroni/postgresql/slots.py
+++ b/patroni/postgresql/slots.py
@@ -258,33 +258,48 @@ class SlotsHandler:
 
         return ret
 
+    def pg_replication_slots_query(self, use_function: bool = False) -> str:
+        """Get query text for retrieveing slots infromation.
+
+        Query retrieves replication slot's ``name``, ``type``, ``plugin``, ``database`` and ``datoid``.
+        If PostgreSQL version is 10 or newer also retrieves ``catalog_xmin`` and ``confirmed_flush_lsn``.
+        If PostgreSQL version is 17 or above also retrieves ``failover`` and ``synced``.
+
+        :param use_function: whether to use ``pg_get_replication_slots()`` function or ``pg_replication_slots`` view
+                             in the query.
+
+        :return: string containing SQL query text.
+        """
+        pg_wal_lsn_diff = f"pg_catalog.pg_{self._postgresql.wal_name}_{self._postgresql.lsn_name}_diff"
+
+        extra = f", catalog_xmin, {pg_wal_lsn_diff}(confirmed_flush_lsn, '0/0')::bigint AS confirmed_flush_lsn" \
+            if self._postgresql.major_version >= 100000 else ""
+        extra += ", failover, synced" if self._postgresql.major_version >= 170000 else ""
+
+        filter_columns = ["NOT temporary"] if self._postgresql.major_version >= 100000 else []
+        filter_columns += ["(NOT failover OR NOT synced)"] if self._postgresql.major_version >= 170000 else []
+
+        where_filter = ' AND '.join(filter_columns)
+        where_condition = f' WHERE {where_filter}' if where_filter else ''
+
+        database = '' if use_function else ', database'
+        pg_replication_slots_obj = "pg_get_replication_slots()" if use_function else 'pg_replication_slots'
+
+        return "SELECT slot_name, slot_type AS type, xmin, " \
+            f"{pg_wal_lsn_diff}(restart_lsn, '0/0')::bigint AS restart_lsn, plugin{database}, " \
+            f"datoid::bigint{extra} FROM pg_catalog.{pg_replication_slots_obj}{where_condition}"
+
     def load_replication_slots(self) -> None:
         """Query replication slot information from the database and store it for processing by other tasks.
 
         .. note::
             Only supported from PostgreSQL version 9.4 onwards.
 
-        Store replication slot ``name``, ``type``, ``plugin``, ``database`` and ``datoid``.
-        If PostgreSQL version is 10 or newer also store ``catalog_xmin`` and ``confirmed_flush_lsn``.
-        If PostgreSQL version is 17 or above also fetch ``failover`` and ``synced``.
-
-        When using logical slots, store information separately for slot synchronisation  on replica nodes.
+        When using logical slots, store information separately for slot synchronisation on replica nodes.
         """
         if self._postgresql.major_version >= 90400 and self._schedule_load_slots:
             replication_slots: Dict[str, Dict[str, Any]] = {}
-            pg_wal_lsn_diff = f"pg_catalog.pg_{self._postgresql.wal_name}_{self._postgresql.lsn_name}_diff"
-
-            extra = f", catalog_xmin, {pg_wal_lsn_diff}(confirmed_flush_lsn, '0/0')::bigint" \
-                if self._postgresql.major_version >= 100000 else ""
-            extra += ", failover, synced" if self._postgresql.major_version >= 170000 else ""
-
-            filter_columns = ["NOT temporary"] if self._postgresql.major_version >= 100000 else []
-            filter_columns += ["(NOT failover OR NOT synced)"] if self._postgresql.major_version >= 170000 else []
-            where_filter = ' AND '.join(filter_columns)
-            where_condition = f' WHERE {where_filter}' if where_filter else ''
-            for r in self._query("SELECT slot_name, slot_type, xmin, "
-                                 f"{pg_wal_lsn_diff}(restart_lsn, '0/0')::bigint, plugin, database, datoid{extra}"
-                                 f" FROM pg_catalog.pg_replication_slots{where_condition}"):
+            for r in self._query(self.pg_replication_slots_query()):
                 value = {'type': r[1]}
                 if r[1] == 'logical':
                     value.update(plugin=r[4], database=r[5], datoid=r[6])

--- a/patroni/postgresql/slots.py
+++ b/patroni/postgresql/slots.py
@@ -212,7 +212,8 @@ class SlotsHandler:
         :param dst: destination dictionary to be updated.
         :param keys: optional list of keys to be looked up in the source dictionary.
         """
-        dst.update({key: src[key] for key in keys or ('datoid', 'catalog_xmin', 'confirmed_flush_lsn')})
+        dst.update({key: src[key] for key in keys or (
+            'datoid', 'catalog_xmin', 'confirmed_flush_lsn', 'failover', 'synced') if key in src})
 
     def process_permanent_slots(self, slots: List[Dict[str, Any]]) -> Dict[str, int]:
         """Process replication slot information from the host and prepare information used in subsequent cluster tasks.

--- a/patroni/postgresql/slots.py
+++ b/patroni/postgresql/slots.py
@@ -10,7 +10,7 @@ import shutil
 from collections import defaultdict
 from contextlib import contextmanager
 from threading import Condition, Thread
-from typing import Any, Collection, Dict, Generator, List, Optional, Tuple, TYPE_CHECKING, Union
+from typing import Any, Dict, Generator, List, Optional, Tuple, TYPE_CHECKING, Union
 
 from .. import global_config
 from ..dcs import Cluster, Leader
@@ -204,16 +204,20 @@ class SlotsHandler:
         """
         return self._postgresql.query(sql, *params, retry=False)
 
-    @staticmethod
-    def _copy_items(src: Dict[str, Any], dst: Dict[str, Any], keys: Optional[Collection[str]] = None) -> None:
-        """Select values from *src* dictionary to update in *dst* dictionary for optional supplied *keys*.
+    def copy_slot_items(self, src: Dict[str, Any], dst: Dict[str, Any], is_logical: bool = True) -> None:
+        """Select values from *src* slots dictionary to update in *dst* slots dictionary.
 
         :param src: source dictionary that *keys* will be looked up from.
         :param dst: destination dictionary to be updated.
-        :param keys: optional list of keys to be looked up in the source dictionary.
+        :param is_logical: whether the slot type is logical.
         """
-        dst.update({key: src[key] for key in keys or (
-            'datoid', 'catalog_xmin', 'confirmed_flush_lsn', 'failover', 'synced') if key in src})
+        if is_logical:
+            keys = ('datoid', 'catalog_xmin', 'confirmed_flush_lsn')
+            if self._postgresql.major_version >= 17:
+                keys += ('failover', 'synced')
+        else:
+            keys = ('restart_lsn', 'xmin')
+        dst.update({key: src[key] for key in keys if key in src})
 
     def process_permanent_slots(self, slots: List[Dict[str, Any]]) -> Dict[str, int]:
         """Process replication slot information from the host and prepare information used in subsequent cluster tasks.
@@ -245,10 +249,10 @@ class SlotsHandler:
                 if compare_slots(value, self._replication_slots[name], 'datoid'):
                     if value['type'] == 'logical':
                         ret[name] = value['confirmed_flush_lsn']
-                        self._copy_items(value, self._replication_slots[name])
+                        self.copy_slot_items(value, self._replication_slots[name])
                     else:
                         ret[name] = value['restart_lsn']
-                        self._copy_items(value, self._replication_slots[name], ('restart_lsn', 'xmin'))
+                        self.copy_slot_items(value, self._replication_slots[name], is_logical=False)
                 else:
                     self._schedule_load_slots = True
 
@@ -436,7 +440,7 @@ class SlotsHandler:
             # change, which would prevent Postgres from advancing the xmin horizon.
             if self._postgresql.can_advance_slots and name in self._replication_slots and\
                     self._replication_slots[name]['type'] == 'physical':
-                self._copy_items(self._replication_slots[name], value, ('restart_lsn', 'xmin'))
+                self.copy_slot_items(self._replication_slots[name], value, is_logical=False)
                 if clean_inactive_physical_slots and value.get('expected_active') is False and value['xmin']:
                     logger.warning('Dropping physical replication slot %s because of its xmin value %s',
                                    name, value['xmin'])
@@ -505,7 +509,7 @@ class SlotsHandler:
         for name, value in slots.items():
             if value['type'] == 'logical':
                 if self._replication_slots.get(name, {}).get('datoid'):
-                    self._copy_items(self._replication_slots[name], value)
+                    self.copy_slot_items(self._replication_slots[name], value)
                 else:
                     logical_slots[value['database']][name] = value
 
@@ -549,7 +553,7 @@ class SlotsHandler:
 
             # If the logical already exists, copy some information about it into the original structure
             if name in self._replication_slots and compare_slots(value, self._replication_slots[name]):
-                self._copy_items(self._replication_slots[name], value)
+                self.copy_slot_items(self._replication_slots[name], value)
 
                 # The slot has feedback in DCS
                 if 'lsn' in value:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -141,7 +141,7 @@ class MockCursor(object):
         elif sql.startswith('SELECT slot_name'):
             self.results = [('blabla', 'physical', 1, 12345),
                             ('foobar', 'physical', 1, 12345),
-                            ('ls', 'logical', 1, 499, 'b', 'a', 5, 100, 500)]
+                            ('ls', 'logical', 1, 499, 'b', 'a', 5, 100, 500, False, False)]
         elif sql.startswith('WITH slots AS (SELECT slot_name, active'):
             self.results = [(False, True)] if self.rowcount == 1 else []
         elif sql.startswith('SELECT CASE WHEN pg_catalog.pg_is_in_recovery()'):

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -1191,10 +1191,16 @@ class TestPostgresql2(BaseTestPostgresql):
 
     def test_cluster_info_query(self):
         self.assertIn('diff(pg_catalog.pg_current_wal_flush_lsn(', self.p.cluster_info_query)
+        self.assertIn('WHERE NOT temporary', self.p.cluster_info_query)
+        self.assertNotIn('(NOT failover OR NOT synced)', self.p.cluster_info_query)
         self.p._major_version = 90600
         self.assertIn('diff(pg_catalog.pg_current_xlog_flush_location(', self.p.cluster_info_query)
+        self.assertNotIn('WHERE NOT temporary', self.p.cluster_info_query)
         self.p._major_version = 90500
         self.assertIn('diff(pg_catalog.pg_current_xlog_location(', self.p.cluster_info_query)
+        self.assertNotIn('WHERE NOT temporary', self.p.cluster_info_query)
+        self.p._major_version = 180000
+        self.assertIn('WHERE NOT temporary AND (NOT failover OR NOT synced)', self.p.cluster_info_query)
 
     @patch.object(Postgresql, 'is_primary', Mock(return_value=False))
     @patch.object(Postgresql, '_query', Mock(return_value=[('primary_conninfo', 'host=a port=5433 passfile=/blabla')]))

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -83,6 +83,26 @@ class TestSlotsHandler(BaseTestPostgresql):
                 self.p.set_role(PostgresqlRole.REPLICA)
                 self.s.sync_replication_slots(cluster, self.tags)
 
+        config = ClusterConfig(1, {'slots': {'ls': {'type': 'logical', 'plugin': 'b', 'database': 'a'}}}, 1)
+        cluster = Cluster(True, config, self.leader,
+                          Status(0, {'test_3': 10}, []),
+                          [self.me, self.other, self.leadermem], None, SyncState.empty(), None, None)
+        global_config.update(cluster)
+        with patch.object(Postgresql, 'major_version', PropertyMock(return_value=170000)), \
+                patch.object(Postgresql, 'is_primary', Mock(side_effect=[False, True])):
+            # as replica
+            self.s.sync_replication_slots(cluster, self.tags)
+            self.assertIn('ls', self.s._replication_slots)
+            self.assertEqual(self.s._replication_slots['ls'],
+                             {'type': 'logical', 'plugin': 'b', 'database': 'a', 'datoid': 5,
+                              'catalog_xmin': 100, 'confirmed_flush_lsn': 500, 'failover': False, 'synced': False})
+            # as primary
+            self.s.sync_replication_slots(cluster, self.tags)
+            self.assertIn('ls', self.s._replication_slots)
+            self.assertEqual(self.s._replication_slots['ls'],
+                             {'type': 'logical', 'plugin': 'b', 'database': 'a', 'datoid': 5,
+                              'catalog_xmin': 100, 'confirmed_flush_lsn': 500, 'failover': False, 'synced': False})
+
     def test_cascading_replica_sync_replication_slots(self):
         """Test sync with a cascading replica so physical slots are present on a replica."""
         config = ClusterConfig(1, {'slots': {'ls': {'database': 'a', 'plugin': 'b'}}}, 1)

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -425,7 +425,7 @@ class TestSlotsHandler(BaseTestPostgresql):
         with patch.object(SlotsHandler, '_query', Mock(side_effect=[[('test_1', 'physical', 1, 12345, None, None,
                                                                       None, None, None)], Exception])) as mock_query:
             self.s.sync_replication_slots(cluster, self.tags)
-            self.assertTrue(mock_query.call_args[0][0].startswith('SELECT slot_name, slot_type, xmin, '))
+            self.assertTrue(mock_query.call_args[0][0].startswith('SELECT slot_name, slot_type AS type, xmin, '))
 
     def test__drop_replication_slot(self):
         """Test the :meth:~SlotsHandler._drop_replication_slot` method."""


### PR DESCRIPTION
_ensure_logical_slots_primary() and _ensure_logical_slots_replica() were not copying over
 this fields to the final struct wich was resulting in KeyError exceptions in _drop_incorrect_failover_synced_slots
and in _drop_incorrect_slots.
Apart from that, ensure these fields are updated in process_permanent_slots and the main monitoring query has the same slots filtering as the load_replication_slots query

follow-up for: https://github.com/patroni/patroni/pull/3493