### PR TITLE
Honor primary_stop_timeout during primary restart

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -345,8 +345,9 @@ class PatroniController(AbstractController):
         except Exception:
             return None
 
-    def patroni_hang(self, timeout):
-        hang = ProcessHang(self._handle.pid, timeout)
+    def patroni_hang(self, timeout, pid=None):
+        pid = pid or self._handle.pid
+        hang = ProcessHang(pid, timeout)
         self._closables.append(hang)
         hang.start()
 
@@ -386,14 +387,17 @@ class ProcessHang(object):
         self.timeout = timeout
 
     def start(self):
+        os.kill(self.pid, signal.SIGSTOP)
         self._thread.start()
 
     def run(self):
-        os.kill(self.pid, signal.SIGSTOP)
         try:
             self._cancelled.wait(self.timeout)
         finally:
-            os.kill(self.pid, signal.SIGCONT)
+            try:
+                os.kill(self.pid, signal.SIGCONT)
+            except ProcessLookupError:
+                pass
 
     def close(self):
         self._cancelled.set()

--- a/features/patroni_api.feature
+++ b/features/patroni_api.feature
@@ -60,6 +60,17 @@ Scenario: check the scheduled restart
 	And Response on GET http://127.0.0.1:8008/patroni does not contain pending_restart after 10 seconds
 	And postgres-0 role is the primary after 10 seconds
 
+Scenario: primary restart honors primary_stop_timeout
+	Given I start postgres-0
+	And postgres-0 is a leader after 10 seconds
+	When I issue a PATCH request to http://127.0.0.1:8008/config with {"synchronous_mode": true, "primary_stop_timeout": 3}
+	Then I receive a response code 200
+	And Response on GET http://127.0.0.1:8008/config contains primary_stop_timeout=3 after 10 seconds
+	When I suspend a backend on postgres-0 for 20 seconds
+	And I issue a POST request to http://127.0.0.1:8008/restart with {"role": "primary"} and client timeout 12 seconds
+	Then I receive a response code 200
+	And postgres-0 role is the primary after 10 seconds
+
 Scenario: check API requests for the primary-replica pair in the pause mode
 	Given I start postgres-1
 	Then replication works from postgres-0 to postgres-1 after 20 seconds

--- a/features/steps/patroni_api.py
+++ b/features/steps/patroni_api.py
@@ -70,6 +70,19 @@ def do_post_empty(context, url):
     do_request(context, 'POST', url, None)
 
 
+@step('I issue a {request_method:w} request to {url:url} with {data} and client timeout {timeout:d} seconds')
+def do_request_with_timeout(context, request_method, url, data, timeout):
+    if context.certfile:
+        url = url.replace('http://', 'https://')
+    data = data and json.loads(data)
+    try:
+        r = context.request_executor.request(request_method, url, data, timeout=timeout)
+    except Exception:
+        context.status_code = context.response = None
+    else:
+        _set_response(context, r)
+
+
 @step('I issue a {request_method:w} request to {url:url} with {data}')
 def do_request(context, request_method, url, data):
     if context.certfile:
@@ -83,6 +96,12 @@ def do_request(context, request_method, url, data):
         context.status_code = context.response = None
     else:
         _set_response(context, r)
+
+
+@step('I suspend a backend on {pg_name:name} for {timeout:d} seconds')
+def suspend_backend(context, pg_name, timeout):
+    pid = context.pctl.query(pg_name, "SELECT pg_catalog.pg_backend_pid()").fetchone()[0]
+    context.pctl.patroni_hang(pg_name, timeout * context.timeout_multiplier, pid=pid)
 
 
 @step('I run {cmd}')

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -2056,11 +2056,15 @@ class Ha(object):
         def after_start() -> None:
             self.notify_mpp_coordinator('after_promote')
 
+        has_lock = self.has_lock()
+        stop_timeout = self.primary_stop_timeout() if has_lock else None
+
         # For non async cases we want to wait for restart to complete or timeout before returning.
         do_restart = functools.partial(self.state_handler.restart, timeout, self._async_executor.critical_task,
-                                       before_shutdown=before_shutdown if self.has_lock() else None,
-                                       after_start=after_start if self.has_lock() else None)
-        if self.is_synchronous_mode() and not self.has_lock():
+                                       before_shutdown=before_shutdown if has_lock else None,
+                                       after_start=after_start if has_lock else None,
+                                       stop_timeout=stop_timeout)
+        if self.is_synchronous_mode() and not has_lock:
             do_restart = functools.partial(self.while_not_sync_standby, do_restart)
 
         if run_async:

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -1038,7 +1038,8 @@ class Postgresql(object):
     def restart(self, timeout: Optional[float] = None, task: Optional[CriticalTask] = None,
                 block_callbacks: bool = False, role: Optional[PostgresqlRole] = None,
                 before_shutdown: Optional[Callable[..., Any]] = None,
-                after_start: Optional[Callable[..., Any]] = None) -> Optional[bool]:
+                after_start: Optional[Callable[..., Any]] = None,
+                stop_timeout: Optional[int] = None) -> Optional[bool]:
         """Restarts PostgreSQL.
 
         When timeout parameter is set the call will block either until PostgreSQL has started, failed to start or
@@ -1049,7 +1050,7 @@ class Postgresql(object):
         self.set_state(PostgresqlState.RESTARTING)
         if not block_callbacks:
             self.__cb_pending = CallbackAction.ON_RESTART
-        ret = self.stop(block_callbacks=True, before_shutdown=before_shutdown)\
+        ret = self.stop(block_callbacks=True, before_shutdown=before_shutdown, stop_timeout=stop_timeout)\
             and self.start(timeout, task, True, role, after_start)
         if not ret and not self.is_starting():
             logger.warning('restart failed (%r)', self.state)

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -1365,6 +1365,18 @@ class TestHa(PostgresInit):
             global_config.update(self.ha.cluster)
             self.assertEqual(self.ha.primary_stop_timeout(), None)
 
+    def test_restart_passes_primary_stop_timeout(self):
+        self.ha.cluster = get_cluster_initialized_with_leader(sync=(self.p.name, 'other'))
+        self.ha.cluster.config.data.update({'primary_stop_timeout': 30})
+        global_config.update(self.ha.cluster)
+        self.ha.has_lock = true
+        self.p.restart = Mock(return_value=True)
+
+        with patch.object(Ha, 'is_synchronous_mode', Mock(return_value=True)):
+            self.assertEqual(self.ha.restart({}), (True, 'restarted successfully'))
+
+        self.assertEqual(self.p.restart.call_args.kwargs.get('stop_timeout'), 30)
+
     @patch('patroni.postgresql.Postgresql.follow')
     def test_demote_immediate(self, follow):
         self.ha.has_lock = true


### PR DESCRIPTION
## Summary
- Apply `primary_stop_timeout` to primary restarts by passing it through `Ha.restart()` and `Postgresql.restart()` into `Postgresql.stop()`.
- Add unit coverage for the HA restart path and a Behave scenario that verifies `/restart` returns while a backend is stuck during shutdown.

Fixes #3657

## Test plan
- `python -m flake8 features/environment.py features/steps/patroni_api.py patroni/ha.py patroni/postgresql/__init__.py tests/test_ha.py`
- `python -m pytest tests/test_ha.py -q`
- `python -m pytest tests/test_postgresql.py -q`
- `python -m behave features/patroni_api.feature --name 'primary restart honors primary_stop_timeout'`