### PR TITLE
Handle pg_rewind while postgres is starting as standby

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -777,10 +777,9 @@ class Ha(object):
                 self.state_handler.get_history(self._leader_timeline + 1):
             self._rewind.trigger_check_diverged_lsn()
 
-        if not self.state_handler.is_starting():
-            msg = self._handle_rewind_or_reinitialize()
-            if msg:
-                return msg
+        msg = self._handle_rewind_or_reinitialize()
+        if msg:
+            return msg
 
         if not self.is_paused():
             self.state_handler.handle_parameter_change()
@@ -808,10 +807,9 @@ class Ha(object):
 
                 if self._last_timeline and self._leader_timeline and self._last_timeline < self._leader_timeline:
                     self._rewind.trigger_check_diverged_lsn()
-                    if not self.state_handler.is_starting():
-                        msg = self._handle_rewind_or_reinitialize()
-                        if msg:
-                            return msg
+                    msg = self._handle_rewind_or_reinitialize()
+                    if msg:
+                        return msg
 
         return follow_reason
 

--- a/patroni/postgresql/rewind.py
+++ b/patroni/postgresql/rewind.py
@@ -195,11 +195,19 @@ class Rewind(object):
         return in_recovery, timeline, lsn
 
     def _get_local_timeline_lsn(self) -> Tuple[Optional[bool], Optional[int], Optional[int]]:
+        in_recovery = timeline = lsn = None
         if self._postgresql.is_running():  # if postgres is running - get timeline from replication connection
+            try:
+                timeline = self._postgresql.get_replica_timeline()
+                lsn = self._postgresql.replay_lsn()
+            except Exception:
+                if not self._postgresql.is_starting():
+                    return None, None, None
+                logger.info('PostgreSQL is still starting, will use pg_controldata as a fallback')
             in_recovery = True
-            timeline = self._postgresql.get_replica_timeline()
-            lsn = self._postgresql.replay_lsn()
-        else:  # otherwise analyze pg_controldata output
+
+        if timeline is None and lsn is None:
+            # analyze pg_controldata output if not running or not accepting connections
             in_recovery, timeline, lsn = self._get_local_timeline_lsn_from_controldata()
 
         log_lsn = format_lsn(lsn) if isinstance(lsn, int) else lsn

--- a/tests/test_rewind.py
+++ b/tests/test_rewind.py
@@ -176,10 +176,22 @@ class TestRewind(BaseTestPostgresql):
             self.r.rewind_or_reinitialize_needed_and_possible(self.leader)
 
         with patch.object(Postgresql, 'is_running', Mock(return_value=True)), \
-                patch.object(MockCursor, 'fetchone', Mock(side_effect=Exception)), \
-                patch.object(MockCursor, 'fetchall',
-                             Mock(return_value=[(0, 0, 1, 1, 0, 0, 0, 0, 0, None, None, None)])):
-            self.r.rewind_or_reinitialize_needed_and_possible(self.leader)
+                patch.object(MockCursor, 'fetchone', Mock(side_effect=Exception)):
+            with patch.object(MockCursor, 'fetchall',
+                              Mock(return_value=[(0, 0, 1, 1, 0, 0, 0, 0, 0, None, None, None)])):
+                self.r.rewind_or_reinitialize_needed_and_possible(self.leader)
+
+            self.p.reset_cluster_info_state(None)
+            with patch.object(MockCursor, 'fetchall', Mock(side_effect=Exception)):
+                self.r.rewind_or_reinitialize_needed_and_possible(self.leader)
+
+                with patch.object(Postgresql, 'controldata',
+                                  Mock(return_value={'Database cluster state': 'in archive recovery',
+                                                     'Minimum recovery ending location': '0/1',
+                                                     "Min recovery ending loc's timeline": '1',
+                                                     'Latest checkpoint location': '0/1'})), \
+                        patch.object(Postgresql, 'is_starting', Mock(return_value=True)):
+                    self.r.rewind_or_reinitialize_needed_and_possible(self.leader)
 
     @patch.object(CancellableSubprocess, 'call', mock_cancellable_call)
     @patch.object(Postgresql, 'get_guc_value', Mock(return_value=''))


### PR DESCRIPTION
It is achieved by modifying _get_local_timeline_lsn() method so that it uses pg_controldata as a fallback when postgres is running but not yet accepting connections and remove not is_starting restrictions in ha.py

Close #3650