### PR TITLE
Add `patroni_logical_slot_active` Prometheus metric

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -465,20 +465,6 @@ The ``managedby`` label bridges this gap: it is derived by cross-referencing eac
 against ``permanent_slots`` — information already in memory inside the Patroni process,
 requiring no extra DCS call.
 
-This makes it possible to write alert rules that were previously not expressible:
-
-.. code-block:: yaml
-
-    # Unmanaged slot has lost its consumer — WAL will accumulate indefinitely
-    - alert: LogicalSlotOtherInactive
-      expr: patroni_logical_slot_active{managedby="other"} == 0
-      for: 5m
-
-    # Active unmanaged slots exist — these will be lost on failover (PG < 17)
-    - alert: LogicalSlotOtherActivePreFailover
-      expr: patroni_logical_slot_active{managedby="other"} == 1
-      for: 0m
-
 
 Cluster status endpoints
 ------------------------

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -367,6 +367,10 @@ Retrieve the Patroni metrics in Prometheus format through the ``GET /metrics`` e
 	# HELP patroni_failover_priority Failover priority of this node.
 	# TYPE patroni_failover_priority gauge
 	patroni_failover_priority{scope="batman",name="patroni1"} 1
+	# HELP patroni_logical_slot_active Value is 1 if the logical replication slot has an active consumer, 0 otherwise.
+	# TYPE patroni_logical_slot_active gauge
+	patroni_logical_slot_active{scope="batman",name="patroni1",slot="cdc_slot",managedby="patroni"} 1
+	patroni_logical_slot_active{scope="batman",name="patroni1",slot="old_slot",managedby="other"} 0
 
 PostgreSQL State Values
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -428,6 +432,52 @@ The ``patroni_postgres_state`` metric provides a numeric representation of the c
 
 .. note::
    These numeric values are fixed and will never change to maintain backward compatibility with existing monitoring systems. If new states are added in the future, they will be assigned new numeric values without changing existing ones.
+
+Logical Replication Slot Metrics
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``patroni_logical_slot_active`` is a per-slot gauge that exposes the ``active`` field from
+``pg_catalog.pg_replication_slots`` for every logical slot on the node. The value is ``1``
+when a consumer is connected and ``0`` when the slot has no active consumer. The metric is
+emitted only when PostgreSQL is reachable and at least one logical slot exists; if the query
+fails, the metric is omitted for that scrape and all other metrics are unaffected.
+
+Each series carries four labels:
+
+- ``scope``: cluster scope name.
+- ``name``: this Patroni node's name.
+- ``slot``: the slot name from ``pg_replication_slots``.
+- ``managedby``: ``patroni`` if the slot is listed in ``permanent_slots`` in the DCS
+  configuration, ``other`` for any slot created outside Patroni's control.
+
+**Why this metric is needed**
+
+Logical replication slots are a common source of unplanned disk-full incidents: an abandoned
+CDC connector leaves a slot with no active consumer, and PostgreSQL retains WAL indefinitely
+until that consumer reconnects. On Patroni clusters this risk is compounded by failover
+behaviour — on PostgreSQL < 17, slots not tracked by Patroni's ``permanent_slots`` are
+silently lost when the primary changes, breaking any application that depended on them.
+
+The ``postgres_exporter`` already exposes raw slot metrics such as
+``pg_replication_slots_active``, but it has no awareness of Patroni's DCS configuration and
+cannot distinguish slots that Patroni manages from slots created directly by applications.
+The ``managedby`` label bridges this gap: it is derived by cross-referencing each slot name
+against ``permanent_slots`` — information already in memory inside the Patroni process,
+requiring no extra DCS call.
+
+This makes it possible to write alert rules that were previously not expressible:
+
+.. code-block:: yaml
+
+    # Unmanaged slot has lost its consumer — WAL will accumulate indefinitely
+    - alert: LogicalSlotOtherInactive
+      expr: patroni_logical_slot_active{managedby="other"} == 0
+      for: 5m
+
+    # Active unmanaged slots exist — these will be lost on failover (PG < 17)
+    - alert: LogicalSlotOtherActivePreFailover
+      expr: patroni_logical_slot_active{managedby="other"} == 1
+      for: 0m
 
 
 Cluster status endpoints

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -621,7 +621,11 @@ class RestApiHandler(BaseHTTPRequestHandler):
             * ``patroni_postgres_timeline``: PostgreSQL timeline based on current WAL file name;
             * ``patroni_dcs_last_seen``: epoch timestamp when DCS was last contacted successfully;
             * ``patroni_pending_restart``: ``1`` if this PostgreSQL node is pending a restart, else ``0``;
-            * ``patroni_is_paused``: ``1`` if Patroni is in maintenance node, else ``0``.
+            * ``patroni_is_paused``: ``1`` if Patroni is in maintenance node, else ``0``;
+            * ``patroni_logical_slot_active``: per-slot gauge. ``1`` if the logical replication slot
+              has an active consumer, ``0`` otherwise. Emitted only when PostgreSQL is reachable and
+              at least one logical slot exists. Labels: ``scope``, ``name``, ``slot`` (slot name),
+              ``managedby`` (``patroni`` | ``other``).
 
         For PostgreSQL v9.6+ the response will also have the following:
 
@@ -767,6 +771,41 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# HELP patroni_failover_priority Failover priority of this node.")
         metrics.append("# TYPE patroni_failover_priority gauge")
         metrics.append("patroni_failover_priority{0} {1}".format(labels, patroni.failover_priority))
+
+        try:
+            server_version = postgres.get('server_version', 0)
+            temp_filter = " AND NOT temporary" if server_version >= 100000 else ""
+            slot_sql = (
+                "SELECT slot_name, active"
+                " FROM pg_catalog.pg_replication_slots"
+                " WHERE slot_type = 'logical'"
+                + temp_filter
+            )
+            slot_rows = self.query(slot_sql)
+            cluster = patroni.dcs.cluster
+            patroni_slots = set(global_config.from_cluster(cluster).permanent_slots.keys())
+        except (psycopg.Error, PostgresConnectionException):
+            slot_rows = []
+            patroni_slots = set()
+
+        active_lines: List[str] = []
+        for row in slot_rows:
+            slot_name = row[0]
+            active = row[1]
+            managed = 'patroni' if slot_name in patroni_slots else 'other'
+
+            slot_labels = (
+                f'{{scope="{patroni.postgresql.scope}",'
+                f'name="{patroni.postgresql.name}",'
+                f'slot="{slot_name}",managedby="{managed}"}}'
+            )
+            active_lines.append(f"patroni_logical_slot_active{slot_labels} {int(active)}")
+
+        if active_lines:
+            metrics.append("# HELP patroni_logical_slot_active"
+                           " Value is 1 if the logical replication slot has an active consumer, 0 otherwise.")
+            metrics.append("# TYPE patroni_logical_slot_active gauge")
+            metrics.extend(active_lines)
 
         self.write_response(200, '\n'.join(metrics) + '\n', content_type='text/plain')
 

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -20,7 +20,7 @@ import traceback
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from ipaddress import ip_address, ip_network, IPv4Network, IPv6Network
 from socketserver import ThreadingMixIn
-from typing import Any, Callable, cast, Dict, Iterator, List, Optional, Tuple, TYPE_CHECKING, Union
+from typing import Any, Callable, cast, Dict, Iterator, List, Optional, Set, Tuple, TYPE_CHECKING, Union
 from urllib.parse import parse_qs, urlparse
 
 import dateutil.parser
@@ -786,7 +786,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
             patroni_slots = set(global_config.from_cluster(cluster).permanent_slots.keys())
         except (psycopg.Error, PostgresConnectionException):
             slot_rows = []
-            patroni_slots = set()
+            patroni_slots: Set[str] = set()
 
         active_lines: List[str] = []
         for row in slot_rows:

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -774,13 +774,12 @@ class RestApiHandler(BaseHTTPRequestHandler):
 
         try:
             server_version = postgres.get('server_version', 0)
-            temp_filter = " AND NOT temporary" if server_version >= 100000 else ""
-            slot_sql = (
-                "SELECT slot_name, active"
-                " FROM pg_catalog.pg_replication_slots"
-                " WHERE slot_type = 'logical'"
-                + temp_filter
-            )
+            if server_version >= 100000:
+                slot_sql = ("SELECT slot_name, active FROM pg_catalog.pg_replication_slots"
+                            " WHERE slot_type = 'logical' AND NOT temporary")
+            else:
+                slot_sql = ("SELECT slot_name, active FROM pg_catalog.pg_replication_slots"
+                            " WHERE slot_type = 'logical'")
             slot_rows = self.query(slot_sql)
             cluster = patroni.dcs.cluster
             patroni_slots = set(global_config.from_cluster(cluster).permanent_slots.keys())

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -427,6 +427,7 @@ class TestRestApiHandler(unittest.TestCase):
 
     @patch.object(MockPatroni, 'dcs')
     def test_do_GET_metrics(self, mock_dcs):
+        mock_dcs.cluster.config.data = {}
         self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /metrics'))
         # Test with failsafe_mode enabled
         with patch.object(MockHa, 'is_failsafe_mode', Mock(return_value=True)):
@@ -440,6 +441,50 @@ class TestRestApiHandler(unittest.TestCase):
         # Test with failsafe as None
         type(mock_dcs).failsafe = PropertyMock(return_value=None)
         self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /metrics'))
+
+        # Logical slot metrics: patroni-managed slot active, unmanaged slot inactive
+        slot_rows = [('cdc_slot', True), ('old_slot', False)]
+        cdc_slot_cfg = {'type': 'logical', 'plugin': 'pgoutput', 'database': 'app'}
+        mock_dcs.cluster.config.data = {'slots': {'cdc_slot': cdc_slot_cfg}}
+
+        def mixed_slot_query(sql, *params):
+            if 'pg_replication_slots' in sql:
+                return slot_rows
+            return MockConnection.query(sql, *params)
+
+        with patch.object(RestApiServer, 'query', side_effect=mixed_slot_query), \
+                patch.object(RestApiHandler, 'write_response') as resp_mock:
+            MockRestApiServer(RestApiHandler, 'GET /metrics')
+            body = resp_mock.call_args[0][1]
+            self.assertIn('slot="cdc_slot",managedby="patroni"} 1', body)
+            self.assertIn('slot="old_slot",managedby="other"} 0', body)
+
+        # Postgres unreachable: slot metrics omitted, other metrics still present
+        mock_dcs.cluster.config.data = {}
+
+        def failing_slot_query(sql, *params):
+            if 'pg_replication_slots' in sql:
+                raise PostgresConnectionException('down')
+            return MockConnection.query(sql, *params)
+
+        with patch.object(RestApiServer, 'query', side_effect=failing_slot_query), \
+                patch.object(RestApiHandler, 'write_response') as resp_mock:
+            MockRestApiServer(RestApiHandler, 'GET /metrics')
+            body = resp_mock.call_args[0][1]
+            self.assertIn('patroni_postgres_running', body)
+            self.assertNotIn('patroni_logical_slot_active', body)
+
+        # No logical slots: HELP/TYPE lines not emitted
+        def empty_slot_query(sql, *params):
+            if 'pg_replication_slots' in sql:
+                return []
+            return MockConnection.query(sql, *params)
+
+        with patch.object(RestApiServer, 'query', side_effect=empty_slot_query), \
+                patch.object(RestApiHandler, 'write_response') as resp_mock:
+            MockRestApiServer(RestApiHandler, 'GET /metrics')
+            body = resp_mock.call_args[0][1]
+            self.assertNotIn('patroni_logical_slot_active', body)
 
     @patch.object(MockPatroni, 'dcs')
     def test_do_PATCH_config(self, mock_dcs):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -486,6 +486,18 @@ class TestRestApiHandler(unittest.TestCase):
             body = resp_mock.call_args[0][1]
             self.assertNotIn('patroni_logical_slot_active', body)
 
+        # PG >= 10: AND NOT temporary filter is included in the query
+        def pg10_slot_query(sql, *params):
+            if 'pg_replication_slots' in sql:
+                self.assertIn('AND NOT temporary', sql)
+                return slot_rows
+            return MockConnection.query(sql, *params)
+
+        with patch.object(MockPostgresql, 'server_version', 150000), \
+                patch.object(RestApiServer, 'query', side_effect=pg10_slot_query), \
+                patch.object(RestApiHandler, 'write_response'):
+            MockRestApiServer(RestApiHandler, 'GET /metrics')
+
     @patch.object(MockPatroni, 'dcs')
     def test_do_PATCH_config(self, mock_dcs):
         config = {'postgresql': {'use_slots': False, 'use_pg_rewind': True, 'parameters': {'wal_level': 'logical'}}}


### PR DESCRIPTION
## The Idea Behind Adding the Metric

``patroni_logical_slot_active`` is a per-slot gauge that exposes the ``active`` field from ``pg_catalog.pg_replication_slots`` for every logical slot on the node. The value is ``1`` when a consumer is connected and ``0`` when the slot has no active consumer. The metric is emitted only when PostgreSQL is reachable and at least one logical slot exists; if the query fails, the metric is omitted for that scrape and all other metrics are unaffected.

Logical replication slots are a common source of unplanned disk-full incidents: an abandoned CDC connector leaves a slot with no consumer, and PostgreSQL retains WAL indefinitely until it reconnects.On Patroni clusters this is compounded by failover risk on PostgreSQL < 17, slots not tracked by Patroni are silently lost when the primary changes.

The postgres_exporter already exposes raw slot metrics, but it has no awareness of Patroni's DCS configuration and cannot distinguish slots that Patroni manages from slots created directly by applications.

Each series carries a `managedby` label derived from Patroni's own `permanent_slots` DCS config:

| `managedby` | Source | Failover behaviour |
|-------------|--------|--------------------|
| `patroni` | Listed in `permanent_slots` in DCS config | Patroni recreates the slot on the new primary automatically |
| `other` | Created directly by an application, not in Patroni config | **Lost after failover on PG < 17. Never cleaned up. WAL accumulates if consumer disconnects.** |

This makes it possible to write alerts that were previously impossible:
```
    # WAL accumulating — unmanaged slot has no consumer
    patroni_logical_slot_active{managedby="other"} == 0

    # Active unmanaged slots that will break on failover (PG < 17)
    patroni_logical_slot_active{managedby="other"} == 1
```

The metric is emitted only when PostgreSQL is reachable and at least one logical slot exists. If the slot query fails the metric is omitted for that scrape and all other metrics are unaffected.


## The Example Metric Output

```
# HELP patroni_logical_slot_active Value is 1 if the logical replication slot has an active consumer, 0 otherwise.
# TYPE patroni_logical_slot_active gauge
patroni_logical_slot_active{scope="demo",name="patroni2",slot="patroni_cdc_slot",managedby="patroni"} 1
patroni_logical_slot_active{scope="demo",name="patroni2",slot="unmanaged_slot",managedby="other"} 0
```

