### PR TITLE
fix(validator): allow synchronous_mode to accept 'quorum' and boolean…

### DIFF
--- a/patroni/validator.py
+++ b/patroni/validator.py
@@ -16,7 +16,7 @@ from .dcs import dcs_modules
 from .exceptions import ConfigParseError, PatroniAssertionError
 from .log import type_logformat
 from .postgresql.sync import SYNC_STRICT_PLACEHOLDER
-from .utils import data_directory_is_empty, get_major_version, parse_int, parse_real, split_host_port
+from .utils import data_directory_is_empty, get_major_version, parse_bool, parse_int, parse_real, split_host_port
 
 # Additional parameters to fine-tune validation process
 _validation_params: Dict[str, Any] = {}
@@ -972,6 +972,16 @@ def validate_watchdog_mode(value: Any) -> None:
     assert_(value in (False, "off", "automatic", "required"))
 
 
+def validate_synchronous_mode(value: Any) -> None:
+    """Validate ``synchronous_mode`` configuration option.
+
+    :param value: value of ``synchronous_mode`` to be validated.
+    """
+    assert_(isinstance(value, (str, bool)), "expected type is not a string or boolean")
+    if isinstance(value, str):
+        assert_(value.lower() == "quorum" or parse_bool(value) is not None, "invalid value for synchronous_mode")
+
+
 def validate_name(value: Any) -> None:
     """Validate ``name`` configuration option.
 
@@ -1144,7 +1154,7 @@ schema = Schema({
                 Optional("archive_cleanup_command"): str,
                 Optional("recovery_min_apply_delay"): str
             },
-            Optional("synchronous_mode"): bool,
+            Optional("synchronous_mode"): validate_synchronous_mode,
             Optional("synchronous_mode_strict"): bool,
             Optional("synchronous_node_count"): IntValidator(min=1, raise_assert=True),
         },

--- a/patroni/validator.py
+++ b/patroni/validator.py
@@ -977,9 +977,8 @@ def validate_synchronous_mode(value: Any) -> None:
 
     :param value: value of ``synchronous_mode`` to be validated.
     """
-    assert_(isinstance(value, (str, bool)), "expected type is not a string or boolean")
-    if isinstance(value, str):
-        assert_(value.lower() == "quorum" or parse_bool(value) is not None, "invalid value for synchronous_mode")
+    assert_(isinstance(value, str) and value.lower() == "quorum" or parse_bool(value) is not None,
+            "invalid value for synchronous_mode")
 
 
 def validate_name(value: Any) -> None:

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -475,3 +475,36 @@ class TestValidator(unittest.TestCase):
         c['raft']['connection_retry_time'] = -1
         errors = schema(c)
         self.assertTrue(any('connection_retry_time' in e for e in errors))
+
+    def test_synchronous_mode_validation(self, *args):
+        c = copy.deepcopy(config)
+        
+        # Test with True
+        c['bootstrap'] = {'dcs': {'synchronous_mode': True}}
+        errors = schema(c)
+        self.assertNotIn('bootstrap.dcs.synchronous_mode', "\n".join(errors))
+
+        # Test with False
+        c['bootstrap'] = {'dcs': {'synchronous_mode': False}}
+        errors = schema(c)
+        self.assertNotIn('bootstrap.dcs.synchronous_mode', "\n".join(errors))
+
+        # Test with "quorum"
+        c['bootstrap'] = {'dcs': {'synchronous_mode': 'quorum'}}
+        errors = schema(c)
+        self.assertNotIn('bootstrap.dcs.synchronous_mode', "\n".join(errors))
+
+        # Test with "on"
+        c['bootstrap'] = {'dcs': {'synchronous_mode': 'on'}}
+        errors = schema(c)
+        self.assertNotIn('bootstrap.dcs.synchronous_mode', "\n".join(errors))
+
+        # Test with invalid string value
+        c['bootstrap'] = {'dcs': {'synchronous_mode': 'invalid'}}
+        errors = schema(c)
+        self.assertTrue(any('bootstrap.dcs.synchronous_mode' in error for error in errors))
+
+        # Test with invalid numeric value (not a truthy/falsy recognized by parse_bool)
+        c['bootstrap'] = {'dcs': {'synchronous_mode': 123}}
+        errors = schema(c)
+        self.assertTrue(any('bootstrap.dcs.synchronous_mode' in error for error in errors))

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -478,7 +478,6 @@ class TestValidator(unittest.TestCase):
 
     def test_synchronous_mode_validation(self, *args):
         c = copy.deepcopy(config)
-        
         # Test with True
         c['bootstrap'] = {'dcs': {'synchronous_mode': True}}
         errors = schema(c)


### PR DESCRIPTION
The synchronous_mode configuration option accepts three types of values at runtime (via global_config.py): boolean, PostgreSQL-style boolean strings (on/off/yes/no/true/false/1/0), and the special 'quorum' string.

However, the config validator (patroni --validate-config) only accepted strict Python bool, rejecting valid values like 'quorum' with:
  'synchronous_mode quorum is not a boolean'

This adds a validate_synchronous_mode() function that mirrors the runtime logic by using parse_bool() for boolean-like strings and explicit check for 'quorum', keeping validator.py consistent with global_config.py.

Fixes #3606