### PR TITLE
Add site configuration and make cloning site-aware

### DIFF
--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -13,6 +13,7 @@ Global/Universal
 -  **PATRONI\_NAME**: name of the node where the current instance of Patroni is running. Must be unique for the cluster. The value ``__patroni_strict_sync_replica_placeholder__`` is reserved for internal use by Patroni and cannot be used as a node name.
 -  **PATRONI\_NAMESPACE**: path within the configuration store where Patroni will keep information about the cluster. Default value: "/service"
 -  **PATRONI\_SCOPE**: cluster name
+-  **PATRONI\_SITE**: optional string name of the physical site or location where this Patroni node runs, such as a data center, availability zone, or region. When configured, Patroni records it in member metadata and uses it to prefer local clone sources for replica bootstrap and ``patronictl reinit``.
 -  **PG\_MALLOC\_ARENA\_MAX**: custom value for ``MALLOC_ARENA_MAX`` environment variable for  ``postmaster`` process. If not set, ``postmaster`` will inherit ``MALLOC_ARENA_MAX`` value.
 
 Log

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -732,6 +732,11 @@ The following information is included in the output:
 ``Cluster``
     Name of the Patroni cluster.
 
+``Site``
+    Site of the Patroni node, as set in the local configuration.
+
+    If all members belong to the same site, the site is shown in the cluster header instead of as a column.
+
 ``Member``
     Name of the Patroni member.
 
@@ -888,6 +893,11 @@ Parameters
 
     ``TIME`` is the interval between refreshes, in seconds.
 
+``--site``
+    Filter the listed members by the configured site name.
+
+    Only members whose ``site`` matches the provided value are shown.
+
 .. _patronictl_list_examples:
 
 Examples
@@ -898,26 +908,26 @@ Show information about the cluster in pretty format:
 .. code:: bash
 
     $ patronictl -c postgres0.yml list batman
-    + Cluster: batman (7277694203142172922) -+-----------+----+-------------+-----+------------+-----+
-    | Member      | Host           | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
-    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  5 |             |     |            |     |
-    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
+    + Cluster: batman (7277694203142172922) --------+-----------+----+-------------+-----+------------+-----+
+    | Site | Member      | Host           | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag |
+    +------+-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
+    | dc1  | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  5 |             |     |            |     |
+    | dc1  | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    | dc2  | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    +------+-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
 
 Show information about the cluster in pretty format with extended columns:
 
 .. code:: bash
 
     $ patronictl -c postgres0.yml list batman -e
-    + Cluster: batman (7277694203142172922) -+-----------+----+-------------+-----+------------+-----+-----------------+------------------------+-------------------+------+
-    | Member      | Host           | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag | Pending restart | Pending restart reason | Scheduled restart | Tags |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+-----------------+------------------------+-------------------+------+
-    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  5 |             |     |            |     |                 |                        |                   |      |
-    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |                 |                        |                   |      |
-    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |                 |                        |                   |      |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+-----------------+------------------------+-------------------+------+
+    + Cluster: batman (7277694203142172922) --------+-----------+----+-------------+-----+------------+-----+-----------------+------------------------+-------------------+------+
+    | Site | Member      | Host           | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag | Pending restart | Pending restart reason | Scheduled restart | Tags |
+    +------+-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+-----------------+------------------------+-------------------+------+
+    | dc1  | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  5 |             |     |            |     |                 |                        |                   |      |
+    | dc1  | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |                 |                        |                   |      |
+    | dc2  | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |                 |                        |                   |      |
+    +------+-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+-----------------+------------------------+-------------------+------+
 
 Show information about the cluster in YAML format, with timestamp of execution:
 
@@ -929,6 +939,7 @@ Show information about the cluster in YAML format, with timestamp of execution:
       Host: 127.0.0.1:5432
       Member: postgresql0
       Role: Leader
+      Site: dc1
       State: running
       TL: 5
     - Cluster: batman
@@ -939,6 +950,7 @@ Show information about the cluster in YAML format, with timestamp of execution:
       Replay Lag: 0
       Member: postgresql1
       Role: Replica
+      Site: dc1
       State: streaming
       TL: 5
     - Cluster: batman
@@ -949,6 +961,7 @@ Show information about the cluster in YAML format, with timestamp of execution:
       Replay Lag: 0
       Member: postgresql2
       Role: Replica
+      Site: dc2
       State: streaming
       TL: 5
 

--- a/docs/replica_bootstrap.rst
+++ b/docs/replica_bootstrap.rst
@@ -188,7 +188,12 @@ A ``basebackup`` method is a special case: it will be used if
 ``create_replica_methods`` is empty, although it is possible
 to list it explicitly among the ``create_replica_methods`` methods. This method initializes a new replica with the
 ``pg_basebackup``, the base backup is taken from the leader unless there are replicas with ``clonefrom`` tag, in which case one
-of such replicas will be used as the origin for pg_basebackup. It works without any configuration; however, it is
+of such replicas will be used as the origin for pg_basebackup. When node ``site`` values are configured, Patroni prefers
+running replicas in the same site with ``clonefrom: true`` as local sources for bootstrap. If no local replica candidate
+exists, Patroni will prefer a local leader in the same site before falling back to a remote clone source or the actual
+leader.
+
+It works without any configuration; however, it is
 possible to specify a ``basebackup`` configuration section. Same rules as with the other method configuration apply,
 namely, only long (with --) options should be specified there. Not all parameters make sense, if you override a connection
 string or provide an option to created tar-ed or compressed base backups, patroni won't be able to make a replica out

--- a/docs/yaml_configuration.rst
+++ b/docs/yaml_configuration.rst
@@ -10,8 +10,9 @@ Global/Universal
 -  **thread\_pool\_size**: size of thread pool used by Patroni to execute asynchronous tasks and communicate via REST API with other members during leader race or failsafe checks. Minimal value is ``5``, default value is ``5``.
 -  **thread\_stack\_size**: specifies the stack size to be used for threads started by Patroni. Value must be aligned by ``64kB``. Minimal value is ``64kB``,  default value (set by Patroni) is ``512kB``.
 -  **name**: the name of the host. Must be unique for the cluster. The value ``__patroni_strict_sync_replica_placeholder__`` is reserved for internal use by Patroni and cannot be used as a node name.
--  **namespace**: path within the configuration store where Patroni will keep information about the cluster. Default value: "/service"
--  **scope**: cluster name
+-  **namespace**: path within the configuration store where Patroni will keep information about the cluster. Default value: "/service".
+-  **scope**: cluster name.
+-  **site**: optional string name of the physical site or location where this Patroni node runs, such as a data center, availability zone, or region. When configured, Patroni records it in member metadata and uses it to prefer local clone sources for replica bootstrap and ``patronictl reinit``.
 
 .. _log_settings:
 

--- a/features/site_awareness.feature
+++ b/features/site_awareness.feature
@@ -1,0 +1,18 @@
+Feature: site awareness
+  Scenario: setup a mutisite cluster
+    When I start postgres-0 in site dc1
+    And postgres-0 is a leader after 10 seconds
+    And there is a non empty initialize key in DCS after 15 seconds
+    And "members/postgres-0" key in DCS has site=dc1 after 5 seconds
+    And I start postgres-1 in site dc1 with failover priority 2, sync priority 2
+    And I start postgres-2 in site dc2 with failover priority 3, sync priority 3
+    And I start postgres-3 in site dc2 with failover priority 4, sync priority 4
+    Then "members/postgres-1" key in DCS has site=dc1 after 5 seconds
+    And "members/postgres-2" key in DCS has site=dc2 after 5 seconds
+    And "members/postgres-3" key in DCS has site=dc2 after 5 seconds
+    And "status" key in DCS has dc1 in current_site
+
+  Scenario: test site-aware reinit
+    When I run patronictl.py reinit batman postgres-2 --force
+    Then I receive a response returncode 0
+    And there is one of ["bootstrapped from replica 'postgres-3'"] INFO in the postgres-2 patroni log after 25 seconds

--- a/features/site_awareness.feature
+++ b/features/site_awareness.feature
@@ -10,6 +10,9 @@ Feature: site awareness
     Then "members/postgres-1" key in DCS has site=dc1 after 5 seconds
     And "members/postgres-2" key in DCS has site=dc2 after 5 seconds
     And "members/postgres-3" key in DCS has site=dc2 after 5 seconds
+    And "members/postgres-1" key in DCS has state=running after 15 seconds
+    And "members/postgres-2" key in DCS has state=running after 15 seconds
+    And "members/postgres-3" key in DCS has state=running after 15 seconds
     And "status" key in DCS has dc1 in current_site
 
   Scenario: test site-aware reinit

--- a/features/site_awareness.feature
+++ b/features/site_awareness.feature
@@ -1,5 +1,5 @@
 Feature: site awareness
-  Scenario: setup a mutisite cluster
+  Scenario: setup a multisite cluster
     When I start postgres-0 in site dc1
     And postgres-0 is a leader after 10 seconds
     And there is a non empty initialize key in DCS after 15 seconds

--- a/features/steps/site_awareness.py
+++ b/features/steps/site_awareness.py
@@ -1,4 +1,6 @@
-from behave import step
+import time
+
+from behave import step, then
 
 
 @step('I start {name:name} in site {site_name:w} with failover priority {failover_priority:d}, '
@@ -21,3 +23,25 @@ def start_patroni_tags(context, name, site_name, failover_priority, sync_priorit
 @step('I start {name:name} in site {site_name:w}')
 def start_patroni(context, name, site_name):
     start_patroni_tags(context, name, site_name, None, None)
+
+
+@then('{name:name} is in sync with primary after {timeout:d} seconds')
+def replica_not_lagging(context, name, timeout):
+    leader = context.dcs_ctl.query("leader")
+    bound_time = time.time() + timeout
+    function_name = 'pg_current_xlog_location()' if context.pctl.server_version / 10000 < 10 else 'pg_current_wal_lsn()'
+    location_name = 'replay_location' if context.pctl.server_version / 10000 < 10 else 'replay_lsn'
+
+    while time.time() < bound_time:
+        cur = context.pctl.query(
+            leader,
+            f"SELECT {function_name} - {location_name} FROM pg_catalog.pg_stat_replication \
+                WHERE application_name = '{name}'",
+            fail_ok=True
+        )
+        if cur and cur.fetchall() == [(0,)]:
+            break
+
+        time.sleep(1)
+    else:
+        assert False, "{0} is lagging behind after {1} seconds".format(name, timeout)

--- a/features/steps/site_awareness.py
+++ b/features/steps/site_awareness.py
@@ -1,0 +1,23 @@
+from behave import step
+
+
+@step('I start {name:name} in site {site_name:w} with failover priority {failover_priority:d}, '
+      'sync priority {sync_priority:d}')
+def start_patroni_tags(context, name, site_name, failover_priority, sync_priority):
+    config = {
+        "site": site_name,
+        "tags": {
+            "clonefrom": True
+        }
+    }
+    if failover_priority is not None:
+        config["tags"]["failover_priority"] = failover_priority
+    if sync_priority is not None:
+        config["tags"]["sync_priority"] = sync_priority
+
+    return context.pctl.start(name, custom_config=config)
+
+
+@step('I start {name:name} in site {site_name:w}')
+def start_patroni(context, name, site_name):
+    start_patroni_tags(context, name, site_name, None, None)

--- a/patroni/__main__.py
+++ b/patroni/__main__.py
@@ -182,6 +182,8 @@ class Patroni(AbstractPatroniDaemon, Tags):
             super(Patroni, self).reload_config(sighup, local)
             if local:
                 self._tags = self._get_tags()
+                self._site = self.config.get('site')
+                self.postgresql.sync_handler.site = self._site
                 self.request.reload_config(self.config)
             if local or sighup and self.api.reload_local_certificate():
                 self.api.reload_config(self.config['restapi'])

--- a/patroni/__main__.py
+++ b/patroni/__main__.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Optional, TYPE_CHECKING
 from patroni import global_config, MIN_PSYCOPG2, MIN_PSYCOPG3, parse_version
 from patroni.collections import EMPTY_DICT
 from patroni.daemon import abstract_main, AbstractPatroniDaemon, get_base_arg_parser
+from patroni.site import ClusterSite
 from patroni.tags import Tags
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -25,7 +26,7 @@ if TYPE_CHECKING:  # pragma: no cover
 logger = logging.getLogger(__name__)
 
 
-class Patroni(AbstractPatroniDaemon, Tags):
+class Patroni(AbstractPatroniDaemon, ClusterSite, Tags):
     """Implement ``patroni`` command daemon.
 
     :ivar version: Patroni version.
@@ -70,10 +71,10 @@ class Patroni(AbstractPatroniDaemon, Tags):
         logger.info('Patroni global thread_pool_size = %d', thread_pool_size)
         thread_pool.configure_global_pool(thread_pool_size)
 
-        super(Patroni, self).__init__(config, patroni_logger)
+        AbstractPatroniDaemon.__init__(self, config, patroni_logger)
+        ClusterSite.__init__(self, config.get('site'))
 
         self.version = __version__
-        self._site = self.config.get('site')
         self.dcs = get_dcs(self.config)
         self.request = PatroniRequest(self.config, True)
 
@@ -181,9 +182,10 @@ class Patroni(AbstractPatroniDaemon, Tags):
         try:
             super(Patroni, self).reload_config(sighup, local)
             if local:
+                site = self.config.get('site')
+                self.reload_site(site)
+                self.postgresql.reload_site(site)
                 self._tags = self._get_tags()
-                self._site = self.config.get('site')
-                self.postgresql.sync_handler.site = self._site
                 self.request.reload_config(self.config)
             if local or sighup and self.api.reload_local_certificate():
                 self.api.reload_config(self.config['restapi'])
@@ -200,11 +202,6 @@ class Patroni(AbstractPatroniDaemon, Tags):
     def tags(self) -> Dict[str, Any]:
         """Tags configured for this node, if any."""
         return self._tags
-
-    @property
-    def site(self) -> Optional[str]:
-        """Site configured for this node, if any."""
-        return self._site
 
     def schedule_next_run(self) -> None:
         """Schedule the next run of the ``patroni`` daemon main loop.

--- a/patroni/__main__.py
+++ b/patroni/__main__.py
@@ -182,9 +182,6 @@ class Patroni(AbstractPatroniDaemon, ClusterSite, Tags):
         try:
             super(Patroni, self).reload_config(sighup, local)
             if local:
-                site = self.config.get('site')
-                self.reload_site(site)
-                self.postgresql.reload_site(site)
                 self._tags = self._get_tags()
                 self.request.reload_config(self.config)
             if local or sighup and self.api.reload_local_certificate():

--- a/patroni/__main__.py
+++ b/patroni/__main__.py
@@ -73,6 +73,7 @@ class Patroni(AbstractPatroniDaemon, Tags):
         super(Patroni, self).__init__(config, patroni_logger)
 
         self.version = __version__
+        self._site = self.config.get('site')
         self.dcs = get_dcs(self.config)
         self.request = PatroniRequest(self.config, True)
 
@@ -197,6 +198,11 @@ class Patroni(AbstractPatroniDaemon, Tags):
     def tags(self) -> Dict[str, Any]:
         """Tags configured for this node, if any."""
         return self._tags
+
+    @property
+    def site(self) -> Optional[str]:
+        """Site configured for this node, if any."""
+        return self._site
 
     def schedule_next_run(self) -> None:
         """Schedule the next run of the ``patroni`` daemon main loop.

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -227,6 +227,9 @@ class RestApiHandler(BaseHTTPRequestHandler):
             'scope': patroni.postgresql.scope,
             'name': patroni.postgresql.name
         }
+
+        if patroni.site:
+            response['site'] = patroni.site
         if patroni.scheduled_restart:
             response['scheduled_restart'] = patroni.scheduled_restart.copy()
             del response['scheduled_restart']['postmaster_start_time']

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -500,7 +500,7 @@ class Config(object):
             """
             return os.environ.pop(PATRONI_ENV_PREFIX + name.upper(), None)
 
-        for param in ('name', 'namespace', 'scope', 'thread_pool_size', 'thread_stack_size'):
+        for param in ('name', 'namespace', 'scope', 'site', 'thread_pool_size', 'thread_stack_size'):
             value = _popenv(param)
             if value:
                 ret[param] = value
@@ -776,7 +776,8 @@ class Config(object):
             'name',
             'scope',
             'retry_timeout',
-            'citus'
+            'citus',
+            'site'
         )
 
         pg_config.update({p: config[p] for p in updated_fields if p in config})

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -1683,8 +1683,9 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
         title = 'Cluster'
         title_details = f' ({initialize})'
 
-    site = len(cluster_sites) == 1 and list(cluster_sites)[0] and ' Site: ' + list(cluster_sites)[0] or ''
-    title = f' {title}: {name}{title_details}{site} '
+    site = next(iter(cluster_sites)) if len(cluster_sites) == 1 else ''
+    site = f'Site: {site}, ' if site else ''
+    title = f' {site}{title}: {name}{title_details} '
     if fmt in ('pretty', 'topology'):
         columns[columns.index('Replay Lag')] = columns[columns.index('Receive Lag')] = 'Lag'
     print_output(columns, rows,

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -1569,6 +1569,7 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
     Information is printed to console through :func:`print_output`, and contains:
 
         * ``Cluster``: name of the Patroni cluster, as per ``scope`` configuration;
+        * ``Site``: site of the Patroni node, as per ``site`` configuration;
         * ``Member``: name of the Patroni node, as per ``name`` configuration;
         * ``Host``: hostname (or IP) and port, as per ``postgresql.listen`` configuration;
         * ``Role``: ``Leader``, ``Standby Leader``, ``Sync Standby`` or ``Replica``;
@@ -1618,7 +1619,7 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
         if extended or any(m.get(c.lower().replace(' ', '_')) for m in all_members):
             columns.append(c)
 
-    cluster_sites = set(str(m.get('site')) for m in all_members)
+    cluster_sites = set(m.get('site') for m in all_members)
     if len(cluster_sites) > 1:
         columns.insert(1, 'Site')
 
@@ -1662,7 +1663,7 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
                           receive_lsn=receive_lsn, replay_lsn=replay_lsn,
                           pending_restart='*' if member.get('pending_restart') else '',
                           pending_restart_reason=restart_reason,
-                          site=member.get('site', '') if member.get('site') != 'None' else '')
+                          site=member.get('site', ''))
 
             if append_port and member['host'] and member.get('port'):
                 member['host'] = ':'.join([member['host'], str(member['port'])])
@@ -1682,7 +1683,7 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
         title = 'Cluster'
         title_details = f' ({initialize})'
 
-    site = len(cluster_sites) == 1 and list(cluster_sites)[0] != 'None' and ' Site: ' + list(cluster_sites)[0] or ''
+    site = len(cluster_sites) == 1 and list(cluster_sites)[0] and ' Site: ' + list(cluster_sites)[0] or ''
     title = f' {title}: {name}{title_details}{site} '
     if fmt in ('pretty', 'topology'):
         columns[columns.index('Replay Lag')] = columns[columns.index('Receive Lag')] = 'Lag'

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -316,6 +316,7 @@ option_default_citus_group = click.option('--group', required=False, type=int, h
                                           default=lambda: _get_configuration().get('citus', {}).get('group'))
 option_citus_group = click.option('--group', required=False, type=int, help='Citus group')
 role_choice = click.Choice([role.value for role in CtlPostgresqlRole])
+option_site = click.option('--site', help='Filter members by site', required=False, type=str, default=None)
 
 
 @click.group(cls=click.Group)
@@ -1562,7 +1563,7 @@ def get_cluster_service_info(cluster: Dict[str, Any]) -> List[str]:
 
 
 def output_members(cluster: Cluster, name: str, extended: bool = False,
-                   fmt: str = 'pretty', group: Optional[int] = None) -> None:
+                   fmt: str = 'pretty', group: Optional[int] = None, site: Optional[str] = None) -> None:
     """Print information about the Patroni cluster and its members.
 
     Information is printed to console through :func:`print_output`, and contains:
@@ -1595,6 +1596,7 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
         ``topology`` nor ``pretty``, then complementary information gathered through :func:`get_cluster_service_info` is
         not printed.
     :param group: filter which Citus group we should get members from. If ``None`` get from all groups.
+    :param site: filter which site of the cluster we should get members from.  If ``None`` get from all sites.
     """
     rows: List[List[Any]] = []
     logging.debug(cluster)
@@ -1616,6 +1618,10 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
         if extended or any(m.get(c.lower().replace(' ', '_')) for m in all_members):
             columns.append(c)
 
+    cluster_sites = set(str(m.get('site')) for m in all_members)
+    if len(cluster_sites) > 1:
+        columns.insert(1, 'Site')
+
     # Show Host as 'host:port' if somebody is running on non-standard port or two nodes are running on the same host
     append_port = any('port' in m and m['port'] != 5432 for m in all_members) or\
         len(set(m['host'] for m in all_members)) < len(all_members)
@@ -1624,6 +1630,9 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
     for g, c in sorted(clusters.items()):
         for member in sort(c['members']):
             logging.debug(member)
+
+            if site and member.get('site') != site:
+                continue
 
             def format_diff(param: str, values: Dict[str, str], hide_long: bool):
                 full_diff = param + ': ' + values['old_value'] + '->' + values['new_value']
@@ -1652,7 +1661,8 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
                           receive_lag=receive_lag, replay_lag=replay_lag,
                           receive_lsn=receive_lsn, replay_lsn=replay_lsn,
                           pending_restart='*' if member.get('pending_restart') else '',
-                          pending_restart_reason=restart_reason)
+                          pending_restart_reason=restart_reason,
+                          site=member.get('site', '') if member.get('site') != 'None' else '')
 
             if append_port and member['host'] and member.get('port'):
                 member['host'] = ':'.join([member['host'], str(member['port'])])
@@ -1672,7 +1682,8 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
         title = 'Cluster'
         title_details = f' ({initialize})'
 
-    title = f' {title}: {name}{title_details} '
+    site = len(cluster_sites) == 1 and list(cluster_sites)[0] != 'None' and ' Site: ' + list(cluster_sites)[0] or ''
+    title = f' {title}: {name}{title_details}{site} '
     if fmt in ('pretty', 'topology'):
         columns[columns.index('Replay Lag')] = columns[columns.index('Receive Lag')] = 'Lag'
     print_output(columns, rows,
@@ -1694,11 +1705,12 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
 @option_citus_group
 @click.option('--extended', '-e', help='Show some extra information', is_flag=True)
 @click.option('--timestamp', '-t', 'ts', help='Print timestamp', is_flag=True)
+@option_site
 @option_format
 @option_watch
 @option_watchrefresh
 def members(cluster_names: List[str], group: Optional[int], fmt: str,
-            watch: Optional[int], w: bool, extended: bool, ts: bool) -> None:
+            watch: Optional[int], w: bool, extended: bool, ts: bool, site: Optional[str]) -> None:
     """Process ``list`` command of ``patronictl`` utility.
 
     Print information about the Patroni cluster through :func:`output_members`.
@@ -1728,7 +1740,7 @@ def members(cluster_names: List[str], group: Optional[int], fmt: str,
             dcs = get_dcs(cluster_name, group)
 
             cluster = dcs.get_cluster()
-            output_members(cluster, cluster_name, extended, fmt, group)
+            output_members(cluster, cluster_name, extended, fmt, group, site)
 
 
 @ctl.command('topology', help='Prints ASCII topology for given cluster')

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -130,7 +130,7 @@ def get_dcs(config: Union['Config', Dict[str, Any]]) -> 'AbstractDCS':
     for name, dcs_class in iter_dcs_classes(config):
         # Propagate some parameters from top level of config if defined to the DCS specific config section.
         config[name].update({
-            p: config[p] for p in ('namespace', 'name', 'scope', 'loop_wait',
+            p: config[p] for p in ('namespace', 'name', 'scope', 'site', 'loop_wait',
                                    'patronictl', 'ttl', 'retry_timeout')
             if p in config})
 

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -337,6 +337,10 @@ class Member(Tags, NamedTuple('Member',
     def replay_lsn(self) -> Optional[int]:
         return parse_int(self.data.get('replay_lsn'))
 
+    @property
+    def site(self) -> Optional[str]:
+        return self.data.get('site')
+
 
 class RemoteMember(Member):
     """Represents a remote member (typically a primary) for a standby cluster.
@@ -781,10 +785,12 @@ class Status(NamedTuple):
     :ivar last_lsn: :class:`int` object containing position of last known leader LSN.
     :ivar slots: state of permanent replication slots on the primary in the format: ``{"slot_name": int}``.
     :ivar retain_slots: list physical replication slots for members that exist in the cluster.
+    :ivar current_site: the name of the site where leader is located.
     """
     last_lsn: int
     slots: Optional[Dict[str, int]]
     retain_slots: List[str]
+    current_site: Optional[str]
 
     @staticmethod
     def empty() -> 'Status':
@@ -792,14 +798,14 @@ class Status(NamedTuple):
 
         :returns: empty :class:`Status` object.
         """
-        return Status(0, None, [])
+        return Status(0, None, [], None)
 
     def is_empty(self):
         """Validate definition of all attributes of this :class:`Status` instance.
 
         :returns: ``True`` if all attributes of the current :class:`Status` are unpopulated.
         """
-        return self.last_lsn == 0 and self.slots is None and not self.retain_slots
+        return self.last_lsn == 0 and self.slots is None and not self.retain_slots and self.current_site is None
 
     @staticmethod
     def from_node(value: Union[str, Dict[str, Any], None]) -> 'Status':
@@ -816,7 +822,7 @@ class Status(NamedTuple):
             return Status.empty()
 
         if isinstance(value, int):  # legacy
-            return Status(value, None, [])
+            return Status(value, None, [], None)
 
         if not isinstance(value, dict):
             return Status.empty()
@@ -844,7 +850,7 @@ class Status(NamedTuple):
         if not isinstance(retain_slots, list):
             retain_slots = []
 
-        return Status(last_lsn, slots, retain_slots)
+        return Status(last_lsn, slots, retain_slots, value.get('current_site'))
 
 
 class Cluster(NamedTuple('Cluster',
@@ -920,7 +926,7 @@ class Cluster(NamedTuple('Cluster',
 
            >>> assert bool(cluster) is False
 
-           >>> status = Status(0, None, [])
+           >>> status = Status(0, None, [], 'dc1')
            >>> cluster = Cluster(None, None, None, status, [1, 2, 3], None, SyncState.empty(), None, None, {})
            >>> len(cluster)
            1
@@ -964,17 +970,25 @@ class Cluster(NamedTuple('Cluster',
         return next((m for m in self.members if m.name == member_name),
                     self.leader if fallback_to_leader else None)
 
-    def get_clone_member(self, exclude_name: str) -> Union[Member, Leader, None]:
+    def get_clone_member(self, exclude_name: str, site: Optional[str]) -> Union[Member, Leader, None]:
         """Get member or leader object to use as clone source.
 
         :param exclude_name: name of a member name to exclude.
+        :param site: the site to which the clone member should belong.
 
         :returns: a randomly selected candidate member from available running members that are configured to as viable
                  sources for cloning (has tag ``clonefrom`` in configuration). If no member is appropriate the current
-                 leader is used.
+                 leader is used. If there is neither replica nor leader in the requested site, chose among all available
+                 members.
         """
         exclude = [exclude_name] + ([self.leader.name] if self.leader else [])
+
         candidates = [m for m in self.members if m.clonefrom and m.is_running and m.name not in exclude]
+        local_candidates = [m for m in candidates if (site is None or m.site == site)]
+        if len(local_candidates) > 0:
+            candidates = local_candidates
+        elif self.leader and (site is None or self.leader.member.site == site):
+            candidates = [self.leader]
         return candidates[randint(0, len(candidates) - 1)] if candidates else self.leader
 
     @staticmethod
@@ -1771,7 +1785,8 @@ class AbstractDCS(abc.ABC):
             self._cluster_valid_till = time.time() + self.ttl
 
             self._last_seen = int(time.time())
-            self._last_status = {self._OPTIME: cluster.status.last_lsn, 'retain_slots': cluster.status.retain_slots}
+            self._last_status = {self._OPTIME: cluster.status.last_lsn, 'retain_slots': cluster.status.retain_slots,
+                                 'current_site': cluster.status.current_site}
             if cluster.status.slots:
                 self._last_status['slots'] = cluster.status.slots
             self._last_failsafe = cluster.failsafe
@@ -1833,7 +1848,7 @@ class AbstractDCS(abc.ABC):
         """
         # This method is always called with ``optime`` key, rest of the keys are optional.
         # In case if we know old values (stored in self._last_status), we will copy them over.
-        for name in ('slots', 'retain_slots'):
+        for name in ('slots', 'retain_slots', 'current_site'):
             if name not in value and self._last_status.get(name):
                 value[name] = self._last_status[name]
         # if the key is present, but the value is None, we will not write such pair.
@@ -1933,13 +1948,15 @@ class AbstractDCS(abc.ABC):
                       cluster: Cluster,
                       last_lsn: Optional[int],
                       slots: Optional[Dict[str, int]] = None,
-                      failsafe: Optional[Dict[str, str]] = None) -> bool:
+                      failsafe: Optional[Dict[str, str]] = None,
+                      site: Optional[str] = None) -> bool:
         """Update ``leader`` key (or session) ttl, ``/status``, and ``/failsafe`` keys.
 
         :param cluster: :class:`Cluster` object with information about the current cluster state.
         :param last_lsn: absolute WAL LSN in bytes.
         :param slots: dictionary with permanent slots ``confirmed_flush_lsn``.
         :param failsafe: if defined dictionary passed to :meth:`~AbstractDCS.write_failsafe`.
+        :param site: the site to which the leader belongs.
 
         :returns: ``True`` if ``leader`` key (or session) has been updated successfully.
         """
@@ -1948,7 +1965,8 @@ class AbstractDCS(abc.ABC):
         ret = self._update_leader(cluster.leader)
         if ret and last_lsn:
             status: Dict[str, Any] = {self._OPTIME: last_lsn, 'slots': slots or None,
-                                      'retain_slots': self._build_retain_slots(cluster, slots)}
+                                      'retain_slots': self._build_retain_slots(cluster, slots),
+                                      'current_site': site}
             self.write_status(status)
 
         if ret and failsafe is not None:

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -987,7 +987,8 @@ class Cluster(NamedTuple('Cluster',
         local_candidates = [m for m in candidates if (site is None or m.site == site)]
         if len(local_candidates) > 0:
             candidates = local_candidates
-        elif self.leader and (site is None or self.leader.member.site == site):
+        elif self.leader and site and self.leader.member.site == site:
+            # prefer local leader over remote replicas
             candidates = [self.leader]
         return candidates[randint(0, len(candidates) - 1)] if candidates else self.leader
 

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -1550,6 +1550,7 @@ class AbstractDCS(abc.ABC):
         """
         self._mpp = mpp
         self._name = config['name']
+        self._site = config.get('site')
         self._base_path = re.sub('/+', '/', '/'.join(['', config.get('namespace', 'service'), config['scope']]))
         self._set_loop_wait(config.get('loop_wait', 10))
 
@@ -1667,6 +1668,7 @@ class AbstractDCS(abc.ABC):
         self._set_loop_wait(config['loop_wait'])
         self.set_ttl(config['ttl'])
         self.set_retry_timeout(config['retry_timeout'])
+        self._site = config.get('site')
 
     @property
     def loop_wait(self) -> int:
@@ -1949,8 +1951,7 @@ class AbstractDCS(abc.ABC):
                       cluster: Cluster,
                       last_lsn: Optional[int],
                       slots: Optional[Dict[str, int]] = None,
-                      failsafe: Optional[Dict[str, str]] = None,
-                      site: Optional[str] = None) -> bool:
+                      failsafe: Optional[Dict[str, str]] = None) -> bool:
         """Update ``leader`` key (or session) ttl, ``/status``, and ``/failsafe`` keys.
 
         :param cluster: :class:`Cluster` object with information about the current cluster state.
@@ -1966,8 +1967,9 @@ class AbstractDCS(abc.ABC):
         ret = self._update_leader(cluster.leader)
         if ret and last_lsn:
             status: Dict[str, Any] = {self._OPTIME: last_lsn, 'slots': slots or None,
-                                      'retain_slots': self._build_retain_slots(cluster, slots),
-                                      'current_site': site}
+                                      'retain_slots': self._build_retain_slots(cluster, slots)}
+            if self._site:
+                status['current_site'] = self._site
             self.write_status(status)
 
         if ret and failsafe is not None:

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -19,6 +19,7 @@ import dateutil.parser
 from .. import global_config
 from ..dynamic_loader import iter_classes, iter_modules
 from ..exceptions import PatroniAssertionError, PatroniFatalException
+from ..site import ClusterSite
 from ..tags import Tags
 from ..utils import deep_compare, parse_int, uri
 
@@ -1459,7 +1460,7 @@ def catch_return_false_exception(func: Callable[..., Any]) -> Any:
     return wrapper
 
 
-class AbstractDCS(abc.ABC):
+class AbstractDCS(ClusterSite, abc.ABC):
     """Abstract representation of DCS modules.
 
     Implementations of a concrete DCS class, using appropriate backend client interfaces, must include the following
@@ -1548,9 +1549,10 @@ class AbstractDCS(abc.ABC):
                        i.e.: ``zookeeper`` for zookeeper, ``etcd`` for etcd, etc...
         :param mpp: an object implementing :class:`AbstractMPP` interface.
         """
+        ClusterSite.__init__(self, config.get('site'))
+
         self._mpp = mpp
         self._name = config['name']
-        self._site = config.get('site')
         self._base_path = re.sub('/+', '/', '/'.join(['', config.get('namespace', 'service'), config['scope']]))
         self._set_loop_wait(config.get('loop_wait', 10))
 
@@ -1668,7 +1670,7 @@ class AbstractDCS(abc.ABC):
         self._set_loop_wait(config['loop_wait'])
         self.set_ttl(config['ttl'])
         self.set_retry_timeout(config['retry_timeout'])
-        self._site = config.get('site')
+        self.reload_site(config.get('site'))
 
     @property
     def loop_wait(self) -> int:
@@ -1968,8 +1970,8 @@ class AbstractDCS(abc.ABC):
         if ret and last_lsn:
             status: Dict[str, Any] = {self._OPTIME: last_lsn, 'slots': slots or None,
                                       'retain_slots': self._build_retain_slots(cluster, slots)}
-            if self._site:
-                status['current_site'] = self._site
+            if self.site:
+                status['current_site'] = self.site
             self.write_status(status)
 
         if ret and failsafe is not None:

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -1670,7 +1670,6 @@ class AbstractDCS(ClusterSite, abc.ABC):
         self._set_loop_wait(config['loop_wait'])
         self.set_ttl(config['ttl'])
         self.set_retry_timeout(config['retry_timeout'])
-        self.reload_site(config.get('site'))
 
     @property
     def loop_wait(self) -> int:

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -1959,7 +1959,6 @@ class AbstractDCS(ClusterSite, abc.ABC):
         :param last_lsn: absolute WAL LSN in bytes.
         :param slots: dictionary with permanent slots ``confirmed_flush_lsn``.
         :param failsafe: if defined dictionary passed to :meth:`~AbstractDCS.write_failsafe`.
-        :param site: the site to which the leader belongs.
 
         :returns: ``True`` if ``leader`` key (or session) has been updated successfully.
         """

--- a/patroni/dcs/kubernetes.py
+++ b/patroni/dcs/kubernetes.py
@@ -1246,7 +1246,8 @@ class Kubernetes(AbstractDCS):
         return datetime.datetime.now(tzutc).isoformat()
 
     def update_leader(self, cluster: Cluster, last_lsn: Optional[int],
-                      slots: Optional[Dict[str, int]] = None, failsafe: Optional[Dict[str, str]] = None) -> bool:
+                      slots: Optional[Dict[str, int]] = None, failsafe: Optional[Dict[str, str]] = None,
+                      site: Optional[str] = None) -> bool:
         kind = self._kinds.get(self.leader_path)
         kind_annotations = kind and kind.metadata.annotations or EMPTY_DICT
 
@@ -1257,7 +1258,8 @@ class Kubernetes(AbstractDCS):
         leader_observed_record = kind_annotations or self._leader_observed_record
         annotations = {self._LEADER: self._name, 'ttl': str(self._ttl), 'renewTime': now,
                        'acquireTime': leader_observed_record.get('acquireTime') or now,
-                       'transitions': leader_observed_record.get('transitions') or '0'}
+                       'transitions': leader_observed_record.get('transitions') or '0',
+                       'current_site': site}
         if last_lsn:
             annotations[self._OPTIME] = str(last_lsn)
             annotations['slots'] = json.dumps(slots, separators=(',', ':')) if slots else None

--- a/patroni/dcs/kubernetes.py
+++ b/patroni/dcs/kubernetes.py
@@ -1258,7 +1258,7 @@ class Kubernetes(AbstractDCS):
         annotations = {self._LEADER: self._name, 'ttl': str(self._ttl), 'renewTime': now,
                        'acquireTime': leader_observed_record.get('acquireTime') or now,
                        'transitions': leader_observed_record.get('transitions') or '0',
-                       'current_site': self._site}
+                       'current_site': self.site}
         if last_lsn:
             annotations[self._OPTIME] = str(last_lsn)
             annotations['slots'] = json.dumps(slots, separators=(',', ':')) if slots else None

--- a/patroni/dcs/kubernetes.py
+++ b/patroni/dcs/kubernetes.py
@@ -1246,8 +1246,7 @@ class Kubernetes(AbstractDCS):
         return datetime.datetime.now(tzutc).isoformat()
 
     def update_leader(self, cluster: Cluster, last_lsn: Optional[int],
-                      slots: Optional[Dict[str, int]] = None, failsafe: Optional[Dict[str, str]] = None,
-                      site: Optional[str] = None) -> bool:
+                      slots: Optional[Dict[str, int]] = None, failsafe: Optional[Dict[str, str]] = None) -> bool:
         kind = self._kinds.get(self.leader_path)
         kind_annotations = kind and kind.metadata.annotations or EMPTY_DICT
 
@@ -1259,7 +1258,7 @@ class Kubernetes(AbstractDCS):
         annotations = {self._LEADER: self._name, 'ttl': str(self._ttl), 'renewTime': now,
                        'acquireTime': leader_observed_record.get('acquireTime') or now,
                        'transitions': leader_observed_record.get('transitions') or '0',
-                       'current_site': site}
+                       'current_site': self._site}
         if last_lsn:
             annotations[self._OPTIME] = str(last_lsn)
             annotations['slots'] = json.dumps(slots, separators=(',', ':')) if slots else None

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -455,6 +455,10 @@ class Ha(object):
                 'version': self.patroni.version
             }
 
+            site = self.patroni.site
+            if site:
+                data['site'] = site
+
             proxy_url = self.state_handler.proxy_url
             if proxy_url:
                 data['proxy_url'] = proxy_url

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -397,7 +397,7 @@ class Ha(object):
             except Exception:
                 logger.exception('Exception when called state_handler.last_operation()')
         try:
-            ret = self.dcs.update_leader(self.cluster, last_lsn, slots, self._failsafe_config())
+            ret = self.dcs.update_leader(self.cluster, last_lsn, slots, self._failsafe_config(), self.patroni.site)
         except DCSError:
             raise
         except Exception:
@@ -558,7 +558,8 @@ class Ha(object):
             else:
                 return 'failed to acquire initialize lock'
 
-        clone_member = self.cluster.get_clone_member(self.state_handler.name)
+        clone_member = self.cluster.get_clone_member(self.state_handler.name,
+                                                     self.patroni.site if self.cluster.status.current_site else None)
         # cluster already has a leader, we can bootstrap from it or from one of replicas (if they allow)
         if not self.cluster.is_unlocked() and clone_member:
             member_role = 'leader' if clone_member == self.cluster.leader else 'replica'
@@ -1732,7 +1733,7 @@ class Ha(object):
         is_standby_leader = mode == 'demote-cluster' and not status['released']
         if is_standby_leader:
             with self._async_executor:
-                self.dcs.update_leader(self.cluster, checkpoint_lsn, None, self._failsafe_config())
+                self.dcs.update_leader(self.cluster, checkpoint_lsn, None, self._failsafe_config(), self.patroni.site)
             mode_control['release'] = False
         else:
             self.set_is_leader(False)
@@ -2087,7 +2088,8 @@ class Ha(object):
         if from_leader:
             clone_member = cluster.leader
         else:
-            clone_member = cluster.get_clone_member(self.state_handler.name)
+            clone_member = cluster.get_clone_member(
+                self.state_handler.name, self.patroni.site if cluster.status.current_site else None)
 
         if clone_member:
             member_role = 'leader' if clone_member == cluster.leader else 'replica'

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -397,7 +397,7 @@ class Ha(object):
             except Exception:
                 logger.exception('Exception when called state_handler.last_operation()')
         try:
-            ret = self.dcs.update_leader(self.cluster, last_lsn, slots, self._failsafe_config(), self.patroni.site)
+            ret = self.dcs.update_leader(self.cluster, last_lsn, slots, self._failsafe_config())
         except DCSError:
             raise
         except Exception:
@@ -1732,7 +1732,7 @@ class Ha(object):
         is_standby_leader = mode == 'demote-cluster' and not status['released']
         if is_standby_leader:
             with self._async_executor:
-                self.dcs.update_leader(self.cluster, checkpoint_lsn, None, self._failsafe_config(), self.patroni.site)
+                self.dcs.update_leader(self.cluster, checkpoint_lsn, None, self._failsafe_config())
             mode_control['release'] = False
         else:
             self.set_is_leader(False)

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -558,8 +558,7 @@ class Ha(object):
             else:
                 return 'failed to acquire initialize lock'
 
-        clone_member = self.cluster.get_clone_member(self.state_handler.name,
-                                                     self.patroni.site if self.cluster.status.current_site else None)
+        clone_member = self.cluster.get_clone_member(self.state_handler.name, self.patroni.site)
         # cluster already has a leader, we can bootstrap from it or from one of replicas (if they allow)
         if not self.cluster.is_unlocked() and clone_member:
             member_role = 'leader' if clone_member == self.cluster.leader else 'replica'
@@ -2088,8 +2087,7 @@ class Ha(object):
         if from_leader:
             clone_member = cluster.leader
         else:
-            clone_member = cluster.get_clone_member(
-                self.state_handler.name, self.patroni.site if cluster.status.current_site else None)
+            clone_member = cluster.get_clone_member(self.state_handler.name, self.patroni.site)
 
         if clone_member:
             member_role = 'leader' if clone_member == cluster.leader else 'replica'

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -22,6 +22,7 @@ from ..collections import CaseInsensitiveDict, CaseInsensitiveSet, EMPTY_DICT
 from ..daemon import notify_systemd
 from ..dcs import Cluster, Leader, Member, RemoteMember, slot_name_from_member_name
 from ..exceptions import PostgresConnectionException
+from ..site import ClusterSite
 from ..tags import Tags
 from ..utils import data_directory_is_empty, parse_int, polling_loop, Retry, RetryFailedError
 from .bootstrap import Bootstrap
@@ -64,7 +65,7 @@ def null_context():
     yield
 
 
-class Postgresql(object):
+class Postgresql(ClusterSite):
 
     POSTMASTER_START_TIME = "pg_catalog.pg_postmaster_start_time()"
     TL_LSN = ("CASE WHEN pg_catalog.pg_is_in_recovery() THEN 0 "
@@ -77,6 +78,8 @@ class Postgresql(object):
               "pg_catalog.pg_is_in_recovery() AND pg_catalog.pg_is_{0}_replay_paused()")
 
     def __init__(self, config: Dict[str, Any], mpp: AbstractMPP) -> None:
+        super(Postgresql, self).__init__(config.get('site'))
+
         self.name: str = config['name']
         self.scope: str = config['scope']
         self._data_dir: str = config['data_dir']

--- a/patroni/site.py
+++ b/patroni/site.py
@@ -1,0 +1,32 @@
+"""Cluster site handling."""
+import abc
+
+from typing import Optional
+
+
+class ClusterSite(abc.ABC):
+    """An abstract class that encapsulates all the ``site`` logic."""
+
+    def __init__(self, site: Optional[str]) -> None:
+        """Initialize the :class:`ClusterSite` object.
+
+        :param site: string representing name of the site assigned to the current node.
+            loaded from the local configuration.
+        """
+        self._site = site
+
+    @property
+    def site(self) -> Optional[str]:
+        """Site configured, if any.
+
+        :return: string representing name of the site assigned to the current node.
+        """
+        return self._site
+
+    def reload_site(self, site: Optional[str]) -> None:
+        """Load and set relevant site value from configuration.
+
+        :param site: string representing name of the site assigned to the current node.
+            loaded from the local configuration.
+        """
+        self._site = site

--- a/patroni/site.py
+++ b/patroni/site.py
@@ -22,11 +22,3 @@ class ClusterSite(abc.ABC):
         :return: string representing name of the site assigned to the current node.
         """
         return self._site
-
-    def reload_site(self, site: Optional[str]) -> None:
-        """Load and set relevant site value from configuration.
-
-        :param site: string representing name of the site assigned to the current node.
-            loaded from the local configuration.
-        """
-        self._site = site

--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -971,7 +971,8 @@ def cluster_as_json(cluster: 'Cluster') -> Dict[str, Any]:
             member['host'] = conn_kwargs['host']
             if conn_kwargs.get('port'):
                 member['port'] = int(conn_kwargs['port'])
-        optional_attributes = ('timeline', 'pending_restart', 'pending_restart_reason', 'scheduled_restart', 'tags')
+        optional_attributes = ('timeline', 'pending_restart', 'pending_restart_reason',
+                               'scheduled_restart', 'tags', 'site')
         member.update({n: m.data[n] for n in optional_attributes if n in m.data})
 
         if m.name != leader_name:

--- a/patroni/validator.py
+++ b/patroni/validator.py
@@ -1066,6 +1066,7 @@ validate_etcd = {
 schema = Schema({
     "name": validate_name,
     "scope": str,
+    Optional("site"): str,
     Optional("thread_pool_size"): IntValidator(min=5, expected_type=int, raise_assert=True),
     Optional("thread_stack_size"): IntValidator(min=65536, base_unit='B', aligned=65535,
                                                 expected_type=int, raise_assert=True),

--- a/patroni/validator.py
+++ b/patroni/validator.py
@@ -993,6 +993,18 @@ def validate_name(value: Any) -> None:
         raise ConfigParseError(f"Node 'name' can't be set to '{SYNC_STRICT_PLACEHOLDER}'")
 
 
+def validate_site(value: Any) -> None:
+    """Validate ``site`` configuration option.
+
+    :param value: value of ``site`` to be validated.
+
+    :raises:
+        :class:`~patroni.exceptions.ConfigParseError` if value is an empty string.
+    """
+    if not value:
+        raise ConfigParseError("Site value can't be empty")
+
+
 class RealValidator(object):
     """Validate a real (float) setting.
 
@@ -1046,6 +1058,7 @@ setattr(validate_host_port_listen_multiple_hosts, 'expected_type', str)
 setattr(validate_data_dir, 'expected_type', str)
 setattr(validate_binary_name, 'expected_type', str)
 setattr(validate_name, 'expected_type', str)
+setattr(validate_site, 'expected_type', str)
 validate_etcd = {
     Or("host", "hosts", "srv", "srv_suffix", "url", "proxy"): Case({
         "host": validate_host_port,
@@ -1066,7 +1079,7 @@ validate_etcd = {
 schema = Schema({
     "name": validate_name,
     "scope": str,
-    Optional("site"): str,
+    Optional("site"): validate_site,
     Optional("thread_pool_size"): IntValidator(min=5, expected_type=int, raise_assert=True),
     Optional("thread_stack_size"): IntValidator(min=65536, base_unit='B', aligned=65535,
                                                 expected_type=int, raise_assert=True),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -156,6 +156,7 @@ class MockLogger(object):
 class MockPatroni(object):
 
     ha = MockHa()
+    site = 'dc1'
     postgresql = ha.state_handler
     dcs = Mock()
     logger = MockLogger()

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -509,16 +509,16 @@ class TestCtl(unittest.TestCase):
         result = self.runner.invoke(ctl, ['list'])
         assert '127.0.0.1' in result.output
         assert result.exit_code == 0
-        assert ' Citus cluster: alpha Site: dc1 -' in result.output
+        assert ' Site: dc1, Citus cluster: alpha ' in result.output
 
         result = self.runner.invoke(ctl, ['list', '--group', '0'])
-        assert 'Citus cluster: alpha (group: 0, 12345678901) Site: dc1 -' in result.output
+        assert ' Site: dc1, Citus cluster: alpha (group: 0, 12345678901) -' in result.output
 
         config = get_default_config()
         del config['citus']
         with patch('patroni.ctl.load_config', Mock(return_value=config)):
             result = self.runner.invoke(ctl, ['list'])
-            assert 'Cluster: alpha (12345678901) Site: dc1 -' in result.output
+            assert 'Site: dc1, Cluster: alpha (12345678901) -' in result.output
 
         with patch('patroni.ctl.load_config', Mock(return_value={})):
             self.runner.invoke(ctl, ['list'])

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -145,6 +145,11 @@ class TestCtl(unittest.TestCase):
                 self.assertEqual(mock_echo.call_args_list[1][0][0],
                                  'abc\tfoo\t\tReplica\tin archive recovery\t\tunknown\t\t0/3\t0')
 
+                cluster = get_cluster_initialized_with_leader()
+                mock_echo.reset_mock()
+                self.assertIsNone(output_members(cluster, name='abc', site='foo', fmt='tsv'))
+                self.assertEqual(len(mock_echo.call_args_list), 1)
+
     @patch('patroni.dcs.AbstractDCS.set_failover_value', Mock())
     def test_switchover(self):
         # Confirm
@@ -504,16 +509,16 @@ class TestCtl(unittest.TestCase):
         result = self.runner.invoke(ctl, ['list'])
         assert '127.0.0.1' in result.output
         assert result.exit_code == 0
-        assert 'Citus cluster: alpha -' in result.output
+        assert ' Citus cluster: alpha Site: dc1 -' in result.output
 
         result = self.runner.invoke(ctl, ['list', '--group', '0'])
-        assert 'Citus cluster: alpha (group: 0, 12345678901) -' in result.output
+        assert 'Citus cluster: alpha (group: 0, 12345678901) Site: dc1 -' in result.output
 
         config = get_default_config()
         del config['citus']
         with patch('patroni.ctl.load_config', Mock(return_value=config)):
             result = self.runner.invoke(ctl, ['list'])
-            assert 'Cluster: alpha (12345678901) -' in result.output
+            assert 'Cluster: alpha (12345678901) Site: dc1 -' in result.output
 
         with patch('patroni.ctl.load_config', Mock(return_value={})):
             self.runner.invoke(ctl, ['list'])
@@ -558,10 +563,10 @@ class TestCtl(unittest.TestCase):
                                        'tags': {'replicatefrom': 'nonexistinghost'}}))
         with patch('patroni.dcs.AbstractDCS.get_cluster', Mock(return_value=cluster)):
             result = self.runner.invoke(ctl, ['topology', 'dummy'])
-            assert '+\n|     0 | leader          | 127.0.0.1:5435 | Leader  |' in result.output
-            assert '|\n|     0 | + other         | 127.0.0.1:5436 | Replica |' in result.output
-            assert '|\n|     0 |   + cascade     | 127.0.0.1:5437 | Replica |' in result.output
-            assert '|\n|     0 | + wrong_cascade | 127.0.0.1:5438 | Replica |' in result.output
+            assert '+\n| dc1  |     0 | leader          | 127.0.0.1:5435 | Leader  |' in result.output
+            assert '|\n| dc1  |     0 | + other         | 127.0.0.1:5436 | Replica |' in result.output
+            assert '|\n|      |     0 |   + cascade     | 127.0.0.1:5437 | Replica |' in result.output
+            assert '|\n|      |     0 | + wrong_cascade | 127.0.0.1:5438 | Replica |' in result.output
 
         with patch('patroni.dcs.AbstractDCS.get_cluster', Mock(return_value=get_cluster_initialized_without_leader())):
             result = self.runner.invoke(ctl, ['topology', 'dummy'])

--- a/tests/test_etcd.py
+++ b/tests/test_etcd.py
@@ -267,7 +267,7 @@ class TestEtcd(unittest.TestCase):
     @patch.object(EtcdClient, '_get_machines_list',
                   Mock(return_value=['http://localhost:2379', 'http://localhost:4001']))
     def setUp(self):
-        self.etcd = Etcd({'namespace': '/patroni/', 'ttl': 30, 'retry_timeout': 10,
+        self.etcd = Etcd({'site': 'dc1', 'namespace': '/patroni/', 'ttl': 30, 'retry_timeout': 10,
                           'host': 'localhost:2379', 'scope': 'test', 'name': 'foo'}, get_mpp({}))
 
     def test_base_path(self):
@@ -332,7 +332,7 @@ class TestEtcd(unittest.TestCase):
 
     def test_update_leader(self):
         cluster = self.etcd.get_cluster()
-        self.assertTrue(self.etcd.update_leader(cluster, None, failsafe={'foo': 'bar'}))
+        self.assertTrue(self.etcd.update_leader(cluster, 1, failsafe={'foo': 'bar'}))
         with patch.object(etcd.Client, 'write',
                           Mock(side_effect=[etcd.EtcdConnectionFailed, etcd.EtcdClusterIdChanged, Exception])):
             self.assertRaises(EtcdError, self.etcd.update_leader, cluster, None)

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -673,6 +673,11 @@ class TestHa(PostgresInit):
         self.ha.cluster.members.pop(2)
         self.assertEqual(self.ha.bootstrap(), "trying to bootstrap from replica 'yetanother'")
 
+        # I do not have site, chose replica with site specified instead of leader with no site
+        self.ha.patroni.site = None
+        self.ha.cluster.members[2].data['site'] = None
+        self.assertEqual(self.ha.bootstrap(), "trying to bootstrap from replica 'yetanother'")
+
     @patch('patroni.psycopg.connect', psycopg_connect)
     @patch('patroni.postgresql.mpp.citus.connect', psycopg_connect)
     @patch('patroni.postgresql.mpp.citus.quote_ident', Mock())

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -47,7 +47,8 @@ def get_cluster(initialize, leader, members, failover, sync, cluster_config=None
     history = TimelineHistory(1, '[[1,67197376,"no recovery target specified","' + t + '","foo"]]',
                               [(1, 67197376, 'no recovery target specified', t, 'foo')])
     cluster_config = cluster_config or ClusterConfig(1, {'check_timeline': True, 'member_slots_ttl': 0}, 1)
-    return Cluster(initialize, cluster_config, leader, Status(10, None, []), members, failover, sync, history, failsafe)
+    return Cluster(initialize, cluster_config, leader, Status(10, None, [], None),
+                   members, failover, sync, history, failsafe)
 
 
 def get_cluster_not_initialized_without_leader(cluster_config=None):
@@ -645,6 +646,33 @@ class TestHa(PostgresInit):
         self.ha.cluster = get_cluster_not_initialized_without_leader()
         self.assertEqual(self.ha.bootstrap(), 'failed to acquire initialize lock')
 
+    def test_bootstrap_from_local_member(self):
+        me = Member(0, 'postgresql0', 28, {'conn_url': 'postgres://replicator:rep-pass@127.0.0.1:5434/postgres',
+                    'state': PostgresqlState.RUNNING, 'site': 'dc1', 'tags': {'clonefrom': True}})
+        one = Member(0, 'one', 28, {'xlog_location': 100, 'state': PostgresqlState.RUNNING,
+                                    'conn_url': 'postgres://replicator:rep-pass@127.0.0.1:5435/postgres',
+                                    'site': 'dc1', 'tags': {'clonefrom': True}})
+        another = Member(0, 'another', 28, {'conn_url': 'postgres://replicator:rep-pass@127.0.0.1:5433/postgres',
+                                            'state': PostgresqlState.RUNNING, 'site': 'dc1',
+                                            'tags': {'clonefrom': True}})
+        yetanother = Member(0, 'yetanother', 28, {'conn_url': 'postgres://replicator:rep-pass@127.0.0.1:5433/postgres',
+                                                  'state': PostgresqlState.RUNNING, 'site': 'dc2',
+                                                  'tags': {'clonefrom': True}})
+        self.ha.cluster = Cluster(True, {}, Leader(-1, 28, one), Status(0, {}, [], 'dc1'),
+                                  [me, one, another, yetanother], None, SyncState.empty(), None, None, None)
+        global_config.update(self.ha.cluster)
+        self.assertEqual(self.ha.bootstrap(), "trying to bootstrap from replica 'another'")
+
+        # only leader is left locally
+        self.ha.cluster.members[2].data['site'] = 'dc2'
+        global_config.update(self.ha.cluster)
+        self.assertEqual(self.ha.bootstrap(), "trying to bootstrap from leader 'one'")
+
+        # all are remote
+        self.ha.cluster.members[1].data['site'] = 'dc2'
+        self.ha.cluster.members.pop(2)
+        self.assertEqual(self.ha.bootstrap(), "trying to bootstrap from replica 'yetanother'")
+
     @patch('patroni.psycopg.connect', psycopg_connect)
     @patch('patroni.postgresql.mpp.citus.connect', psycopg_connect)
     @patch('patroni.postgresql.mpp.citus.quote_ident', Mock())
@@ -691,6 +719,44 @@ class TestHa(PostgresInit):
         self.assertIsNone(self.ha.reinitialize(True, True))
         self.ha._async_executor.schedule('reinitialize')
         self.assertIsNotNone(self.ha.reinitialize())
+
+        # multi-site reinit
+        me = Member(0, 'postgresql0', 28, {'conn_url': 'postgres://replicator:rep-pass@127.0.0.1:5434/postgres',
+                                           'state': PostgresqlState.RUNNING, 'site': 'dc1',
+                                           'tags': {'clonefrom': True}})
+        one = Member(0, 'one', 28, {'xlog_location': 100, 'state': PostgresqlState.RUNNING,
+                                    'conn_url': 'postgres://replicator:rep-pass@127.0.0.1:5435/postgres',
+                                    'site': 'dc1', 'tags': {'clonefrom': True}})
+        another = Member(0, 'another', 28, {'conn_url': 'postgres://replicator:rep-pass@127.0.0.1:5433/postgres',
+                                            'state': PostgresqlState.RUNNING, 'site': 'dc1',
+                                            'tags': {'clonefrom': True}})
+        yetanother = Member(0, 'yetanother', 28, {'conn_url': 'postgres://replicator:rep-pass@127.0.0.1:5433/postgres',
+                                                  'state': PostgresqlState.RUNNING, 'site': 'dc2',
+                                                  'tags': {'clonefrom': True}})
+        self.ha.cluster = Cluster(True, {}, Leader(-1, 28, one), Status(0, {}, [], 'dc1'),
+                                  [me, one, another, yetanother], None, SyncState.empty(), None, None, None)
+        global_config.update(self.ha.cluster)
+        self.ha._async_executor._scheduled_action = None
+        with patch('patroni.ha.logger.info') as mock_info:
+            # local replica
+            self.assertIsNone(self.ha.reinitialize())
+            self.assertEqual(mock_info.call_args_list[0][0],
+                             ('bootstrapped %s', "from replica 'another'"))
+
+            # only leader is left locally
+            mock_info.reset_mock()
+            self.ha.cluster.members[2].data['site'] = 'dc2'
+            self.assertIsNone(self.ha.reinitialize())
+            self.assertEqual(mock_info.call_args_list[0][0],
+                             ('bootstrapped %s', "from leader 'one'"))
+
+            # all are remote
+            mock_info.reset_mock()
+            self.ha.cluster.members[1].data['site'] = 'dc2'
+            self.ha.cluster.members.pop(2)
+            self.assertIsNone(self.ha.reinitialize())
+            self.assertEqual(mock_info.call_args_list[0][0],
+                             ('bootstrapped %s', "from replica 'yetanother'"))
 
         self.ha.state_handler.name = self.ha.cluster.leader.name
         self.assertIsNotNone(self.ha.reinitialize())

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -61,11 +61,12 @@ def get_cluster_bootstrapping_without_leader(cluster_config=None):
 def get_cluster_initialized_without_leader(leader=False, failover=None, sync=None, cluster_config=None, failsafe=False):
     m1 = Member(0, 'leader', 28, {'conn_url': 'postgres://replicator:rep-pass@127.0.0.1:5435/postgres',
                                   'api_url': 'http://127.0.0.1:8008/patroni', 'xlog_location': 4,
-                                  'role': PostgresqlRole.PRIMARY, 'state': 'running'})
+                                  'role': PostgresqlRole.PRIMARY, 'state': 'running', 'site': 'dc1'})
     leader = Leader(0, 0, m1 if leader else Member(0, '', 28, {}))
     m2 = Member(0, 'other', 28, {'conn_url': 'postgres://replicator:rep-pass@127.0.0.1:5436/postgres',
                                  'api_url': 'http://127.0.0.1:8011/patroni',
                                  'state': 'running',
+                                 'site': 'dc1',
                                  'pause': True,
                                  'tags': {'clonefrom': True},
                                  'scheduled_restart': {'schedule': "2100-01-01 10:53:07.560445+00:00",
@@ -168,6 +169,7 @@ zookeeper:
         self.request = lambda *args, **kwargs: requests_get(args[0].api_url, *args[1:], **kwargs)
         self.failover_priority = 1
         self.sync_priority = 1
+        self.site = 'dc1'
 
 
 def run_async(self, func, args=()):

--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -278,8 +278,16 @@ class TestPatroni(unittest.TestCase):
         self.p.tags['replicatefrom'] = 'foo'
         self.assertEqual(self.p.replicatefrom, 'foo')
 
+    @patch('patroni.config.Config.reload_local_configuration', Mock(return_value=True))
     def test_reload_config(self):
         self.p.reload_config()
+        with patch.object(self.p.config, 'get',
+                          lambda key, *args, **kwargs: 'dc2' if key == 'site'
+                          else config.Config.get(self.p.config, key, *args, **kwargs)):
+            self.p.reload_config(local=True)
+        self.assertEqual(self.p._site, 'dc2')
+        self.assertEqual(self.p.dcs._site, 'dc2')
+        self.assertEqual(self.p.postgresql.sync_handler.site, 'dc2')
         self.p._get_tags = Mock(side_effect=Exception)
         self.p.reload_config(local=True)
 

--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -281,13 +281,6 @@ class TestPatroni(unittest.TestCase):
     @patch('patroni.config.Config.reload_local_configuration', Mock(return_value=True))
     def test_reload_config(self):
         self.p.reload_config()
-        with patch.object(self.p.config, 'get',
-                          lambda key, *args, **kwargs: 'dc2' if key == 'site'
-                          else config.Config.get(self.p.config, key, *args, **kwargs)):
-            self.p.reload_config(local=True)
-        self.assertEqual(self.p.site, 'dc2')
-        self.assertEqual(self.p.dcs.site, 'dc2')
-        self.assertEqual(self.p.postgresql.site, 'dc2')
         self.p._get_tags = Mock(side_effect=Exception)
         self.p.reload_config(local=True)
 

--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -285,9 +285,9 @@ class TestPatroni(unittest.TestCase):
                           lambda key, *args, **kwargs: 'dc2' if key == 'site'
                           else config.Config.get(self.p.config, key, *args, **kwargs)):
             self.p.reload_config(local=True)
-        self.assertEqual(self.p._site, 'dc2')
-        self.assertEqual(self.p.dcs._site, 'dc2')
-        self.assertEqual(self.p.postgresql.sync_handler.site, 'dc2')
+        self.assertEqual(self.p.site, 'dc2')
+        self.assertEqual(self.p.dcs.site, 'dc2')
+        self.assertEqual(self.p.postgresql.site, 'dc2')
         self.p._get_tags = Mock(side_effect=Exception)
         self.p.reload_config(local=True)
 

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -38,7 +38,7 @@ class TestSlotsHandler(BaseTestPostgresql):
         self.s = self.p.slots_handler
         self.p.start()
         config = ClusterConfig(1, {'slots': {'ls': {'database': 'a', 'plugin': 'b'}, 'ls2': None}}, 1)
-        self.cluster = Cluster(True, config, self.leader, Status(0, {'ls': 12345, 'ls2': 12345}, []),
+        self.cluster = Cluster(True, config, self.leader, Status(0, {'ls': 12345, 'ls2': 12345}, [], None),
                                [self.me, self.other, self.leadermem], None, SyncState.empty(), None, None)
         global_config.update(self.cluster)
         self.tags = TestTags()
@@ -47,7 +47,7 @@ class TestSlotsHandler(BaseTestPostgresql):
         config = ClusterConfig(1, {'slots': {'test_3': {'database': 'a', 'plugin': 'b'},
                                              'A': 0, 'ls': 0, 'b': {'type': 'logical', 'plugin': '1'}},
                                    'ignore_slots': [{'name': 'blabla'}]}, 1)
-        cluster = Cluster(True, config, self.leader, Status(0, {'test_3': 10}, []),
+        cluster = Cluster(True, config, self.leader, Status(0, {'test_3': 10}, [], None),
                           [self.me, self.other, self.leadermem], None, SyncState.empty(), None, None)
         global_config.update(cluster)
         with mock.patch('patroni.postgresql.Postgresql._query', Mock(side_effect=psycopg.OperationalError)):
@@ -85,7 +85,7 @@ class TestSlotsHandler(BaseTestPostgresql):
 
         config = ClusterConfig(1, {'slots': {'ls': {'type': 'logical', 'plugin': 'b', 'database': 'a'}}}, 1)
         cluster = Cluster(True, config, self.leader,
-                          Status(0, {'test_3': 10}, []),
+                          Status(0, {'test_3': 10}, [], None),
                           [self.me, self.other, self.leadermem], None, SyncState.empty(), None, None)
         global_config.update(cluster)
         with patch.object(Postgresql, 'is_primary', Mock(side_effect=[False, True])):
@@ -109,7 +109,7 @@ class TestSlotsHandler(BaseTestPostgresql):
             'state': PostgresqlState.RUNNING, 'conn_url': 'postgres://replicator:rep-pass@127.0.0.1:5436/postgres',
             'tags': {'replicatefrom': 'postgresql0'}
         })
-        cluster = Cluster(True, config, self.leader, Status(0, {'ls': 10}, []),
+        cluster = Cluster(True, config, self.leader, Status(0, {'ls': 10}, [], None),
                           [self.me, self.other, self.leadermem, cascading_replica], None, SyncState.empty(), None, None)
         self.p.set_role(PostgresqlRole.REPLICA)
         with patch.object(Postgresql, '_query') as mock_query, \
@@ -160,7 +160,7 @@ class TestSlotsHandler(BaseTestPostgresql):
             'state': PostgresqlState.RUNNING, 'conn_url': 'postgres://replicator:rep-pass@127.0.0.1:5436/postgres',
             'xlog_location': 99})
         cluster = Cluster(
-            True, config, self.leader, Status(100, {'leader': 99, 'test_2': 98, 'test_3': 97, 'test_4': 98}, []),
+            True, config, self.leader, Status(100, {'leader': 99, 'test_2': 98, 'test_3': 97, 'test_4': 98}, [], None),
             [self.leadermem, nostream_node, cascade_node, stream_node], None, SyncState.empty(), None, None)
         global_config.update(cluster)
 
@@ -332,7 +332,7 @@ class TestSlotsHandler(BaseTestPostgresql):
     def test_advance_physical_primary(self):
         self.p.name = self.me.name
         config = ClusterConfig(1, {'member_slots_ttl': 0, 'slots': {'test_1': {'type': 'physical'}}}, 1)
-        cluster = Cluster(True, config, self.leader, Status(0, {}, []),
+        cluster = Cluster(True, config, self.leader, Status(0, {}, [], None),
                           [self.me, self.other, self.leadermem], None, SyncState.empty(), None, None)
         self.other.data['xlog_location'] = 12346
         global_config.update(cluster)
@@ -360,7 +360,7 @@ class TestSlotsHandler(BaseTestPostgresql):
     @patch.object(Postgresql, 'role', PropertyMock(return_value=PostgresqlRole.REPLICA))
     def test_advance_physical_slots(self):
         config = ClusterConfig(1, {'slots': {'blabla': {'type': 'physical'}, 'leader': None}}, 1)
-        cluster = Cluster(True, config, self.leader, Status(0, {'blabla': 12346}, []),
+        cluster = Cluster(True, config, self.leader, Status(0, {'blabla': 12346}, [], None),
                           [self.me, self.other, self.leadermem], None, SyncState.empty(), None, None)
         global_config.update(cluster)
         self.s.sync_replication_slots(cluster, self.tags)
@@ -422,7 +422,7 @@ class TestSlotsHandler(BaseTestPostgresql):
     def test_slots_nofailover_tag(self):
         self.p.name = self.leadermem.name
         cluster = Cluster(True, ClusterConfig(1, {}, 1), self.leader,
-                          Status(0, {}, [self.leadermem.name, self.other.name, self.me.name]),
+                          Status(0, {}, [self.leadermem.name, self.other.name, self.me.name], None),
                           [self.me, self.other, self.leadermem], None, SyncState.empty(), None, None)
         global_config.update(cluster)
         with patch.object(SlotsHandler, '_query',
@@ -484,7 +484,7 @@ class TestSlotsHandler(BaseTestPostgresql):
                   Mock(return_value=[('ls', 'logical', 1, 104, 'b', 'a', 5, 12345, 105, 'reserved', True, False)]))
     def test__drop_incorrect_failover_synced_slots(self):
         config = ClusterConfig(1, {}, 1)
-        cluster = Cluster(True, config, self.leader, Status(0, {}, []),
+        cluster = Cluster(True, config, self.leader, Status(0, {}, [], None),
                           [self.me, self.other, self.leadermem], None, SyncState.empty(), None, None)
         with patch('patroni.postgresql.slots.logger.info') as mock_info:
             self.s.sync_replication_slots(cluster, self.tags)
@@ -498,7 +498,7 @@ class TestSlotsHandler(BaseTestPostgresql):
                                      ('test_1', 'physical', 1, 12345, None, None, None, None, None, 'lost')]))
     def test__drop_incorrect_slots(self):
         config = ClusterConfig(1, {}, 1)
-        cluster = Cluster(True, config, self.leader, Status(0, {}, []),
+        cluster = Cluster(True, config, self.leader, Status(0, {}, [], None),
                           [self.me, self.other, self.leadermem], None, SyncState.empty(), None, None)
         with patch('patroni.postgresql.slots.logger.info') as mock_info:
             self.s.sync_replication_slots(cluster, self.tags)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -507,3 +507,15 @@ class TestValidator(unittest.TestCase):
         c['bootstrap'] = {'dcs': {'synchronous_mode': 123}}
         errors = schema(c)
         self.assertTrue(any('bootstrap.dcs.synchronous_mode' in error for error in errors))
+
+    def test_validate_site_empty_string(self, mock_out, mock_err):
+        c = copy.deepcopy(config)
+        c['site'] = ''
+        errors = schema(c)
+        output = "\n".join(errors)
+        self.assertEqual(['postgresql.bin_dir', 'raft.bind_addr', 'raft.self_addr', 'site'], parse_output(output))
+
+        c['site'] = 'dc1'
+        errors = schema(c)
+        output = "\n".join(errors)
+        self.assertEqual(['postgresql.bin_dir', 'raft.bind_addr', 'raft.self_addr'], parse_output(output))


### PR DESCRIPTION
Part 1 of site-awareness work in Patroni

Now site can be configured via local configuration (incl.  environment variables) and make cloning site aware (prefer local reinit and replica bootstrap)
```
+ Cluster: demo (7666092842183090209) ---+-----------+----+-------------+-----+------------+-----+
| Site | Member   | Host       | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag |
+------+----------+------------+---------+-----------+----+-------------+-----+------------+-----+
| dc1  | patroni1 | 172.19.0.3 | Leader  | running   |  1 |             |     |            |     |
| dc1  | patroni2 | 172.19.0.7 | Replica | streaming |  1 |   0/604FB68 |   0 |  0/604FB68 |   0 |
| dc2  | patroni3 | 172.19.0.2 | Replica | streaming |  1 |   0/604FB68 |   0 |  0/604FB68 |   0 |
| dc2  | patroni4 | 172.19.0.6 | Replica | streaming |  1 |   0/604FB68 |   0 |  0/604FB68 |   0 |
+------+----------+------------+---------+-----------+----+-------------+-----+------------+-----+
```