### PR TITLE
docs: give advice on ttl when using failsafe_mode

### DIFF
--- a/docs/dcs_failsafe_mode.rst
+++ b/docs/dcs_failsafe_mode.rst
@@ -25,6 +25,13 @@ DCS Failsafe Mode
 
 We introduce a new special option, the ``failsafe_mode``. It could be enabled only via global :ref:`dynamic configuration <dynamic_configuration>` stored in the DCS ``/config`` key. If the failsafe mode is enabled and the leader lock update in DCS failed due to reasons different from the version/value/index mismatch, Postgres may continue to run as a primary if it can access all known members of the cluster via Patroni REST API.
 
+.. warning::
+    when using **failsafe_mode** ensure there is some margin for the **ttl** value, to allow the failsafe check to complete before the leader lock expires:
+
+    .. code-block:: python
+
+        loop_wait + 2 * retry_timeout + 10 <= ttl
+
 
 Low-level implementation details
 --------------------------------


### PR DESCRIPTION
I seem to have discovered that if there is an unusually slow `etcd` cluster which hangs the existing TCP connections for an extended period, then there is a race between `loop_wait + 2 * retry_timeout` and `ttl`.

Sometimes the former wins and the cluster enters `failsafe_mode`. Other times `ttl` wins and the standby manages to grab `/leader` and force a failover.

Adding a small margin to `ttl` ensures that the `failsafe_mode` code path should always be engaged, preventing unnecessary failovers during DCS instability.

I realise the better solution is "fix the DCS issues" but sometimes we're not in control of that portion of the infrastructure, and this warning will allow people to correctly configure Patroni to use the `failsafe_mode` feature.