### PR TITLE
Stream pg_rewind and pg_basebackup output to logs while running

### DIFF
--- a/docs/replica_bootstrap.rst
+++ b/docs/replica_bootstrap.rst
@@ -197,6 +197,8 @@ Also note that in case symlinks are used for the WAL folder it is up to the user
 path as an option, so that after replica buildup or re-initialization the symlink would persist. This option is supported
 only since v10 though.
 
+When the ``progress`` option is used, the ``pg_basebackup`` output is streamed to the Patroni log as it arrives.
+
 You can specify basebackup parameters as either a map (key-value pairs) or a list of elements, where each element
 could be either a key-value pair or a single key (for options that does not receive any values, for instance, ``--verbose``).
 Consider those 2 examples:

--- a/docs/yaml_configuration.rst
+++ b/docs/yaml_configuration.rst
@@ -343,7 +343,7 @@ PostgreSQL
    -  **pg\_ident\_standby\_leader**: (optional) role-specific pg_ident entries for standby_leader. These completely replace **pg_ident** (no merging). If not defined, **pg_ident** is used.
    -  **pg\_ctl\_timeout**: How long should pg_ctl wait when doing ``start``, ``stop`` or ``restart``. Default value is 60 seconds.
    -  **use\_pg\_rewind**: try to use pg\_rewind on the former leader when it joins cluster as a replica. Either the cluster must be initialized with ``data page checksums`` (``--data-checksums`` option for ``initdb``) and/or ``wal_log_hints`` must be set to ``on``, or ``pg_rewind`` will not work.
-   -  **rewind**: (optional) custom options to pass to the ``pg_rewind`` command. Can be specified as a list of strings and/or single key-value dictionaries. Not allowed options include: ``target-pgdata``, ``source-pgdata``, ``source-server``, ``write-recovery-conf``, ``dry-run``, ``restore-target-wal``, ``config-file``, ``no-ensure-shutdown``, ``version``, and ``help``. Example usage:
+   -  **rewind**: (optional) custom options to pass to the ``pg_rewind`` command. Can be specified as a list of strings and/or single key-value dictionaries. Not allowed options include: ``target-pgdata``, ``source-pgdata``, ``source-server``, ``write-recovery-conf``, ``dry-run``, ``restore-target-wal``, ``config-file``, ``no-ensure-shutdown``, ``version``, and ``help``. When the ``progress`` option is used, the ``pg_rewind`` output is streamed to the Patroni log as it arrives. Example usage:
 
       .. code:: YAML
 

--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -250,6 +250,16 @@ class Bootstrap(object):
         self._postgresql.set_state(PostgresqlState.STOPPED)
         return ret
 
+    @staticmethod
+    def _log_output_line(name: str, line: bytes) -> None:
+        """Log a single line of ``pg_basebackup`` output.
+
+        :param name: name of the stream the line was read from, ``stdout`` or ``stderr``.
+        :param line: one line of output without the trailing newline.
+        """
+        if line:
+            logger.info('pg_basebackup: %s', line.decode('utf-8', 'replace'))
+
     def basebackup(self, conn_url: str, env: Dict[str, str], options: Dict[str, Any]) -> Optional[int]:
         # creates a replica data dir using pg_basebackup.
         # this is the default, built-in create_replica_methods
@@ -285,6 +295,10 @@ class Bootstrap(object):
             "--dbname=" + conn_url,
         ] + user_options
 
+        # pg_basebackup --progress reports the copy progress while it is running, therefore
+        # the output is streamed to the log as it arrives instead of being discarded
+        stream_cb = self._log_output_line if '--progress' in user_options else None
+
         for bbfailures in range(0, maxfailures):
             if self._postgresql.cancellable.is_cancelled:
                 break
@@ -292,7 +306,7 @@ class Bootstrap(object):
                 self._postgresql.remove_data_directory()
             try:
                 logger.debug('calling: %r', cmd)
-                ret = self._postgresql.cancellable.call(cmd, env=env)
+                ret = self._postgresql.cancellable.call(cmd, env=env, stream_cb=stream_cb)
                 if ret == 0:
                     break
                 else:

--- a/patroni/postgresql/cancellable.py
+++ b/patroni/postgresql/cancellable.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import subprocess
 
 from io import BufferedReader
@@ -12,6 +13,11 @@ from patroni.exceptions import PostgresException
 from patroni.utils import polling_loop
 
 logger = logging.getLogger(__name__)
+
+# Records are terminated with LF, CRLF (Windows), or a bare CR. The latter is used by progress reports of
+# pg_basebackup (PostgreSQL 10 and older) and pg_rewind (PostgreSQL 11 and older), which don't check whether
+# the output is a terminal and therefore keep writing CR even when it is a pipe.
+LINE_SEPARATOR_RE = re.compile(b'\r\n|\r|\n')
 
 
 class CancellableExecutor(object):
@@ -83,8 +89,9 @@ class CancellableSubprocess(CancellableExecutor):
 
         ``stderr`` is drained by a single helper thread while ``stdout`` is read inline, so both pipes are drained
         concurrently with only one extra thread. ``read1()`` returns as soon as any data is available, so slowly
-        produced lines are delivered promptly. Exceptions from ``stream_cb`` are swallowed so streaming continues;
-        only read/OS errors abort (after both streams are drained).
+        produced lines are delivered promptly. Lines are split on LF, CRLF, or a bare CR, so that progress reports
+        of old ``pg_basebackup``/``pg_rewind`` versions are streamed as well. Exceptions from ``stream_cb`` are
+        swallowed so streaming continues; only read/OS errors abort (after both streams are drained).
 
         :param stream_cb: called as ``stream_cb(stream_name, line)`` for every complete line of *stdout*/*stderr*.
 
@@ -97,24 +104,30 @@ class CancellableSubprocess(CancellableExecutor):
 
         def emit(name: str, line: bytes) -> None:
             try:
-                stream_cb(name, line.rstrip(b'\r'))  # drop trailing CR (CRLF on Windows)
+                stream_cb(name, line)
             except Exception:
                 pass  # keep streaming despite a bad callback
 
         def reader(stream: BufferedReader, name: str, sink: List[bytes]) -> None:
             buf = b''
+            pending_cr = False
             try:
                 while True:
                     # read1() -> a single underlying read: returns as soon as data is available
                     chunk = stream.read1(32768)
                     if not chunk:  # b'' -> EOF
                         break
-                    sink.append(chunk)
+                    sink.append(chunk)  # the caller gets the output with the original line endings
+                    if pending_cr and chunk[:1] == b'\n':
+                        chunk = chunk[1:]  # the LF of a CRLF that got split between two chunks
+                    # a chunk ending with CR is emitted right away rather than awaiting a possible LF,
+                    # otherwise a CR-terminated progress report would be delayed until the next one
+                    pending_cr = chunk[-1:] == b'\r'
                     buf += chunk
-                    *lines, buf = buf.split(b'\n')
+                    *lines, buf = LINE_SEPARATOR_RE.split(buf)
                     for line in lines:
                         emit(name, line)
-                if buf:  # trailing data without a final newline
+                if buf:  # trailing data without a final line separator
                     emit(name, buf)
             finally:
                 stream.close()

--- a/patroni/postgresql/rewind.py
+++ b/patroni/postgresql/rewind.py
@@ -393,6 +393,16 @@ class Rewind(object):
         logger.info('Trying to fetch the missing wal: %s', cmd)
         return self._postgresql.cancellable.call(shlex.split(cmd)) == 0
 
+    @staticmethod
+    def _log_output_line(name: str, line: bytes) -> None:
+        """Log a single line of ``pg_rewind`` output.
+
+        :param name: name of the stream the line was read from, ``stdout`` or ``stderr``.
+        :param line: one line of output without the trailing newline.
+        """
+        if line:
+            logger.info('pg_rewind: %s', line.decode('utf-8', 'replace'))
+
     def _find_missing_wal(self, data: bytes) -> Optional[str]:
         # could not open file "$PGDATA/pg_wal/0000000A00006AA100000068": No such file or directory
         pattern = 'could not open file "'
@@ -494,16 +504,21 @@ class Rewind(object):
         cmd.extend(['-D', self._postgresql.data_dir, '--source-server', dsn])
         cmd.extend(user_options)
 
+        # pg_rewind --progress reports the copy progress while it is running, therefore
+        # the output is streamed to the log as it arrives instead of being dumped after exit
+        stream_cb = self._log_output_line if '--progress' in user_options else None
+
         while True:
             results: Dict[str, bytes] = {}
-            ret = self._postgresql.cancellable.call(cmd, env=env, communicate=results)
+            ret = self._postgresql.cancellable.call(cmd, env=env, communicate=results, stream_cb=stream_cb)
 
             logger.info('pg_rewind exit code=%s', ret)
             if ret is None:
                 return False
 
-            logger.info(' stdout=%s', results['stdout'].decode('utf-8'))
-            logger.info(' stderr=%s', results['stderr'].decode('utf-8'))
+            if stream_cb is None:  # streamed output has already been logged line by line
+                logger.info(' stdout=%s', results['stdout'].decode('utf-8'))
+                logger.info(' stderr=%s', results['stderr'].decode('utf-8'))
             if ret == 0:
                 return True
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -135,6 +135,27 @@ class TestBootstrap(BaseTestPostgresql):
             # compress is in not_allowed_options for PG < 15, error logged via process_user_options
             mock_error.assert_any_call('compress option for basebackup is not allowed')
 
+    @patch.object(Postgresql, 'data_directory_empty', Mock(return_value=True))
+    @patch.object(ConfigHandler, 'pg_version', PropertyMock(return_value=150000))
+    def test_basebackup_progress(self):
+        """Test that pg_basebackup output is streamed to the log when --progress is among user options."""
+        with patch.object(CancellableSubprocess, 'call', Mock(return_value=0)) as mock_call:
+            self.b.basebackup('', None, ['progress'])
+            self.assertEqual(mock_call.call_args[1]['stream_cb'], Bootstrap._log_output_line)
+
+            # without --progress the output is not touched at all, pg_basebackup keeps writing to the terminal
+            self.b.basebackup('', None, {'foo': 'bar'})
+            self.assertIsNone(mock_call.call_args[1]['stream_cb'])
+
+        with patch('patroni.postgresql.bootstrap.logger.info') as mock_info:
+            Bootstrap._log_output_line('stderr', b'271/271 MB (100%) copied')
+            mock_info.assert_called_once_with('pg_basebackup: %s', '271/271 MB (100%) copied')
+
+        with patch('patroni.postgresql.bootstrap.logger.info') as mock_info:
+            # pg_basebackup writes empty lines, they must not pollute the log
+            Bootstrap._log_output_line('stdout', b'')
+            mock_info.assert_not_called()
+
     def test__initdb(self):
         self.assertRaises(Exception, self.b.bootstrap, {'initdb': [{'pgdata': 'bar'}]})
         self.assertRaises(Exception, self.b.bootstrap, {'initdb': [{'foo': 'bar', 1: 2}]})

--- a/tests/test_cancellable.py
+++ b/tests/test_cancellable.py
@@ -57,8 +57,8 @@ class TestCancellableSubprocess(unittest.TestCase):
         communicate = {}
         ret = self.c.call(['cmd'], communicate=communicate, text=True, stream_cb=cb)
         self.assertEqual(ret, 0)
-        # callback errors are swallowed: every line is still delivered (per-stream order is
-        # deterministic), the trailing stdout line has no newline and the stderr CR is stripped
+        # callback errors are swallowed: every line is still delivered (per-stream order is deterministic),
+        # the trailing stdout line has no newline and the stderr CRLF is consumed as a single separator
         self.assertEqual([line for name, line in lines if name == 'stdout'], [b'out1', b'out2', b'tail'])
         self.assertEqual([line for name, line in lines if name == 'stderr'], [b'err1', b'err2'])
         # the full output is still captured back into the communicate dict
@@ -70,6 +70,39 @@ class TestCancellableSubprocess(unittest.TestCase):
         self.assertEqual(kwargs['stdout'], subprocess.PIPE)
         self.assertEqual(kwargs['stderr'], subprocess.PIPE)
         self.assertNotIn('text', kwargs)
+
+    @patch('patroni.postgresql.cancellable.psutil.Popen')
+    def test_call_stream_cb_cr_terminated(self, mock_popen):
+        lines = []
+
+        class MockStream(object):
+
+            def __init__(self, *chunks):
+                self._chunks = list(chunks)
+                self.lines_before_read = []
+                self.close = Mock()
+
+            def read1(self, _):
+                self.lines_before_read.append(list(lines))
+                return self._chunks.pop(0) if self._chunks else b''
+
+        # pg_basebackup (PostgreSQL 10 and older) and pg_rewind (PostgreSQL 11 and older) terminate every
+        # progress report with a bare CR, and a CRLF may be split between two reads
+        stdout = MockStream(b'128/512 MB (25%) copied\r',
+                            b'256/512 MB (50%) copied\r\n512/512 MB (100%) copied\r',
+                            b'\nsyncing data to disk ...')
+        mock_popen.return_value = Mock(stdout=stdout, stderr=None)
+        mock_popen.return_value.wait.return_value = 0
+
+        communicate = {}
+        ret = self.c.call(['cmd'], communicate=communicate, stream_cb=lambda name, line: lines.append(line))
+        self.assertEqual(ret, 0)
+        # the CR-terminated report was delivered while the process was still writing, not at EOF
+        self.assertEqual(stdout.lines_before_read[1], [b'128/512 MB (25%) copied'])
+        self.assertEqual(lines, [b'128/512 MB (25%) copied', b'256/512 MB (50%) copied',
+                                 b'512/512 MB (100%) copied', b'syncing data to disk ...'])
+        self.assertEqual(communicate['stdout'], b'128/512 MB (25%) copied\r256/512 MB (50%) copied\r\n'
+                                                b'512/512 MB (100%) copied\r\nsyncing data to disk ...')
 
     @patch('patroni.postgresql.cancellable.psutil.Popen')
     def test_call_stream_cb_ignored_with_input(self, mock_popen):

--- a/tests/test_rewind.py
+++ b/tests/test_rewind.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, mock_open, patch, PropertyMock
+from unittest.mock import call, Mock, mock_open, patch, PropertyMock
 
 from patroni.postgresql import Postgresql
 from patroni.postgresql.cancellable import CancellableSubprocess
@@ -164,6 +164,74 @@ class TestRewind(BaseTestPostgresql):
             if 'rewind' in self.p.config._config:
                 del self.p.config._config['rewind']
             self.assertTrue(self.r.pg_rewind(r))
+
+    def test_pg_rewind_progress(self):
+        """Test that pg_rewind output is streamed to the log when --progress is among user options."""
+        r = {'user': '', 'host': '', 'port': '', 'database': '', 'password': ''}
+
+        def mock_call_with_stream_cb(self, cmd, *args, **kwargs):
+            mock_call_with_stream_cb.stream_cb = kwargs.pop('stream_cb', None)
+            communicate = kwargs.pop('communicate', None)
+            if isinstance(communicate, dict):
+                communicate.update(stdout=b'', stderr=b'')
+            return 0
+
+        with patch.object(Postgresql, 'major_version', PropertyMock(return_value=150000)), \
+                patch('subprocess.check_output', Mock(return_value=b'foo %f %p %r %% % %')), \
+                patch.object(CancellableSubprocess, 'call', mock_call_with_stream_cb):
+
+            self.p.config._config['rewind'] = ['progress']
+            with patch('patroni.postgresql.rewind.logger.info') as mock_info:
+                self.assertTrue(self.r.pg_rewind(r))
+                # the stdout/stderr summary is not logged, the output has already been streamed line by line
+                mock_info.assert_called_with('pg_rewind exit code=%s', 0)
+                self.assertEqual(mock_info.call_count, 2)
+            self.assertEqual(mock_call_with_stream_cb.stream_cb, Rewind._log_output_line)
+
+            del self.p.config._config['rewind']
+            with patch('patroni.postgresql.rewind.logger.info') as mock_info:
+                self.assertTrue(self.r.pg_rewind(r))
+                self.assertEqual(mock_info.call_args_list[-2:],
+                                 [call(' stdout=%s', ''), call(' stderr=%s', '')])
+            self.assertIsNone(mock_call_with_stream_cb.stream_cb)
+
+        with patch('patroni.postgresql.rewind.logger.info') as mock_info:
+            Rewind._log_output_line('stderr', b'271/271 MB (100%) copied')
+            mock_info.assert_called_once_with('pg_rewind: %s', '271/271 MB (100%) copied')
+
+        with patch('patroni.postgresql.rewind.logger.info') as mock_info:
+            # pg_rewind writes empty lines, they must not pollute the log
+            Rewind._log_output_line('stdout', b'')
+            mock_info.assert_not_called()
+
+        with patch('patroni.postgresql.rewind.logger.info') as mock_info:
+            # the output is produced in the user's locale and must never break the callback
+            Rewind._log_output_line('stderr', b'pg_rewind: \xff')
+            mock_info.assert_called_once_with('pg_rewind: %s', 'pg_rewind: \ufffd')
+
+        def mock_call_missing_wal(self, cmd, *args, **kwargs):
+            mock_call_missing_wal.stream_cb = kwargs.pop('stream_cb', None)
+            communicate = kwargs.pop('communicate', None)
+            if isinstance(communicate, dict):
+                communicate.update(stdout=b'', stderr=b'')
+                communicate[mock_call_missing_wal.pipe] = \
+                    b'pg_rewind: error: could not open file ' \
+                    b'"data/postgresql0/pg_xlog/000000010000000000000003": No such file'
+            return 1
+
+        # On PostgreSQL < 15 the streamed output must remain available for the missing WAL detection,
+        # no matter whether pg_rewind reported the missing file on stderr or stdout
+        for pipe in ('stderr', 'stdout'):
+            mock_call_missing_wal.pipe = pipe
+            with patch.object(Postgresql, 'major_version', PropertyMock(return_value=120000)), \
+                    patch('subprocess.check_output', Mock(return_value=b'foo %f %p %r %% % %')), \
+                    patch.object(CancellableSubprocess, 'call', mock_call_missing_wal), \
+                    patch.object(Rewind, '_fetch_missing_wal', Mock(return_value=False)) as mock_fetch:
+                self.p.config._config['rewind'] = ['progress']
+                self.assertFalse(self.r.pg_rewind(r))
+                del self.p.config._config['rewind']
+                self.assertIsNotNone(mock_call_missing_wal.stream_cb)
+                mock_fetch.assert_called_once_with('foo %f %p %r %% % %', '000000010000000000000003')
 
     @patch.object(Rewind, 'can_rewind', PropertyMock(return_value=True))
     def test__get_local_timeline_lsn(self):


### PR DESCRIPTION
Closes https://github.com/patroni/patroni/issues/3543

Rebased on top of master now that #3684 (the `stream_cb` plumbing in `CancellableSubprocess`) is merged, so this PR is the consumer side plus one fix in the reader.

When the `progress` option is present in the custom `pg_rewind` options (supported since #3484) or in the `basebackup` options, Patroni streams the output of the command to its log as it arrives, one line at a time, prefixed with `pg_rewind:` / `pg_basebackup:`, instead of dumping it only after the process exits (pg_rewind) or writing it to the terminal Patroni inherited (pg_basebackup).

Implementation notes:

- `Rewind._log_output_line()` and `Bootstrap._log_output_line()` are passed as `stream_cb` to `CancellableSubprocess.call()` only when `--progress` is among the user options. Without it nothing changes: `stream_cb` is None, pg_basebackup stdio is not redirected at all and pg_rewind still logs the captured stdout/stderr after exit.
- Streamed lines are logged at INFO, the level already used for the post-exit dump. For pg_rewind that post-exit `stdout=`/`stderr=` dump is skipped while streaming, so the output is not logged twice.
- `communicate` still returns the byte-exact output of each pipe separately, so `_find_missing_wal()` and its pre-PG15 retry loop are unaffected.
- Progress reports of pg_basebackup (PostgreSQL 10 and older) and pg_rewind (PostgreSQL 11 and older) are terminated with a bare CR rather than LF, because those versions do not check whether the output is a terminal. The reader in `CancellableSubprocess` therefore splits records on LF, CRLF and CR; otherwise the whole progress of these versions would reach the log only at exit. The bytes handed back through `communicate` keep the original line endings.

Verified with unit tests, including one that proves a CR-terminated record is delivered while the process is still writing, with 100% coverage of `patroni/postgresql/cancellable.py`, and against a real subprocess emitting CR-terminated progress through a pipe.
