### PR TITLE
Add `patroni_failover_priority` Prometheus metric

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -364,6 +364,9 @@ Retrieve the Patroni metrics in Prometheus format through the ``GET /metrics`` e
 	# Values: 0=initdb, 1=initdb_failed, 2=custom_bootstrap, 3=custom_bootstrap_failed, 4=creating_replica, 5=running, 6=starting, 7=bootstrap_starting, 8=start_failed, 9=restarting, 10=restart_failed, 11=stopping, 12=stopped, 13=stop_failed, 14=crashed
 	# TYPE patroni_postgres_state gauge
 	patroni_postgres_state{scope="batman",name="patroni1"} 5
+	# HELP patroni_failover_priority Failover priority of this node.
+	# TYPE patroni_failover_priority gauge
+	patroni_failover_priority{scope="batman",name="patroni1"} 1
 
 PostgreSQL State Values
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -616,6 +616,8 @@ class RestApiHandler(BaseHTTPRequestHandler):
             * ``patroni_failsafe_mode_is_active``: ``1`` if ``failsafe_mode`` is currently active, else ``0``;
             * ``patroni_failsafe_mode_enabled``: ``1`` if ``failsafe_mode`` is enabled in configuration, else ``0``;
             * ``patroni_failsafe_member``: ``1`` if this node is a member of failsafe topology, else ``0``;
+            * ``patroni_failover_priority``: failover priority of this node (``0`` if ``nofailover`` is set, else value
+              of ``failover_priority`` tag, defaulting to ``1``);
             * ``patroni_postgres_timeline``: PostgreSQL timeline based on current WAL file name;
             * ``patroni_dcs_last_seen``: epoch timestamp when DCS was last contacted successfully;
             * ``patroni_pending_restart``: ``1`` if this PostgreSQL node is pending a restart, else ``0``;
@@ -761,6 +763,10 @@ class RestApiHandler(BaseHTTPRequestHandler):
         current_state = postgres['state']
         state_value = current_state.index if isinstance(current_state, PostgresqlState) else -1
         metrics.append(f"patroni_postgres_state{labels} {state_value}")
+
+        metrics.append("# HELP patroni_failover_priority Failover priority of this node.")
+        metrics.append("# TYPE patroni_failover_priority gauge")
+        metrics.append("patroni_failover_priority{0} {1}".format(labels, patroni.failover_priority))
 
         self.write_response(200, '\n'.join(metrics) + '\n', content_type='text/plain')
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -162,6 +162,7 @@ class MockPatroni(object):
     tags = {"key1": True, "key2": False, "key3": 1, "key4": 1.4, "key5": "RandomTag"}
     version = '0.00'
     noloadbalance = PropertyMock(return_value=False)
+    failover_priority = 1
     scheduled_restart = {'schedule': future_restart_time,
                          'postmaster_start_time': postgresql.postmaster_start_time()}
 


### PR DESCRIPTION
Expose the failover priority of the node via the /metrics endpoint. The metric is a gauge that returns 0 if the node has nofailover=true set, otherwise returns the value of the failover_priority tag (defaulting to 1 if not configured).

This allows Prometheus monitoring and alerting on node failover priorities across a Patroni cluster, making it easier to understand and track the leader election preferences for each node.

- Add patroni_failover_priority gauge to do_GET_metrics() output
- Document the new metric in the /metrics endpoint docstring
- Add example output to rest_api.rst documentation

Fixes #3578 