### PR TITLE
fix: retry statement_timeout cancellation instead of failing over

### DIFF
--- a/patroni/postgresql/connection.py
+++ b/patroni/postgresql/connection.py
@@ -73,6 +73,12 @@ class NamedConnection:
             with self.get().cursor() as cursor:
                 cursor.execute(sql.encode('utf-8'), params or None)
                 return cursor.fetchall() if cursor.rowcount and cursor.rowcount > 0 else []
+        except psycopg.QueryCanceled as exc:
+            # A statement_timeout cancellation (e.g. of Patroni's own monitoring query when PostgreSQL is
+            # overloaded) leaves the connection healthy and reusable, and with `autocommit` there is no aborted
+            # transaction to clean up. We wrap it as PostgresConnectionException so that it is retried the same
+            # way as other transient failures, while keeping the connection open to avoid a needless reconnect.
+            raise PostgresConnectionException('query timeout') from exc
         except psycopg.Error as exc:
             if cursor and cursor.connection.closed == 0:
                 # When connected via unix socket, psycopg2 can't recognize 'connection lost' and leaves

--- a/patroni/psycopg.py
+++ b/patroni/psycopg.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from psycopg2 import connection, cursor
 
 __all__ = ['connect', 'parse_conninfo', 'quote_ident', 'quote_literal',
-           'DatabaseError', 'Error', 'OperationalError', 'ProgrammingError']
+           'DatabaseError', 'Error', 'OperationalError', 'ProgrammingError', 'QueryCanceled']
 
 _legacy = False
 try:
@@ -21,7 +21,9 @@ try:
     if parse_version(__version__) < MIN_PSYCOPG2:
         raise ImportError
     from psycopg2 import connect as _connect, DatabaseError, Error, OperationalError, ProgrammingError
-    from psycopg2.extensions import adapt
+    # ``psycopg2.errors.QueryCanceled`` only exists since psycopg2 2.8, but the alias in
+    # ``psycopg2.extensions`` has been available for much longer, hence is compatible with MIN_PSYCOPG2.
+    from psycopg2.extensions import adapt, QueryCanceledError as QueryCanceled
 
     try:
         from psycopg2.extensions import parse_dsn, quote_ident as __quote_ident
@@ -73,6 +75,7 @@ except ImportError:
     import types
 
     from psycopg import DatabaseError, Error, OperationalError, ProgrammingError, sql
+    from psycopg.errors import QueryCanceled
     # isort: off
     from psycopg import connect as __connect  # pyright: ignore [reportUnknownVariableType]
     from psycopg.conninfo import conninfo_to_dict as _parse_conninfo

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -132,6 +132,8 @@ class MockCursor(object):
             raise psycopg.ProgrammingError()
         elif sql == 'CHECKPOINT' or sql.startswith('SELECT pg_catalog.pg_create_'):
             raise psycopg.OperationalError()
+        elif sql.startswith('QueryCanceled'):
+            raise psycopg.QueryCanceled()
         elif sql.startswith('RetryFailedError'):
             raise RetryFailedError('retry')
         elif sql.startswith('SELECT slot_name, catalog_xmin'):

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -25,6 +25,7 @@ from patroni.postgresql import PgIsReadyStatus, Postgresql
 from patroni.postgresql.bootstrap import Bootstrap
 from patroni.postgresql.callback_executor import CallbackAction
 from patroni.postgresql.config import _false_validator, get_param_diff
+from patroni.postgresql.connection import NamedConnection
 from patroni.postgresql.misc import PostgresqlRole, PostgresqlState
 from patroni.postgresql.postmaster import PostmasterProcess
 from patroni.postgresql.validator import _get_postgres_guc_validators, _load_postgres_gucs_validators, \
@@ -390,6 +391,13 @@ class TestPostgresql(BaseTestPostgresql):
         self.p.query('select 1')
         self.assertRaises(PostgresConnectionException, self.p.query, 'RetryFailedError')
         self.assertRaises(psycopg.ProgrammingError, self.p.query, 'blabla')
+
+    def test_query_timeout(self):
+        # A statement_timeout cancellation must be wrapped as PostgresConnectionException so that it is retried,
+        # while the connection stays open because it remains healthy and reusable.
+        with patch.object(NamedConnection, 'close') as mock_close:
+            self.assertRaises(PostgresConnectionException, self.p._connection.query, 'QueryCanceled')
+            mock_close.assert_not_called()
 
     @patch.object(Postgresql, 'pg_isready', Mock(return_value=PgIsReadyStatus.REJECT))
     def test_is_primary(self):


### PR DESCRIPTION
A statement_timeout cancellation comes back from psycopg as QueryCanceled, which is a subclass of OperationalError. The exact-type check in NamedConnection.query (`type(exc) in (DatabaseError, OperationalError)`) did not match it, so it was re-raised raw rather than wrapped as PostgresConnectionException. Since Retry only retries PostgresConnectionException, a single slow monitoring query (e.g. when PostgreSQL is briefly overloaded) was never retried and could poison the heart-beat cycle, leading the leader to demote itself.

Catch QueryCanceled explicitly and wrap it as PostgresConnectionException so it is retried the same way as other transient failures. The connection is left open because a statement_timeout cancellation leaves the session healthy and reusable, and with autocommit there is no aborted transaction to clean up.