### PR TITLE
Fix Prometheus metric type for `patroni_postgres_timeline`

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -349,7 +349,7 @@ Retrieve the Patroni metrics in Prometheus format through the ``GET /metrics`` e
 	# TYPE patroni_failsafe_member gauge
 	patroni_failsafe_member{scope="batman",name="patroni1"} 0
 	# HELP patroni_postgres_timeline Postgres timeline of this node (if running), 0 otherwise.
-	# TYPE patroni_postgres_timeline counter
+	# TYPE patroni_postgres_timeline gauge
 	patroni_postgres_timeline{scope="batman",name="patroni1"} 24
 	# HELP patroni_dcs_last_seen Epoch timestamp when DCS was last contacted successfully by Patroni.
 	# TYPE patroni_dcs_last_seen gauge

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -714,7 +714,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
 
         metrics.append("# HELP patroni_postgres_server_version Version of Postgres (if running), 0 otherwise.")
         metrics.append("# TYPE patroni_postgres_server_version gauge")
-        metrics.append("patroni_postgres_server_version {0} {1}".format(labels, postgres.get('server_version', 0)))
+        metrics.append("patroni_postgres_server_version{0} {1}".format(labels, postgres.get('server_version', 0)))
 
         metrics.append("# HELP patroni_cluster_unlocked Value is 1 if the cluster is unlocked, 0 if locked.")
         metrics.append("# TYPE patroni_cluster_unlocked gauge")

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -736,7 +736,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("patroni_failsafe_member{0} {1}".format(labels, int(is_failsafe_member)))
 
         metrics.append("# HELP patroni_postgres_timeline Postgres timeline of this node (if running), 0 otherwise.")
-        metrics.append("# TYPE patroni_postgres_timeline counter")
+        metrics.append("# TYPE patroni_postgres_timeline gauge")
         metrics.append("patroni_postgres_timeline{0} {1}".format(labels, postgres.get('timeline') or 0))
 
         metrics.append("# HELP patroni_dcs_last_seen Epoch timestamp when DCS was last contacted successfully"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -426,9 +426,6 @@ class TestRestApiHandler(unittest.TestCase):
 
     @patch.object(MockPatroni, 'dcs')
     def test_do_GET_metrics(self, mock_dcs):
-        with patch.object(RestApiHandler, 'write_response') as mock_write:
-            MockRestApiServer(RestApiHandler, 'GET /metrics')
-            self.assertIn('# TYPE patroni_postgres_timeline gauge', mock_write.call_args[0][1])
         self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /metrics'))
         # Test with failsafe_mode enabled
         with patch.object(MockHa, 'is_failsafe_mode', Mock(return_value=True)):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -426,6 +426,9 @@ class TestRestApiHandler(unittest.TestCase):
 
     @patch.object(MockPatroni, 'dcs')
     def test_do_GET_metrics(self, mock_dcs):
+        with patch.object(RestApiHandler, 'write_response') as mock_write:
+            MockRestApiServer(RestApiHandler, 'GET /metrics')
+            self.assertIn('# TYPE patroni_postgres_timeline gauge', mock_write.call_args[0][1])
         self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /metrics'))
         # Test with failsafe_mode enabled
         with patch.object(MockHa, 'is_failsafe_mode', Mock(return_value=True)):


### PR DESCRIPTION
While I was reviewing the api.py to review prometheus metrics I realised `patroni_postgres_timeline` is declared as `counter` in the `/metrics` endpoint. Prometheus counters must only ever increase, but the metric's own HELP text documents that it drops to `0` when PostgreSQL is not running: "Postgres timeline of this node (if running), 0 otherwise."

Every PostgreSQL restart — via `patronictl restart`, a config change requiring restart, or crash recovery — produces the scrape sequence `1 → 0 → 1`. Prometheus interprets the drop as a counter reset and applies reset compensation:

```bash
  increase(patroni_postgres_timeline[5m]) = 2   (should be 0)
  rate(patroni_postgres_timeline[5m])     > 0   (should be 0)
```

**Any alert on timeline changes such as `increase(patroni_postgres_timeline[5m]) > 0` fires on every routine restart rather than only on actual failovers.**

The metric represents current state, not a cumulative count. Change its declared type from `counter` to `gauge`.

To prevent false positive timeline alerts on the prometheus side we can update the type of the metric. 
