### PR TITLE
fix: check failsafe mode when update_lock() returns False (K8s DCS)

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1942,6 +1942,20 @@ class Ha(object):
                 if self.state_handler.is_primary():
                     if self.is_paused():
                         return 'continue to run as primary after failing to update leader lock in DCS'
+                    # When update_lock() returns False (rather than raising DCSError),
+                    # _handle_dcs_error() is never reached and failsafe_mode is bypassed.
+                    # This happens with Kubernetes DCS, where @catch_kubernetes_errors
+                    # on _patch_or_create() swallows KubernetesError (= DCSError) and
+                    # converts it to a False return before it can propagate to _run_cycle().
+                    # Check failsafe here to cover that gap.
+                    if self.is_failsafe_mode() and self.state_handler.is_running() \
+                            and self.check_failsafe_topology():
+                        self.set_is_leader(True)
+                        self._failsafe.set_is_active(time.time())
+                        self.watchdog.keepalive()
+                        self._sync_replication_slots(True)
+                        return 'continue to run as a leader because failsafe mode is enabled'\
+                               ' and all members are accessible'
                     self.demote('immediate-nolock')
                     return 'demoted self because failed to update leader lock in DCS'
                 else:

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1943,21 +1943,13 @@ class Ha(object):
                     if self.is_paused():
                         return 'continue to run as primary after failing to update leader lock in DCS'
                     # When update_lock() returns False (rather than raising DCSError),
-                    # _handle_dcs_error() is never reached and failsafe_mode is bypassed.
+                    # _handle_dcs_error() is never reached via the except DCSError path
+                    # in _run_cycle(), and failsafe_mode is bypassed.
                     # This happens with Kubernetes DCS, where @catch_kubernetes_errors
                     # on _patch_or_create() swallows KubernetesError (= DCSError) and
                     # converts it to a False return before it can propagate to _run_cycle().
-                    # Check failsafe here to cover that gap.
-                    if self.is_failsafe_mode() and self.state_handler.is_running() \
-                            and self.check_failsafe_topology():
-                        self.set_is_leader(True)
-                        self._failsafe.set_is_active(time.time())
-                        self.watchdog.keepalive()
-                        self._sync_replication_slots(True)
-                        return 'continue to run as a leader because failsafe mode is enabled'\
-                               ' and all members are accessible'
-                    self.demote('immediate-nolock')
-                    return 'demoted self because failed to update leader lock in DCS'
+                    # Delegate to _handle_dcs_error() to check failsafe before demoting.
+                    return self._handle_dcs_error()
                 else:
                     return 'not promoting because failed to update leader lock in DCS'
         else:

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -489,9 +489,11 @@ class TestHa(PostgresInit):
     def test_demote_because_update_lock_failed(self):
         self.ha.has_lock = true
         self.ha.update_lock = false
-        self.assertEqual(self.ha.run_cycle(), 'demoted self because failed to update leader lock in DCS')
+        self.assertEqual(self.ha.run_cycle(),
+                         'demoted self because DCS is not accessible and I was a leader')
         with patch.object(Ha, '_get_node_to_follow', Mock(side_effect=DCSError('foo'))):
-            self.assertEqual(self.ha.run_cycle(), 'demoted self because failed to update leader lock in DCS')
+            self.assertEqual(self.ha.run_cycle(),
+                             'demoted self because DCS is not accessible and I was a leader')
         self.p.is_primary = false
         self.assertEqual(self.ha.run_cycle(), 'not promoting because failed to update leader lock in DCS')
 

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -576,6 +576,22 @@ class TestHa(PostgresInit):
         self.assertEqual(self.ha.run_cycle(),
                          'continue to run as a leader because failsafe mode is enabled and all members are accessible')
 
+    def test_update_lock_returns_false_failsafe(self):
+        """Test failsafe when update_lock() returns False instead of raising DCSError.
+
+        This happens with Kubernetes DCS, where @catch_kubernetes_errors on
+        _patch_or_create() swallows KubernetesError (= DCSError) and converts
+        it to a False return before it can propagate to _run_cycle().
+        """
+        self.ha.cluster = get_cluster_initialized_with_leader_and_failsafe()
+        global_config.update(self.ha.cluster)
+        self.ha.dcs.update_leader = Mock(return_value=False)
+        self.ha.dcs._last_failsafe = self.ha.cluster.failsafe
+        self.ha.state_handler.name = self.ha.cluster.leader.name
+        self.assertEqual(self.ha.run_cycle(),
+                         'continue to run as a leader because failsafe mode is enabled'
+                         ' and all members are accessible')
+
     def test_no_dcs_connection_replica_failsafe(self):
         self.p.last_operation = Mock(side_effect=PostgresConnectionException(''))
         self.ha.load_cluster_from_dcs = Mock(side_effect=DCSError('Etcd is not responding properly'))


### PR DESCRIPTION
## Problem

When using Kubernetes DCS, `failsafe_mode` is bypassed when `update_lock()` returns `False` instead of raising `DCSError`. This causes unnecessary leader demotion during K8s API timeouts (e.g., etcd defragmentation, API server overload).

### Root cause

`@catch_kubernetes_errors` on `_patch_or_create()` catches `KubernetesError` (which inherits from `DCSError`) and converts it to a `False` return:

```python
# kubernetes.py
@catch_kubernetes_errors                              # ← catches KubernetesError (= DCSError)
def _patch_or_create(self, name, annotations, ...):   # ← returns False instead of raising DCSError
    ...

def catch_kubernetes_errors(func):
    def wrapper(self, *args, **kwargs):
        try:
            return self._run_and_handle_exceptions(func, self, *args, **kwargs)
        except KubernetesError:   # ← KubernetesError inherits from DCSError (kubernetes.py:70)
            return False           # ← swallowed, update_lock() sees False, not DCSError
    return wrapper
```

As a result, `update_lock()` in `ha.py` returns `False` (not `DCSError`), and `process_healthy_cluster()` demotes without checking failsafe:

```python
# ha.py, process_healthy_cluster()
if self.update_lock(True):   # ← returns False (not DCSError) for K8s DCS
    ...                       # ← not reached
else:
    self.demote('immediate-nolock')   # ← demote WITHOUT failsafe check
```

The failsafe check in `_handle_dcs_error()` is only reachable via `except DCSError:` in `_run_cycle()` — which is never triggered because `@catch_kubernetes_errors` swallowed the exception.

### When does this happen?

Two conditions must be met simultaneously:
1. `load_cluster_from_dcs()` **succeeds** (ObjectCache has valid cached data → reads from cache)
2. `update_lock()` **fails** (K8s API PATCH times out → `@catch_kubernetes_errors` swallows error → returns `False`)

This is exactly what happens during etcd defragmentation: ObjectCache retains cached data (reads succeed), but etcd can't process writes (~5 seconds).

### When does failsafe work correctly?

When `load_cluster_from_dcs()` also fails (e.g., SSL errors, complete K8s API connection failure), `DCSError` IS raised (via `__load_cluster()` → `KubernetesError`), reaches `_run_cycle()`, and `_handle_dcs_error()` is called with failsafe check. This was confirmed in production logs.

### This is consistent with PR #2484

PR #2484 ("Raise DCSError when communication with DCS fails") explicitly stated the intent:

> *"Previously such an exception was raised only from the `get_cluster()` method, and now we will do the same from the `update_leader()` and `attempt_to_acquire_leader()` methods."*

However, for K8s DCS, `@catch_kubernetes_errors` on `_patch_or_create()` prevents `DCSError` from propagating out of `update_leader()`. The dead `except (RetryFailedError, K8sException)` block in `_update_leader_with_retry()` (added in the same PR) proves the intent was for exceptions to propagate.

### Related issues

- **#3344** — "Demoting self when failsafe mode is enabled and got ReadTimeoutError from k8s api" (Patroni 4.0.4)
- **#3462** — "patroni demoting master while having issues with k8s api (failsafe mode is on)" (Patroni 4.0.6)

In #3462, failsafe worked correctly for ~2 minutes (via read path), then the leader was demoted when `update_lock()` returned `False` (write path). The logs show `ReadTimeoutError` and `ConnectTimeoutError`, not HTTP 409.

- **#3404** — Similar fix for etcd DCS: *"We need to convert it to etcd.EtcdConnectionFailed for failsafe_mode to work."*
- **#3348** — Partial fix for `attempt_to_acquire_leader()` path (409 handling), but does not address `update_leader()` path.

## Fix

Add a failsafe check in `process_healthy_cluster()` before demoting, mirroring the logic in `_handle_dcs_error()`:

```python
else:
    logger.error('failed to update leader lock')
    if self.state_handler.is_primary():
        if self.is_paused():
            return 'continue to run as primary after failing to update leader lock in DCS'
        if self.is_failsafe_mode() and self.state_handler.is_running() \
                and self.check_failsafe_topology():
            self.set_is_leader(True)
            self._failsafe.set_is_active(time.time())
            self.watchdog.keepalive()
            self._sync_replication_slots(True)
            return 'continue to run as a leader because failsafe mode is enabled'\
                   ' and all members are accessible'
        self.demote('immediate-nolock')
        return 'demoted self because failed to update leader lock in DCS'
```

This is safe because `check_failsafe_topology()` contacts all replicas via REST. If another node has legitimately taken leadership, it responds with `Running as a leader` → `check_failsafe_topology()` returns `False` → demote proceeds correctly.

## Test

Added `test_update_lock_returns_false_failsafe` — verifies that when `update_leader` returns `False` (simulating K8s DCS behavior), failsafe is still checked and the leader continues running.