### PR TITLE
Prevent unclean shutdown when postmaster hangs during restart

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -2056,11 +2056,15 @@ class Ha(object):
         def after_start() -> None:
             self.notify_mpp_coordinator('after_promote')
 
+        has_lock = self.has_lock()
+        stop_timeout = self.primary_stop_timeout() if has_lock else None
+
         # For non async cases we want to wait for restart to complete or timeout before returning.
         do_restart = functools.partial(self.state_handler.restart, timeout, self._async_executor.critical_task,
-                                       before_shutdown=before_shutdown if self.has_lock() else None,
-                                       after_start=after_start if self.has_lock() else None)
-        if self.is_synchronous_mode() and not self.has_lock():
+                                       before_shutdown=before_shutdown if has_lock else None,
+                                       after_start=after_start if has_lock else None,
+                                       stop_timeout=stop_timeout)
+        if self.is_synchronous_mode() and not has_lock:
             do_restart = functools.partial(self.while_not_sync_standby, do_restart)
 
         if run_async:

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -854,7 +854,8 @@ class Postgresql(object):
 
     def stop(self, mode: str = 'fast', block_callbacks: bool = False, checkpoint: Optional[bool] = None,
              on_safepoint: Optional[Callable[..., Any]] = None, on_shutdown: Optional[Callable[[int, int], Any]] = None,
-             before_shutdown: Optional[Callable[..., Any]] = None, stop_timeout: Optional[int] = None) -> bool:
+             before_shutdown: Optional[Callable[..., Any]] = None, stop_timeout: Optional[int] = None,
+             safe_kill: bool = False) -> bool:
         """Stop PostgreSQL
 
         Supports a callback when a safepoint is reached. A safepoint is when no user backend can return a successful
@@ -864,12 +865,13 @@ class Postgresql(object):
         :param on_safepoint: This callback is called when no user backends are running.
         :param on_shutdown: is called when pg_controldata starts reporting `Database cluster state: shut down`
         :param before_shutdown: is called after running optional CHECKPOINT and before running pg_ctl stop
+        :param safe_kill: if True, only terminate postmaster after a clean shut down (used for restart)
         """
         if checkpoint is None:
             checkpoint = False if mode == 'immediate' else True
 
         success, pg_signaled = self._do_stop(mode, block_callbacks, checkpoint, on_safepoint,
-                                             on_shutdown, before_shutdown, stop_timeout)
+                                             on_shutdown, before_shutdown, stop_timeout, safe_kill)
         if success:
             # block_callbacks is used during restart to avoid
             # running start/stop callbacks in addition to restart ones
@@ -884,7 +886,8 @@ class Postgresql(object):
 
     def _do_stop(self, mode: str, block_callbacks: bool, checkpoint: bool,
                  on_safepoint: Optional[Callable[..., Any]], on_shutdown: Optional[Callable[[int, int], Any]],
-                 before_shutdown: Optional[Callable[..., Any]], stop_timeout: Optional[int]) -> Tuple[bool, bool]:
+                 before_shutdown: Optional[Callable[..., Any]], stop_timeout: Optional[int],
+                 safe_kill: bool = False) -> Tuple[bool, bool]:
         postmaster = self.is_running()
         if not postmaster:
             if on_safepoint:
@@ -920,19 +923,21 @@ class Postgresql(object):
         if on_safepoint and postmaster.wait_for_user_backends_to_close(stop_timeout):
             on_safepoint()
 
-        if on_shutdown and mode in ('fast', 'smart'):
+        # Wait for pg_controldata `Database cluster state:` to change to "shut down"
+        clean_shutdown = False
+        if (on_shutdown or safe_kill) and mode in ('fast', 'smart'):
             i = 0
-            # Wait for pg_controldata `Database cluster state:` to change to "shut down"
             while postmaster.is_running():
                 data = self.controldata()
-                if data.get('Database cluster state', '') == 'shut down':
-                    checkpoint_lsn, prev_lsn = self.latest_checkpoint_locations(data)
-                    if checkpoint_lsn is not None and prev_lsn is not None:
-                        on_shutdown(checkpoint_lsn, prev_lsn)
-                        if on_safepoint:
-                            on_safepoint()
-                    break
-                elif data.get('Database cluster state', '').startswith('shut down'):  # shut down in recovery
+                state = data.get('Database cluster state', '')
+                if state.startswith('shut down'):
+                    clean_shutdown = True
+                    if on_shutdown and state == 'shut down':
+                        checkpoint_lsn, prev_lsn = self.latest_checkpoint_locations(data)
+                        if checkpoint_lsn is not None and prev_lsn is not None:
+                            on_shutdown(checkpoint_lsn, prev_lsn)
+                            if on_safepoint:
+                                on_safepoint()
                     break
                 elif stop_timeout and i >= stop_timeout:
                     stop_timeout = 0
@@ -941,8 +946,16 @@ class Postgresql(object):
                 i += STOP_POLLING_INTERVAL
 
         try:
-            postmaster.wait(timeout=stop_timeout)
+            # With safe_kill, once cleanly shut down there is nothing left to wait for,
+            # so terminate any lingering processes (e.g. replication connections) right away.
+            postmaster.wait(timeout=0 if safe_kill and clean_shutdown else stop_timeout)
         except TimeoutExpired:
+            # With safe_kill, never terminate before a clean shutdown: recovering from an
+            # unclean shutdown may take much longer than waiting for shutdown would have.
+            if safe_kill and not clean_shutdown:
+                logger.warning("Timeout during postmaster stop, but Postgres is not 'shut down'. Skipping kill")
+                return False, True
+
             logger.warning("Timeout during postmaster stop, aborting Postgres.")
             if not self.terminate_postmaster(postmaster, mode, stop_timeout):
                 postmaster.wait()
@@ -1042,7 +1055,8 @@ class Postgresql(object):
     def restart(self, timeout: Optional[float] = None, task: Optional[CriticalTask] = None,
                 block_callbacks: bool = False, role: Optional[PostgresqlRole] = None,
                 before_shutdown: Optional[Callable[..., Any]] = None,
-                after_start: Optional[Callable[..., Any]] = None) -> Optional[bool]:
+                after_start: Optional[Callable[..., Any]] = None,
+                stop_timeout: Optional[int] = None) -> Optional[bool]:
         """Restarts PostgreSQL.
 
         When timeout parameter is set the call will block either until PostgreSQL has started, failed to start or
@@ -1053,7 +1067,8 @@ class Postgresql(object):
         self.set_state(PostgresqlState.RESTARTING)
         if not block_callbacks:
             self.__cb_pending = CallbackAction.ON_RESTART
-        ret = self.stop(block_callbacks=True, before_shutdown=before_shutdown)\
+        ret = self.stop(block_callbacks=True, before_shutdown=before_shutdown,
+                        stop_timeout=stop_timeout, safe_kill=True) \
             and self.start(timeout, task, True, role, after_start)
         if not ret and not self.is_starting():
             logger.warning('restart failed (%r)', self.state)

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -1365,6 +1365,18 @@ class TestHa(PostgresInit):
             global_config.update(self.ha.cluster)
             self.assertEqual(self.ha.primary_stop_timeout(), None)
 
+    def test_restart_passes_primary_stop_timeout(self):
+        self.ha.cluster = get_cluster_initialized_with_leader(sync=(self.p.name, 'other'))
+        self.ha.cluster.config.data.update({'primary_stop_timeout': 30})
+        global_config.update(self.ha.cluster)
+        self.ha.has_lock = true
+        self.p.restart = Mock(return_value=True)
+
+        with patch.object(Ha, 'is_synchronous_mode', Mock(return_value=True)):
+            self.assertEqual(self.ha.restart({}), (True, 'restarted successfully'))
+
+        self.assertEqual(self.p.restart.call_args.kwargs.get('stop_timeout'), 30)
+
     @patch('patroni.postgresql.Postgresql.follow')
     def test_demote_immediate(self, follow):
         self.ha.has_lock = true

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -1375,7 +1375,7 @@ class TestHa(PostgresInit):
         with patch.object(Ha, 'is_synchronous_mode', Mock(return_value=True)):
             self.assertEqual(self.ha.restart({}), (True, 'restarted successfully'))
 
-        self.assertEqual(self.p.restart.call_args.kwargs.get('stop_timeout'), 30)
+        self.assertEqual(self.p.restart.call_args[1].get('stop_timeout'), 30)
 
     @patch('patroni.postgresql.Postgresql.follow')
     def test_demote_immediate(self, follow):

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -260,10 +260,35 @@ class TestPostgresql(BaseTestPostgresql):
         with patch.object(Postgresql, 'controldata', Mock(return_value={'Database cluster state': 'shutting down'})):
             self.assertTrue(self.p.stop(on_shutdown=mock_callback, stop_timeout=3))
 
+    @patch('time.sleep', Mock())
+    @patch.object(Postgresql, '_wait_for_connection_close', Mock())
+    @patch.object(Postgresql, 'is_running')
+    def test_stop_safe_kill(self, mock_is_running):
+        mock_postmaster = MockPostmaster()
+        mock_is_running.return_value = mock_postmaster
+        mock_postmaster.wait.side_effect = psutil.TimeoutExpired(0)
+
+        # Timeout before shut down: do not terminate (restart must avoid unclean shutdown)
+        with patch.object(Postgresql, 'controldata', Mock(return_value={'Database cluster state': 'shutting down'})):
+            with patch.object(Postgresql, 'terminate_postmaster') as mock_terminate:
+                self.assertFalse(self.p.stop(stop_timeout=3, safe_kill=True))
+                mock_terminate.assert_not_called()
+
+        # After clean shut down: terminate remaining processes
+        with patch.object(Postgresql, 'controldata', Mock(return_value={'Database cluster state': 'shut down'})):
+            with patch.object(Postgresql, 'terminate_postmaster', Mock(return_value=True)) as mock_terminate:
+                self.assertTrue(self.p.stop(stop_timeout=3, safe_kill=True))
+                mock_terminate.assert_called_once()
+
     def test_restart(self):
         self.p.start = Mock(return_value=False)
         self.assertFalse(self.p.restart())
         self.assertEqual(self.p.state, PostgresqlState.RESTART_FAILED)
+        self.p.start = Mock(return_value=True)
+        with patch.object(self.p, 'stop', Mock(return_value=True)) as mock_stop:
+            self.assertTrue(self.p.restart(stop_timeout=30))
+            self.assertEqual(mock_stop.call_args.kwargs.get('stop_timeout'), 30)
+            self.assertTrue(mock_stop.call_args.kwargs.get('safe_kill'))
 
     @patch('os.chmod', Mock())
     @patch('builtins.open', MagicMock())

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -287,8 +287,8 @@ class TestPostgresql(BaseTestPostgresql):
         self.p.start = Mock(return_value=True)
         with patch.object(self.p, 'stop', Mock(return_value=True)) as mock_stop:
             self.assertTrue(self.p.restart(stop_timeout=30))
-            self.assertEqual(mock_stop.call_args.kwargs.get('stop_timeout'), 30)
-            self.assertTrue(mock_stop.call_args.kwargs.get('safe_kill'))
+            self.assertEqual(mock_stop.call_args[1].get('stop_timeout'), 30)
+            self.assertTrue(mock_stop.call_args[1].get('safe_kill'))
 
     @patch('os.chmod', Mock())
     @patch('builtins.open', MagicMock())


### PR DESCRIPTION
Previously, if stop_timeout was reached during a restart, Patroni would unconditionally send SIGKILL to the postmaster. This caused an unclean shutdown and triggered crash recovery if PostgreSQL was legitimately blocked (e.g. waiting for synchronous standby).

This commit introduces a safe_kill option. During a restart, Patroni now checks pg_controldata before sending SIGKILL. If the database is not in the "shut down" state, Patroni skips the kill to prevent crash recovery and fails the restart gracefully. If it is safely "shut down" but the postmaster is hung, Patroni proceeds with the kill.

Closes #3657