### PR TITLE
Extend `Assigning synchronous_standby_names` log with added/removed members

### DIFF
--- a/patroni/postgresql/sync.py
+++ b/patroni/postgresql/sync.py
@@ -311,18 +311,12 @@ class SyncHandler(object):
         if synchronous_standby_names == self._synchronous_standby_names:
             return
 
-        old_members = self._ssn_data.members
         self._synchronous_standby_names = synchronous_standby_names
         try:
             self._ssn_data = parse_sync_standby_names(synchronous_standby_names)
         except ValueError as e:
             logger.warning('%s', e)
             self._ssn_data = deepcopy(_EMPTY_SSN)
-
-        added = sorted(self._ssn_data.members - old_members)
-        removed = sorted(old_members - self._ssn_data.members)
-        if added or removed:
-            logger.info('`synchronous_standby_names` changed: added=%s removed=%s', added, removed)
 
         # Invalidate cache of "sync" connections
         for app_name in list(self._ready_replicas.keys()):
@@ -429,6 +423,7 @@ END;$$""")
         """
         # Special case. If sync nodes set is empty but requested num of sync nodes >= 1
         # we want to set synchronous_standby_names to '__patroni_strict_sync_replica_placeholder__'
+        _new_members = CaseInsensitiveSet([s for s in sync if s != '*'])
         sync_strict = '*' in sync or num and num >= 1 and not sync
         if sync_strict:
             sync = [SYNC_STRICT_PLACEHOLDER]
@@ -447,7 +442,13 @@ END;$$""")
             sync_param = f'{prefix}{num} ({sync_param})'
 
         if sync_param is not None:
-            logger.info("Assigning synchronous_standby_names to %s", sync_param)
+            _old = self._ssn_data.members
+            _added = tuple(sorted(_new_members - _old))
+            _removed = tuple(sorted(_old - _new_members))
+            if _added or _removed:
+                logger.info("Assigning synchronous_standby_names to %s (added=%s removed=%s)", sync_param, _added, _removed)
+            else:
+                logger.info("Assigning synchronous_standby_names to %s", sync_param)
 
         if not (self._postgresql.config.set_synchronous_standby_names(sync_param)
                 and self._postgresql.state == PostgresqlState.RUNNING

--- a/patroni/postgresql/sync.py
+++ b/patroni/postgresql/sync.py
@@ -443,10 +443,13 @@ END;$$""")
 
         if sync_param is not None:
             _old = self._ssn_data.members
-            _added = tuple(sorted(_new_members - _old))
-            _removed = tuple(sorted(_old - _new_members))
+            _added = sorted(_new_members - _old)
+            _removed = sorted(_old - _new_members)
             if _added or _removed:
-                logger.info("Assigning synchronous_standby_names to %s (added=%s removed=%s)", sync_param, _added, _removed)
+                def _fmt(ns: List[str]) -> str:
+                    return '(' + ', '.join(repr(n) for n in ns) + ')'
+                logger.info("Assigning synchronous_standby_names to %s (added=%s removed=%s)",
+                            sync_param, _fmt(_added), _fmt(_removed))
             else:
                 logger.info("Assigning synchronous_standby_names to %s", sync_param)
 

--- a/patroni/postgresql/sync.py
+++ b/patroni/postgresql/sync.py
@@ -446,10 +446,8 @@ END;$$""")
             _added = sorted(_new_members - _old)
             _removed = sorted(_old - _new_members)
             if _added or _removed:
-                def _fmt(ns: List[str]) -> str:
-                    return '(' + ', '.join(repr(n) for n in ns) + ')'
                 logger.info("Assigning synchronous_standby_names to %s (added=%s removed=%s)",
-                            sync_param, _fmt(_added), _fmt(_removed))
+                            sync_param, _added, _removed)
             else:
                 logger.info("Assigning synchronous_standby_names to %s", sync_param)
 

--- a/patroni/postgresql/sync.py
+++ b/patroni/postgresql/sync.py
@@ -311,12 +311,18 @@ class SyncHandler(object):
         if synchronous_standby_names == self._synchronous_standby_names:
             return
 
+        old_members = self._ssn_data.members
         self._synchronous_standby_names = synchronous_standby_names
         try:
             self._ssn_data = parse_sync_standby_names(synchronous_standby_names)
         except ValueError as e:
             logger.warning('%s', e)
             self._ssn_data = deepcopy(_EMPTY_SSN)
+
+        added = sorted(self._ssn_data.members - old_members)
+        removed = sorted(old_members - self._ssn_data.members)
+        if added or removed:
+            logger.info('`synchronous_standby_names` changed: added=%s removed=%s', added, removed)
 
         # Invalidate cache of "sync" connections
         for app_name in list(self._ready_replicas.keys()):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -196,39 +196,28 @@ class TestSync(BaseTestPostgresql):
         mock_reload.assert_called()
         self.assertEqual(value_in_conf(), "synchronous_standby_names = '\"a-1\"'")
 
-    @patch.object(Postgresql, 'last_operation', Mock(return_value=1))
-    @patch.object(Postgresql, 'query', Mock())
-    @patch.object(Postgresql, 'reset_cluster_info_state', Mock())
-    def test_handle_synchronous_standby_names_change(self):
-        # No change — no log emitted
-        with patch.object(Postgresql, 'synchronous_standby_names', return_value=''):
-            with self.assertLogs('patroni.postgresql.sync', level='INFO') as logs:
-                self.s._handle_synchronous_standby_names_change()
-                # force at least one log so assertLogs doesn't fail on empty
-                logging.getLogger('patroni.postgresql.sync').info('_baseline_')
-        self.assertFalse(any('`synchronous_standby_names` changed' in m for m in logs.output))
+    @patch('time.sleep', Mock())
+    def test_set_sync_standby_log_diff(self):
+        self.p.reload = Mock()
 
-        # Member added
-        with patch.object(Postgresql, 'synchronous_standby_names', return_value='patroni2'):
-            with self.assertLogs('patroni.postgresql.sync', level='INFO') as logs:
-                self.s._handle_synchronous_standby_names_change()
-        self.assertTrue(any("added=['patroni2'] removed=[]" in m for m in logs.output))
+        # Add n1 from empty state — diff shown
+        with self.assertLogs('patroni.postgresql.sync', level='INFO') as logs:
+            self.s.set_synchronous_standby_names(CaseInsensitiveSet(['n1']))
+        self.assertTrue(any("added=('n1',) removed=()" in m for m in logs.output))
 
-        # Member removed
-        with patch.object(Postgresql, 'synchronous_standby_names', return_value=''):
-            with self.assertLogs('patroni.postgresql.sync', level='INFO') as logs:
-                self.s._handle_synchronous_standby_names_change()
-        self.assertTrue(any("added=[] removed=['patroni2']" in m for m in logs.output))
+        # Simulate confirmation: advance _ssn_data as _handle_... would
+        self.s._ssn_data = self.s._ssn_data._replace(members=CaseInsensitiveSet(['n1']))
 
-        # Member swapped
-        with patch.object(Postgresql, 'synchronous_standby_names', return_value='patroni3'):
-            with self.assertLogs('patroni.postgresql.sync', level='INFO') as logs:
-                self.s._handle_synchronous_standby_names_change()
-        self.assertTrue(any("added=['patroni3'] removed=[]" in m for m in logs.output))
-        with patch.object(Postgresql, 'synchronous_standby_names', return_value='patroni4'):
-            with self.assertLogs('patroni.postgresql.sync', level='INFO') as logs:
-                self.s._handle_synchronous_standby_names_change()
-        self.assertTrue(any("added=['patroni4'] removed=['patroni3']" in m for m in logs.output))
+        # Same members — no diff appended to log
+        with self.assertLogs('patroni.postgresql.sync', level='INFO') as logs:
+            self.s.set_synchronous_standby_names(CaseInsensitiveSet(['n1']))
+            logging.getLogger('patroni.postgresql.sync').info('_baseline_')
+        self.assertFalse(any('(added=' in m for m in logs.output))
+
+        # Swap n1 for n2 — both sides shown
+        with self.assertLogs('patroni.postgresql.sync', level='INFO') as logs:
+            self.s.set_synchronous_standby_names(CaseInsensitiveSet(['n2']))
+        self.assertTrue(any("added=('n2',) removed=('n1',)" in m for m in logs.output))
 
     @patch.object(Postgresql, 'last_operation', Mock(return_value=0))
     @patch.object(Postgresql, 'query', Mock())

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -203,7 +203,7 @@ class TestSync(BaseTestPostgresql):
         # Add n1 from empty state — diff shown
         with self.assertLogs('patroni.postgresql.sync', level='INFO') as logs:
             self.s.set_synchronous_standby_names(CaseInsensitiveSet(['n1']))
-        self.assertTrue(any("added=('n1') removed=()" in m for m in logs.output))
+        self.assertTrue(any("added=['n1'] removed=[]" in m for m in logs.output))
 
         # Simulate confirmation: advance _ssn_data as _handle_... would
         self.s._ssn_data = self.s._ssn_data._replace(members=CaseInsensitiveSet(['n1']))
@@ -212,12 +212,12 @@ class TestSync(BaseTestPostgresql):
         with self.assertLogs('patroni.postgresql.sync', level='INFO') as logs:
             self.s.set_synchronous_standby_names(CaseInsensitiveSet(['n1']))
             logging.getLogger('patroni.postgresql.sync').info('_baseline_')
-        self.assertFalse(any('(added=' in m for m in logs.output))
+        self.assertFalse(any('added=[' in m for m in logs.output))
 
         # Swap n1 for n2 — both sides shown
         with self.assertLogs('patroni.postgresql.sync', level='INFO') as logs:
             self.s.set_synchronous_standby_names(CaseInsensitiveSet(['n2']))
-        self.assertTrue(any("added=('n2') removed=('n1')" in m for m in logs.output))
+        self.assertTrue(any("added=['n2'] removed=['n1']" in m for m in logs.output))
 
     @patch.object(Postgresql, 'last_operation', Mock(return_value=0))
     @patch.object(Postgresql, 'query', Mock())

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -203,7 +203,7 @@ class TestSync(BaseTestPostgresql):
         # Add n1 from empty state — diff shown
         with self.assertLogs('patroni.postgresql.sync', level='INFO') as logs:
             self.s.set_synchronous_standby_names(CaseInsensitiveSet(['n1']))
-        self.assertTrue(any("added=('n1',) removed=()" in m for m in logs.output))
+        self.assertTrue(any("added=('n1') removed=()" in m for m in logs.output))
 
         # Simulate confirmation: advance _ssn_data as _handle_... would
         self.s._ssn_data = self.s._ssn_data._replace(members=CaseInsensitiveSet(['n1']))
@@ -217,7 +217,7 @@ class TestSync(BaseTestPostgresql):
         # Swap n1 for n2 — both sides shown
         with self.assertLogs('patroni.postgresql.sync', level='INFO') as logs:
             self.s.set_synchronous_standby_names(CaseInsensitiveSet(['n2']))
-        self.assertTrue(any("added=('n2',) removed=('n1',)" in m for m in logs.output))
+        self.assertTrue(any("added=('n2') removed=('n1')" in m for m in logs.output))
 
     @patch.object(Postgresql, 'last_operation', Mock(return_value=0))
     @patch.object(Postgresql, 'query', Mock())

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 from unittest.mock import Mock, patch
@@ -196,6 +197,43 @@ class TestSync(BaseTestPostgresql):
         self.assertEqual(value_in_conf(), "synchronous_standby_names = '\"a-1\"'")
 
     @patch.object(Postgresql, 'last_operation', Mock(return_value=1))
+    @patch.object(Postgresql, 'last_operation', Mock(return_value=1))
+    @patch.object(Postgresql, 'query', Mock())
+    @patch.object(Postgresql, 'reset_cluster_info_state', Mock())
+    def test_handle_synchronous_standby_names_change(self):
+        # No change — no log emitted
+        with patch.object(Postgresql, 'synchronous_standby_names', return_value=''):
+            with self.assertLogs('patroni.postgresql.sync', level='INFO') as logs:
+                self.s._handle_synchronous_standby_names_change()
+                # force at least one log so assertLogs doesn't fail on empty
+                logging.getLogger('patroni.postgresql.sync').info('_baseline_')
+        self.assertFalse(any('`synchronous_standby_names` changed' in m for m in logs.output))
+
+        # Member added
+        with patch.object(Postgresql, 'synchronous_standby_names', return_value='patroni2'):
+            with self.assertLogs('patroni.postgresql.sync', level='INFO') as logs:
+                self.s._handle_synchronous_standby_names_change()
+        self.assertTrue(any("added=['patroni2'] removed=[]" in m for m in logs.output))
+
+        # Member removed
+        with patch.object(Postgresql, 'synchronous_standby_names', return_value=''):
+            with self.assertLogs('patroni.postgresql.sync', level='INFO') as logs:
+                self.s._handle_synchronous_standby_names_change()
+        self.assertTrue(any("added=[] removed=['patroni2']" in m for m in logs.output))
+
+        # Member swapped
+        with patch.object(Postgresql, 'synchronous_standby_names', return_value='patroni3'):
+            with self.assertLogs('patroni.postgresql.sync', level='INFO') as logs:
+                self.s._handle_synchronous_standby_names_change()
+        self.assertTrue(any("added=['patroni3'] removed=[]" in m for m in logs.output))
+        with patch.object(Postgresql, 'synchronous_standby_names', return_value='patroni4'):
+            with self.assertLogs('patroni.postgresql.sync', level='INFO') as logs:
+                self.s._handle_synchronous_standby_names_change()
+        self.assertTrue(any("added=['patroni4'] removed=['patroni3']" in m for m in logs.output))
+
+    @patch.object(Postgresql, 'last_operation', Mock(return_value=0))
+    @patch.object(Postgresql, 'query', Mock())
+    @patch.object(Postgresql, 'reset_cluster_info_state', Mock())
     def test_do_not_prick_yourself(self):
         self.p.name = self.leadermem.name
         cluster = Cluster(True, None, self.leader, 0, [self.me, self.other, self.leadermem], None,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -197,7 +197,6 @@ class TestSync(BaseTestPostgresql):
         self.assertEqual(value_in_conf(), "synchronous_standby_names = '\"a-1\"'")
 
     @patch.object(Postgresql, 'last_operation', Mock(return_value=1))
-    @patch.object(Postgresql, 'last_operation', Mock(return_value=1))
     @patch.object(Postgresql, 'query', Mock())
     @patch.object(Postgresql, 'reset_cluster_info_state', Mock())
     def test_handle_synchronous_standby_names_change(self):


### PR DESCRIPTION

I was reading the patroni logs during an investigation and realised that emitted logs about synchronous_standby_names doesn't reveal the difference. Put another way: I couldn't see the which instance removed and added to synchronous_standby_names during the problem. 

This refactoring is about enhancing the log only. It does not change where the log is emitted, does not add a new log location, and does not alter any existing behavior or log message. **It extends the existing `"Assigning synchronous_standby_names to …"` line which has always been emitted from `set_synchronous_standby_names()`**

New logs will be emitted as follow

```
INFO: Assigning synchronous_standby_names to patroni1 (added=['patroni1'] removed=[])
INFO: Assigning synchronous_standby_names to 2 (patroni1,patroni2) (added=['patroni2'] removed=[])
INFO: Assigning synchronous_standby_names to patroni1 (added=[] removed=['patroni2'])
```

When the member set is unchanged (e.g. Patroni re-confirms the same replica) the original plain form is preserved:

```
INFO: Assigning synchronous_standby_names to patroni1
```

With the enhanced log we can immediately answer:

- *Which replica just became synchronous?* → look for `added=(...)` 
- *Which replica left the sync set?* → look for `removed=(...)`
- *Was patroni2 removed before or after the outage?* → timestamp on the line with `removed=('patroni2')` answers it directly
