### PR TITLE
doco(config): remove incorrect plural from "retry_timeout" parameter

### DIFF
--- a/docs/patroni_configuration.rst
+++ b/docs/patroni_configuration.rst
@@ -45,7 +45,7 @@ Some of the PostgreSQL parameters **must hold the same values on the primary and
 - **max_worker_processes**: default value 8, minimal value 2
 - **max_prepared_transactions**: default value 0, minimal value 0
 - **wal_level**: default value hot_standby, accepted values: hot_standby, replica, logical
-- **track_commit_timestamp**: default value off 
+- **track_commit_timestamp**: default value off
 
 For the parameters below, PostgreSQL does not require equal values among the primary and all the replicas. However, considering the possibility of a replica to become the primary at any time, it doesn't really make sense to set them differently; therefore, **Patroni restricts setting their values to the** :ref:`dynamic configuration <dynamic_configuration>`.
 
@@ -136,7 +136,7 @@ Also the following Patroni configuration options **can be changed only dynamical
 
 - **ttl**: 30
 - **loop_wait**: 10
-- **retry_timeouts**: 10
+- **retry_timeout**: 10
 - **maximum_lag_on_failover**: 1048576
 - **max_timelines_history**: 0
 - **check_timeline**: false
@@ -198,7 +198,7 @@ Patroni configuration for a running instance
 Description
 """""""""""
 
-Generate a Patroni configuration in ``yaml`` format for the locally running PostgreSQL instance. 
+Generate a Patroni configuration in ``yaml`` format for the locally running PostgreSQL instance.
 Either the provided DSN (takes precedence) or PostgreSQL `environment variables <https://www.postgresql.org/docs/current/libpq-envars.html>`__ will be used for the PostgreSQL connection. If the password is not provided, it should be entered via prompt.
 
 All the non-internal GUCs defined in the source Postgres instance, independently if they were set through a configuration file, through the postmaster command-line, or through environment variables, will be used as the source for the following Patroni configuration parameters:


### PR DESCRIPTION
Documentation has an added "s" to the "retry_timeout" parameter