### PR TITLE
Include database name in connection key for CitusDatabaseHandler

### DIFF
--- a/patroni/postgresql/mpp/citus.py
+++ b/patroni/postgresql/mpp/citus.py
@@ -399,8 +399,9 @@ class CitusDatabaseHandler(Citus, Thread):
         self.daemon = True
         if config:
             self._connection = postgresql.connection_pool.get(
-                'citus', {'dbname': config['database'],
-                          'options': '-c statement_timeout=0 -c idle_in_transaction_session_timeout=0'})
+                f'citus-{config["database"]}',
+                {'dbname': config['database'],
+                 'options': '-c statement_timeout=0 -c idle_in_transaction_session_timeout=0'})
         self._pg_dist_group: Dict[int, PgDistTask] = {}  # Cache of pg_dist_node: {groupid: PgDistTask()}
         self._tasks: List[PgDistTask] = []  # Requests to change pg_dist_group, every task is a `PgDistTask`
         self._in_flight: Optional[PgDistTask] = None  # Reference to the `PgDistTask` being changed in a transaction


### PR DESCRIPTION
I used patroni with branch feature/multi-citus and deployed citus cluster with multi databases. But only the metadata of the first database could be updated. I noticed all CitusDatabaseHandler instances use 'citus' as the key, so only the first handler will create a new connection; all subsequent handlers will reuse the same NamedConnection object—which points to the first database. So I used the database name to distinguish connection keys and verified OK. 