### PR TITLE
Set pg_stat_statements.track=none only for connections in pool

### DIFF
--- a/patroni/postgresql/connection.py
+++ b/patroni/postgresql/connection.py
@@ -14,7 +14,7 @@ from ..exceptions import PostgresConnectionException
 logger = logging.getLogger(__name__)
 
 DEFAULT_CONNECT_TIMEOUT = 3
-DEFAULT_CONNECTION_OPTIONS = '-c statement_timeout=2000 -c pg_stat_statements.track=none'
+DEFAULT_CONNECTION_OPTIONS = '-c statement_timeout=2000'
 
 
 class NamedConnection:
@@ -130,7 +130,7 @@ class ConnectionPool:
         """
         with self._lock:
             self._conn_kwargs = {'connect_timeout': DEFAULT_CONNECT_TIMEOUT,
-                                 'options': DEFAULT_CONNECTION_OPTIONS,
+                                 'options': DEFAULT_CONNECTION_OPTIONS + ' -c pg_stat_statements.track=none',
                                  'fallback_application_name': 'Patroni', **value}
 
     def get(self, name: str, kwargs_override: Optional[Dict[str, Any]] = None) -> NamedConnection:


### PR DESCRIPTION
they are guaranteed to be local connections opened by superuser