### PR TITLE
Refactor connection options

### DIFF
--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -258,8 +258,10 @@ class Member(Tags, NamedTuple('Member',
             self.data['conn_kwargs'] = ret.copy()
 
         # apply any remaining authentication parameters
+        # we skip options and connect_timeout to prevent injection via config file
         if auth and isinstance(auth, dict):
-            ret.update({k: v for k, v in cast(Dict[str, Any], auth).items() if v is not None})
+            ret.update({k: v for k, v in cast(Dict[str, Any], auth).items()
+                        if k not in ('options', 'connect_timeout') and v is not None})
             if 'username' in auth:
                 ret['user'] = ret.pop('username')
         return ret

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -1099,6 +1099,7 @@ class Postgresql(object):
     @contextmanager
     def get_replication_connection_cursor(self, host: Optional[str] = None, port: Union[int, str] = 5432,
                                           **kwargs: Any) -> Generator[Union['cursor', 'Cursor[Any]'], None, None]:
+        # We use RemoteMember here because it has the logic to map and sanitize connection parameters
         member = RemoteMember('', {'conn_kwargs': {'host': host, 'port': port}})
         conn_kwargs = member.conn_kwargs(self.config.replication)
         conn_kwargs.update(replication=1)

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -20,7 +20,7 @@ from .. import global_config, psycopg
 from ..async_executor import CriticalTask
 from ..collections import CaseInsensitiveDict, CaseInsensitiveSet, EMPTY_DICT
 from ..daemon import notify_systemd
-from ..dcs import Cluster, Leader, Member, slot_name_from_member_name
+from ..dcs import Cluster, Leader, Member, RemoteMember, slot_name_from_member_name
 from ..exceptions import PostgresConnectionException
 from ..tags import Tags
 from ..utils import data_directory_is_empty, parse_int, polling_loop, Retry, RetryFailedError
@@ -833,14 +833,10 @@ class Postgresql(object):
     def checkpoint(self, connect_kwargs: Optional[Dict[str, Any]] = None,
                    timeout: Optional[float] = None) -> Optional[str]:
         check_not_is_in_recovery = connect_kwargs is not None
-        connect_kwargs = connect_kwargs or self.connection_pool.conn_kwargs
-        for p in ['connect_timeout', 'options']:
-            connect_kwargs.pop(p, None)
-        if timeout:
-            connect_kwargs['connect_timeout'] = timeout
+        conn_kwargs = {**(connect_kwargs or self.connection_pool.conn_kwargs),
+                       'connect_timeout': timeout, 'options': '-c statement_timeout=0'}
         try:
-            with get_connection_cursor(**connect_kwargs) as cur:
-                cur.execute("SET statement_timeout = 0")
+            with get_connection_cursor(**conn_kwargs) as cur:
                 if check_not_is_in_recovery:
                     cur.execute('SELECT pg_catalog.pg_is_in_recovery()')
                     row = cur.fetchone()
@@ -1103,9 +1099,9 @@ class Postgresql(object):
     @contextmanager
     def get_replication_connection_cursor(self, host: Optional[str] = None, port: Union[int, str] = 5432,
                                           **kwargs: Any) -> Generator[Union['cursor', 'Cursor[Any]'], None, None]:
-        conn_kwargs = self.config.replication.copy()
-        conn_kwargs.update(host=host, port=int(port) if port else None, user=conn_kwargs.pop('username'),
-                           connect_timeout=3, replication=1, options='-c statement_timeout=2000')
+        member = RemoteMember('', {'conn_kwargs': {'host': host, 'port': port}})
+        conn_kwargs = member.conn_kwargs(self.config.replication)
+        conn_kwargs.update(replication=1)
         with get_connection_cursor(**conn_kwargs) as cur:
             yield cur
 

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -1172,10 +1172,7 @@ class ConfigHandler(object):
         local_conn_kwargs = {
             **local_address,
             **self._superuser,
-            'dbname': self._postgresql.database,
-            'fallback_application_name': 'Patroni',
-            'connect_timeout': 3,
-            'options': '-c statement_timeout=2000'
+            'dbname': self._postgresql.database
         }
         # if the "username" parameter is present, it actually needs to be "user" for connecting to PostgreSQL
         if 'username' in local_conn_kwargs:

--- a/patroni/postgresql/connection.py
+++ b/patroni/postgresql/connection.py
@@ -13,6 +13,9 @@ from ..exceptions import PostgresConnectionException
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_CONNECT_TIMEOUT = 3
+DEFAULT_CONNECTION_OPTIONS = '-c statement_timeout=2000'
+
 
 class NamedConnection:
     """Helper class to manage ``psycopg`` connections from Patroni to PostgreSQL.
@@ -126,7 +129,9 @@ class ConnectionPool:
         :param value: :class:`dict` object with connection parameters.
         """
         with self._lock:
-            self._conn_kwargs = value
+            self._conn_kwargs = {'connect_timeout': DEFAULT_CONNECT_TIMEOUT,
+                                 'options': DEFAULT_CONNECTION_OPTIONS,
+                                 'fallback_application_name': 'Patroni', **value}
 
     def get(self, name: str, kwargs_override: Optional[Dict[str, Any]] = None) -> NamedConnection:
         """Get a new named :class:`NamedConnection` object from the pool.
@@ -155,7 +160,8 @@ class ConnectionPool:
 
 @contextmanager
 def get_connection_cursor(**kwargs: Any) -> Generator[Union['cursor', 'Cursor[Any]'], None, None]:
-    conn = psycopg.connect(**kwargs)
+    conn_kwargs = {'connect_timeout': DEFAULT_CONNECT_TIMEOUT, 'options': DEFAULT_CONNECTION_OPTIONS, **kwargs}
+    conn = psycopg.connect(**conn_kwargs)
     with conn.cursor() as cur:
         yield cur
     conn.close()

--- a/patroni/postgresql/rewind.py
+++ b/patroni/postgresql/rewind.py
@@ -103,7 +103,7 @@ class Rewind(object):
     @staticmethod
     def check_leader_is_not_in_recovery(conn_kwargs: Dict[str, Any]) -> Optional[bool]:
         try:
-            with get_connection_cursor(connect_timeout=3, options='-c statement_timeout=2000', **conn_kwargs) as cur:
+            with get_connection_cursor(**conn_kwargs) as cur:
                 cur.execute('SELECT pg_catalog.pg_is_in_recovery()')
                 row = cur.fetchone()
                 if not row or not row[0]:
@@ -115,7 +115,7 @@ class Rewind(object):
     @staticmethod
     def check_leader_has_run_checkpoint(conn_kwargs: Dict[str, Any]) -> Optional[str]:
         try:
-            with get_connection_cursor(connect_timeout=3, options='-c statement_timeout=2000', **conn_kwargs) as cur:
+            with get_connection_cursor(**conn_kwargs) as cur:
                 cur.execute("SELECT NOT pg_catalog.pg_is_in_recovery()"
                             " AND ('x' || pg_catalog.substr(pg_catalog.pg_walfile_name("
                             " pg_catalog.pg_current_wal_lsn()), 1, 8))::bit(32)::int = timeline_id"

--- a/patroni/postgresql/slots.py
+++ b/patroni/postgresql/slots.py
@@ -638,7 +638,6 @@ class SlotsHandler:
 
         .. note::
             Uses rewind user credentials because it has enough permissions to read files from PGDATA.
-            Sets the options ``connect_timeout`` to ``3`` and ``statement_timeout`` to ``2000``.
 
         :param leader: object with information on the leader
 
@@ -646,7 +645,7 @@ class SlotsHandler:
         """
         conn_kwargs = leader.conn_kwargs(self._postgresql.config.rewind_credentials)
         conn_kwargs['dbname'] = self._postgresql.database
-        with get_connection_cursor(connect_timeout=3, options="-c statement_timeout=2000", **conn_kwargs) as cur:
+        with get_connection_cursor(**conn_kwargs) as cur:
             yield cur
 
     def check_logical_slots_readiness(self, cluster: Cluster, tags: Tags) -> bool:


### PR DESCRIPTION
In many places we are explicitly using `connect_timeout=3` and `options='-c statement_timeout=2000'`, which are essentially a default.
Therefore, it is logical to use them as default when setting `ConnectionPool.conn_kwargs` or when calling `get_connection_cursor()` function.

We explicitly pass `options` and `connect_timeout` only in case we want to override defaults.