### PR TITLE
Stream subprocess output line-by-line via stream_cb

### DIFF
--- a/patroni/postgresql/cancellable.py
+++ b/patroni/postgresql/cancellable.py
@@ -1,11 +1,13 @@
 import logging
 import subprocess
 
+from io import BufferedReader
 from threading import Lock
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, cast, Dict, List, Optional, Tuple
 
 import psutil
 
+from patroni import thread_pool
 from patroni.exceptions import PostgresException
 from patroni.utils import polling_loop
 
@@ -76,11 +78,78 @@ class CancellableSubprocess(CancellableExecutor):
         super(CancellableSubprocess, self).__init__()
         self._is_cancelled = False
 
-    def call(self, *args: Any, **kwargs: Any) -> Optional[int]:
-        for s in ('stdin', 'stdout', 'stderr'):
-            kwargs.pop(s, None)
+    def _communicate_streaming(self, stream_cb: Callable[[str, bytes], None]) -> Tuple[bytes, bytes]:
+        """Read the running process' stdout/stderr line-by-line as it arrives.
 
-        communicate: Optional[Dict[str, str]] = kwargs.pop('communicate', None)
+        ``stderr`` is drained by a single helper thread while ``stdout`` is read inline, so both pipes are drained
+        concurrently with only one extra thread. ``read1()`` returns as soon as any data is available, so slowly
+        produced lines are delivered promptly. Exceptions from ``stream_cb`` are swallowed so streaming continues;
+        only read/OS errors abort (after both streams are drained).
+
+        :param stream_cb: called as ``stream_cb(stream_name, line)`` for every complete line of *stdout*/*stderr*.
+
+        :returns: ``(stdout_bytes, stderr_bytes)``.
+        """
+        process = cast(psutil.Popen, self._process)
+
+        stdout_chunks: List[bytes] = []
+        stderr_chunks: List[bytes] = []
+
+        def emit(name: str, line: bytes) -> None:
+            try:
+                stream_cb(name, line.rstrip(b'\r'))  # drop trailing CR (CRLF on Windows)
+            except Exception:
+                pass  # keep streaming despite a bad callback
+
+        def reader(stream: BufferedReader, name: str, sink: List[bytes]) -> None:
+            buf = b''
+            try:
+                while True:
+                    # read1() -> a single underlying read: returns as soon as data is available
+                    chunk = stream.read1(32768)
+                    if not chunk:  # b'' -> EOF
+                        break
+                    sink.append(chunk)
+                    buf += chunk
+                    *lines, buf = buf.split(b'\n')
+                    for line in lines:
+                        emit(name, line)
+                if buf:  # trailing data without a final newline
+                    emit(name, buf)
+            finally:
+                stream.close()
+
+        # A single helper task (from the global pool) drains stderr; stdout is read inline below.
+        stderr_future = thread_pool.get_executor().submit(reader, process.stderr, 'stderr', stderr_chunks) \
+            if process.stderr else None
+
+        try:
+            if process.stdout:
+                reader(process.stdout, 'stdout', stdout_chunks)
+        finally:
+            if stderr_future is not None:
+                stderr_future.result()
+
+        return b''.join(stdout_chunks), b''.join(stderr_chunks)
+
+    def call(self, *args: Any, **kwargs: Any) -> Optional[int]:
+        """Start a cancellable subprocess, optionally capture/stream its output, and wait for it to finish.
+
+        Positional and keyword arguments are forwarded to :class:`psutil.Popen`, except for the two special
+        keyword arguments below, which are consumed here.
+
+        :param communicate: optional :class:`dict` used to exchange data with the process. When provided,
+                            *stdout* and *stderr* are captured and stored back into it under the ``stdout`` and
+                            ``stderr`` keys, and an optional ``input`` value is sent to *stdin*.
+        :param stream_cb: optional callback invoked as ``stream_cb(stream_name, line)`` for every complete line
+                          of *stdout*/*stderr* as it arrives. Effective only when there is no ``input`` to send;
+                          forces binary pipes.
+
+        :raises PostgresException: if the executor was already cancelled.
+
+        :returns: the process' exit code, or ``None`` if it could not be started.
+        """
+        communicate: Optional[Dict[str, Any]] = kwargs.pop('communicate', None)
         input_data = None
         if isinstance(communicate, dict):
             input_data = communicate.get('input')
@@ -88,9 +157,17 @@ class CancellableSubprocess(CancellableExecutor):
                 if input_data[-1] != '\n':
                     input_data += '\n'
                 input_data = input_data.encode('utf-8')
-            kwargs['stdin'] = subprocess.PIPE
+
+        stream_cb: Optional[Callable[[str, bytes], None]] = kwargs.pop('stream_cb', None)
+        if stream_cb or isinstance(communicate, dict):
+            kwargs['stdin'] = subprocess.PIPE if input_data else subprocess.DEVNULL
             kwargs['stdout'] = subprocess.PIPE
             kwargs['stderr'] = subprocess.PIPE
+
+        if stream_cb and not input_data:
+            # streaming reads raw bytes, so force binary pipes
+            for key in ('text', 'universal_newlines', 'encoding', 'errors'):
+                kwargs.pop(key, None)
 
         try:
             with self._lock:
@@ -101,9 +178,15 @@ class CancellableSubprocess(CancellableExecutor):
                 started = self._start_process(*args, **kwargs)
 
             if started and self._process is not None:
-                if isinstance(communicate, dict):
+                if stream_cb and not input_data:
+                    stdout, stderr = self._communicate_streaming(stream_cb)
+                    if isinstance(communicate, dict):
+                        # hand the full captured output back to the caller, if requested
+                        communicate.update(stdout=stdout, stderr=stderr)
+                elif isinstance(communicate, dict):
                     communicate['stdout'], communicate['stderr'] = \
                         self._process.communicate(input_data)  # pyright: ignore [reportGeneralTypeIssues]
+
                 return self._process.wait()
         finally:
             with self._lock:

--- a/tests/test_cancellable.py
+++ b/tests/test_cancellable.py
@@ -1,3 +1,4 @@
+import subprocess
 import unittest
 
 from unittest.mock import Mock, patch
@@ -6,6 +7,7 @@ import psutil
 
 from patroni.exceptions import PostgresException
 from patroni.postgresql.cancellable import CancellableSubprocess
+from patroni.thread_pool import PatroniThreadPoolExecutor
 
 
 class TestCancellableSubprocess(unittest.TestCase):
@@ -34,3 +36,54 @@ class TestCancellableSubprocess(unittest.TestCase):
         self.c.cancel()
         self.c._process.is_running.side_effect = [True, False]
         self.c.cancel()
+
+    @patch('patroni.thread_pool.get_executor', Mock(return_value=PatroniThreadPoolExecutor(max_workers=1)))
+    @patch('patroni.postgresql.cancellable.psutil.Popen')
+    def test_call_stream_cb(self, mock_popen):
+        def _mock_stream(*chunks):
+            return Mock(read1=Mock(side_effect=list(chunks) + [b'']), close=Mock())
+
+        mock_popen.return_value = Mock(stdout=_mock_stream(b'out1\nout2\n', b'tail'),
+                                       stderr=_mock_stream(b'err1\r\nerr2\n'))
+        mock_popen.return_value.wait.return_value = 0
+
+        lines = []
+
+        def cb(name, line):
+            lines.append((name, line))
+            if line == b'out2':
+                raise RuntimeError('boom')  # a bad callback must not stop streaming
+
+        communicate = {}
+        ret = self.c.call(['cmd'], communicate=communicate, text=True, stream_cb=cb)
+        self.assertEqual(ret, 0)
+        # callback errors are swallowed: every line is still delivered (per-stream order is
+        # deterministic), the trailing stdout line has no newline and the stderr CR is stripped
+        self.assertEqual([line for name, line in lines if name == 'stdout'], [b'out1', b'out2', b'tail'])
+        self.assertEqual([line for name, line in lines if name == 'stderr'], [b'err1', b'err2'])
+        # the full output is still captured back into the communicate dict
+        self.assertEqual(communicate['stdout'], b'out1\nout2\ntail')
+        self.assertEqual(communicate['stderr'], b'err1\r\nerr2\n')
+        # streaming forces binary pipes and DEVNULL stdin (no input)
+        kwargs = mock_popen.call_args[1]
+        self.assertEqual(kwargs['stdin'], subprocess.DEVNULL)
+        self.assertEqual(kwargs['stdout'], subprocess.PIPE)
+        self.assertEqual(kwargs['stderr'], subprocess.PIPE)
+        self.assertNotIn('text', kwargs)
+
+    @patch('patroni.postgresql.cancellable.psutil.Popen')
+    def test_call_stream_cb_ignored_with_input(self, mock_popen):
+        # when there is input to send, stream_cb is ignored and communicate() is used instead
+        mock_popen.return_value.wait.return_value = 0
+        mock_popen.return_value.communicate.return_value = (b'o', b'e')
+
+        called = []
+        communicate = {'input': 'data'}
+        ret = self.c.call(['cmd'], communicate=communicate,
+                          stream_cb=lambda name, line: called.append((name, line)))
+        self.assertEqual(ret, 0)
+        self.assertEqual(called, [])
+        mock_popen.return_value.communicate.assert_called_once_with(b'data\n')
+        self.assertEqual(communicate['stdout'], b'o')
+        self.assertEqual(communicate['stderr'], b'e')
+        self.assertEqual(mock_popen.call_args[1]['stdin'], subprocess.PIPE)


### PR DESCRIPTION
Add a `stream_cb` option to `CancellableSubprocess.call()` that delivers stdout/stderr to a callback one line at a time as it arrives, instead of only returning the full output after the process exits.