### PR TITLE
Fix thread_stack_size validation alignment

### DIFF
--- a/patroni/validator.py
+++ b/patroni/validator.py
@@ -1058,7 +1058,7 @@ schema = Schema({
     "name": validate_name,
     "scope": str,
     Optional("thread_pool_size"): IntValidator(min=5, expected_type=int, raise_assert=True),
-    Optional("thread_stack_size"): IntValidator(min=65536, base_unit='B', aligned=65535,
+    Optional("thread_stack_size"): IntValidator(min=65536, base_unit='B', aligned=65536,
                                                 expected_type=int, raise_assert=True),
     Optional("log"): {
         Optional("type"): EnumValidator(('plain', 'json'), case_sensitive=True, raise_assert=True),

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -376,6 +376,15 @@ class TestValidator(unittest.TestCase):
         errors = schema(c)
         self.assertIn('tags.failover_priority -6 didn\'t pass validation: Wrong value', errors)
 
+    def test_thread_stack_size(self, *args):
+        c = copy.deepcopy(config)
+        c["thread_stack_size"] = 524288
+        errors = schema(c)
+        self.assertEqual([], [e for e in errors if "thread_stack_size" in e])
+        c["thread_stack_size"] = 65535
+        errors = schema(c)
+        self.assertIn("thread_stack_size 65535 didn't pass validation: Wrong value", errors)
+
     def test_json_log_format(self, *args):
         c = copy.deepcopy(config)
         c["log"]["type"] = "json"


### PR DESCRIPTION
The `thread_stack_size` schema entry aligns on `65535` instead of `65536`:

```python
Optional("thread_stack_size"): IntValidator(min=65536, base_unit='B', aligned=65535, ...)
```

`IntValidator` checks `value % aligned == 0`, so with `aligned=65535` every realistic stack size is rejected by `patroni --validate-config`, including the `524288` default that the daemon itself applies (`daemon.py`) and every power-of-two / page-multiple value. Only multiples of 65535 pass, which are exactly the values `threading.stack_size()` refuses at runtime.

`65536` (64 KiB) is a multiple of every common page size and matches the `min`, so this is a one-character typo. Changing it to `65536` makes the validator accept the values the runtime already accepts.

Introduced in #3526.

### Tests

Added `test_thread_stack_size` covering that the `524288` default passes and a non-aligned value (`65535`) is still rejected.
