### PR TITLE
Handle statement timeout error for monitoring query

### DIFF
--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -508,6 +508,11 @@ class Postgresql(object):
                     cluster_info_state['slots'] =\
                         self.slots_handler.process_permanent_slots(cluster_info_state['slots'])
                 self._cluster_info_state = cluster_info_state
+            except psycopg.OperationalError as e:
+                if e.diag.sqlstate == '57014':  # QueryCanceled
+                    self._cluster_info_state = {'error': str(e)}
+                else:
+                    raise
             except RetryFailedError as e:  # SELECT failed two times
                 self._cluster_info_state = {'error': str(e)}
                 if not self.is_starting() and self.pg_isready() == PgIsReadyStatus.REJECT:

--- a/patroni/postgresql/connection.py
+++ b/patroni/postgresql/connection.py
@@ -14,7 +14,7 @@ from ..exceptions import PostgresConnectionException
 logger = logging.getLogger(__name__)
 
 DEFAULT_CONNECT_TIMEOUT = 3
-DEFAULT_CONNECTION_OPTIONS = '-c statement_timeout=2000'
+DEFAULT_CONNECTION_OPTIONS = '-c statement_timeout=2000 -c pg_stat_statements.track=none'
 
 
 class NamedConnection:

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -729,10 +729,10 @@ class TestPostgresql(BaseTestPostgresql):
         self.assertEqual(self.p.config.local_replication_address, {'host': '/tmp', 'port': '5432'})
         self.p.config._server_parameters.pop('unix_socket_directories')
         self.p.config.resolve_connection_addresses()
-        self.assertEqual(self.p.connection_pool.conn_kwargs, {'connect_timeout': 3, 'dbname': 'postgres',
-                                                              'fallback_application_name': 'Patroni',
-                                                              'options': '-c statement_timeout=2000',
-                                                              'password': 'test', 'port': '5432', 'user': 'foo'})
+        self.assertEqual(self.p.connection_pool.conn_kwargs,
+                         {'connect_timeout': 3, 'dbname': 'postgres', 'fallback_application_name': 'Patroni',
+                          'options': '-c statement_timeout=2000 -c pg_stat_statements.track=none',
+                          'password': 'test', 'port': '5432', 'user': 'foo'})
 
     @patch.object(Postgresql, '_version_file_exists', Mock(return_value=True))
     def test_get_major_version(self):
@@ -1168,6 +1168,17 @@ class TestPostgresql(BaseTestPostgresql):
         pg_conf = os.path.join(os.path.abspath(os.sep) + 'tmp', 'postgresql.conf')
         self.p.config.set_file_permissions(pg_conf)
         mock_chmod.assert_called_with(pg_conf, 0o666 & ~pg_perm.orig_umask)
+
+    @patch.object(Postgresql, '_query', Mock(side_effect=psycopg.OperationalError))
+    def test__cluster_info_state_get(self):
+        self.p.set_role(PostgresqlRole.STANDBY_LEADER)
+        with patch.object(psycopg.OperationalError, 'diag') as mock_diag:
+            type(mock_diag).sqlstate = PropertyMock(return_value='57014')  # QueryCanceled
+            self.p.reset_cluster_info_state(None)
+            self.assertRaises(PostgresConnectionException, self.p.received_timeline)
+            type(mock_diag).sqlstate = PropertyMock(return_value='54023')  # TooManyArguments
+            self.p.reset_cluster_info_state(None)
+            self.assertRaises(psycopg.OperationalError, self.p.received_timeline)
 
 
 @patch('subprocess.call', Mock(return_value=0))


### PR DESCRIPTION
In case of statement timeout we will use cached role fallback to avoid demoting primary.

Besides that forcibly set `pg_stat_statements.track` to `none` to avoid expensive GC calls.

Close #3646 and #3637