### PR TITLE
ci: pin isort/isort-action@master to a full commit SHA

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -251,7 +251,7 @@ jobs:
         cache: pip
 
     - name: isort
-      uses: isort/isort-action@master
+      uses: isort/isort-action@24d8a7a51d33ca7f36c3f23598dafa33f7071326 # v1.1.1
       with:
         requirementsFiles: "requirements.txt requirements.dev.txt requirements.docs.txt"
         sort-paths: "patroni tests features setup.py"


### PR DESCRIPTION
Hi, and thank you for Patroni.

Small supply-chain hardening for `.github/workflows/tests.yaml`. The `isort` job uses the third-party action `isort/isort-action@master` (line 254). `@master` is a mutable branch, and the workflow declares `CODACY_PROJECT_TOKEN` at the workflow level (lines 10-12), so that secret is present in every job's environment — including the `isort` job when `isort-action@master` runs. If that upstream branch were repointed or compromised (the `tj-actions/changed-files` class of risk), it could read the Codacy token on `push`/merge events.

This PR pins the action to a full commit SHA (`v1.1.1`), consistent with how the other third-party actions in this repo are already version-referenced. Behaviour is unchanged. (If you'd also like, a natural follow-up would be to scope `CODACY_PROJECT_TOKEN` onto only the jobs that use it — happy to do that separately.)

For transparency: I used AI assistance to help identify this and draft the change; I verified every line against the live workflow myself.
