### PR TITLE
Implement site-aware failover and manual switchover

### DIFF
--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -13,7 +13,7 @@ Global/Universal
 -  **PATRONI\_NAME**: name of the node where the current instance of Patroni is running. Must be unique for the cluster. The value ``__patroni_strict_sync_replica_placeholder__`` is reserved for internal use by Patroni and cannot be used as a node name.
 -  **PATRONI\_NAMESPACE**: path within the configuration store where Patroni will keep information about the cluster. Default value: "/service"
 -  **PATRONI\_SCOPE**: cluster name
--  **PATRONI\_SITE**: optional string name of the physical site or location where this Patroni node runs, such as a data center, availability zone, or region. When configured, Patroni records it in member metadata and uses it to prefer local clone sources for replica bootstrap and ``patronictl reinit``.
+-  **PATRONI\_SITE**: optional string name of the physical site or location where this Patroni node runs, such as a data center, availability zone, or region. When configured, Patroni records it in member metadata and uses it to prefer local automatic failover to the site where the last known leader is located, while also helping to prefer local clone sources for replica bootstrap and ``patronictl reinit``.
 -  **PG\_MALLOC\_ARENA\_MAX**: custom value for ``MALLOC_ARENA_MAX`` environment variable for  ``postmaster`` process. If not set, ``postmaster`` will inherit ``MALLOC_ARENA_MAX`` value.
 
 Log

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -390,6 +390,7 @@ Synopsis
       [ CLUSTER_NAME ]
       [ --group CITUS_GROUP ]
       --candidate CANDIDATE_NAME
+      [ --site SITE_NAME ]
       [ --force ]
 
 .. _patronictl_failover_description:
@@ -405,6 +406,8 @@ It is designed to be used when the cluster is not healthy, e.g.:
 - There is no synchronous standby available in a synchronous cluster.
 
 It also allows to fail over to an asynchronous node if synchronous mode is enabled.
+
+If ``--site`` is supplied, only members belonging to that site are considered when listing failover candidates for selection. Because failover requires an explicit candidate, the command still needs a candidate value to complete the operation.
 
 .. note::
     Nothing prevents you from running ``patronictl failover`` in a healthy cluster. However, we recommend using ``patronictl switchover`` in those cases.
@@ -431,6 +434,11 @@ Parameters
     The node to be promoted on failover.
 
     ``CANDIDATE_NAME`` is the name of the node to be promoted.
+
+``--site``
+    Restrict failover candidates to members that belong to the given site.
+
+    ``SITE_NAME`` is the site name configured for the Patroni nodes.
 
 ``--force``
     Flag to skip confirmation prompts when performing the failover.
@@ -1785,7 +1793,8 @@ Synopsis
       [ CLUSTER_NAME ]
       [ --group CITUS_GROUP ]
       [ { --leader | --primary } LEADER_NAME ]
-      --candidate CANDIDATE_NAME
+      [ --candidate CANDIDATE_NAME ]
+      [ --site SITE_NAME ]
       [ --scheduled TIMESTAMP ]
       [ --force ]
 
@@ -1800,6 +1809,8 @@ It is designed to be used when the cluster is healthy, e.g.:
 
 - There is a leader;
 - There are synchronous standbys available in a synchronous cluster.
+
+If ``--site`` is supplied, only members belonging to that site are considered when listing switchover candidates for selection. Unlike failover, switchover can be performed with a site filter even if no explicit candidate is provided.
 
 .. note::
     If your cluster is unhealthy you might be interested in ``patronictl failover`` instead.
@@ -1828,6 +1839,11 @@ Parameters
     The node to be promoted on switchover, and take the primary role.
 
     ``CANDIDATE_NAME`` is the name of the node to be promoted.
+
+``--site``
+    Restrict switchover candidates to members that belong to the given site.
+
+    ``SITE_NAME`` is the site name configured for the Patroni nodes.
 
 ``--scheduled``
     Schedule a switchover to occur at the given timestamp.

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -665,7 +665,7 @@ Switchover
 
 When calling ``/switchover`` endpoint a candidate can be specified but is not required, in contrast to ``/failover`` endpoint. If a candidate is not provided, all the eligible nodes of the cluster will participate in the leader race after the leader stepped down.
 
-In the JSON body of the ``POST`` request you must specify the ``leader`` field. The ``candidate`` and the ``scheduled_at`` fields are optional and can be used to schedule a switchover at a specific time.
+In the JSON body of the ``POST`` request you must specify the ``leader`` field. The ``candidate`` and ``scheduled_at`` fields are optional, and the optional ``site`` field can be used to restrict the promotion target to members from a specific site instead of choosing an individual candidate. If a ``candidate`` is specified, the ``site`` value is ignored.
 
 Depending on the situation, requests might return different HTTP status codes and bodies. Status code **200** is returned when the switchover or failover successfully completed. If the switchover was successfully scheduled, Patroni will return HTTP status code **202**. In case something went wrong, the error status code (one of **400**, **412**, or **503**) will be returned with some details in the response body.
 
@@ -702,7 +702,7 @@ Failover
 
 ``/failover`` endpoint can be used to perform a manual failover when there are no healthy nodes (e.g. to an asynchronous standby if all synchronous standbys are not healthy enough to promote). However there is no requirement for a cluster not to have leader - failover can also be run on a healthy cluster.
 
-In the JSON body of the ``POST`` request you must specify the ``candidate`` field. If the ``leader`` field is specified, a switchover is triggered instead.
+In the JSON body of the ``POST`` request you must specify the ``candidate`` field. If the ``leader`` field is specified, a switchover is triggered instead. Unlike switchover, failover always requires a specific candidate and cannot be expressed with a ``site`` value.
 
 **Example:**
 
@@ -735,6 +735,9 @@ In the JSON body of the ``POST`` request you must specify the ``candidate`` fiel
    * - Can be run in pause
      - yes
      - yes (only to a specific candidate)
+   * - Can be restricted to a site
+     - no
+     - yes
    * - Can be scheduled
      - no
      - yes (if not in pause)

--- a/docs/yaml_configuration.rst
+++ b/docs/yaml_configuration.rst
@@ -12,7 +12,7 @@ Global/Universal
 -  **name**: the name of the host. Must be unique for the cluster. The value ``__patroni_strict_sync_replica_placeholder__`` is reserved for internal use by Patroni and cannot be used as a node name.
 -  **namespace**: path within the configuration store where Patroni will keep information about the cluster. Default value: "/service".
 -  **scope**: cluster name.
--  **site**: optional string name of the physical site or location where this Patroni node runs, such as a data center, availability zone, or region. When configured, Patroni records it in member metadata and uses it to prefer local clone sources for replica bootstrap and ``patronictl reinit``.
+-  **site**: optional string name of the physical site or location where this Patroni node runs, such as a data center, availability zone, or region. When configured, Patroni records it in member metadata and uses it to prefer local automatic failover to the site where the last known leader is located, while also helping to prefer local clone sources for replica bootstrap and ``patronictl reinit``.
 
 .. _log_settings:
 

--- a/features/site_awareness.feature
+++ b/features/site_awareness.feature
@@ -19,3 +19,16 @@ Feature: site awareness
     When I run patronictl.py reinit batman postgres-2 --force
     Then I receive a response returncode 0
     And there is one of ["bootstrapped from replica 'postgres-3'"] INFO in the postgres-2 patroni log after 25 seconds
+    And postgres-2 is in sync with primary after 30 seconds
+
+  Scenario: test local failover
+    When I shut down postgres-0
+    Then "members/postgres-1" key in DCS has role=primary after 10 seconds
+    And postgres-2 is in sync with primary after 30 seconds
+    And postgres-3 is in sync with primary after 30 seconds
+
+  Scenario: test site failover with failover_priority
+    When I shut down postgres-1
+    Then "members/postgres-3" key in DCS has role=primary after 10 seconds
+    And postgres-2 is in sync with primary after 30 seconds
+

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -1081,7 +1081,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
         """
         failover = self.server.patroni.dcs.get_cluster().failover
         if failover and failover.scheduled_at:
-            if not self.server.patroni.dcs.manual_failover('', '', version=failover.version):
+            if not self.server.patroni.dcs.manual_failover('', '', '', version=failover.version):
                 return self.send_error(409)
             else:
                 data = "scheduled switchover deleted"
@@ -1157,12 +1157,13 @@ class RestApiHandler(BaseHTTPRequestHandler):
             action.title(), timeout * 2)
 
     def is_failover_possible(self, cluster: Cluster, leader: Optional[str], candidate: Optional[str],
-                             action: str) -> Optional[str]:
+                             site: Optional[str], action: str) -> Optional[str]:
         """Checks whether there are nodes that could take over after demoting the primary.
 
         :param cluster: the Patroni cluster.
         :param leader: name of the current Patroni leader.
         :param candidate: name of the Patroni node to be promoted.
+        :param site: name of the site to failover/switchover to.
         :param action: the action to be performed (``switchover`` or ``failover``).
 
         :returns: a string with the error message or ``None`` if good nodes are found.
@@ -1177,14 +1178,21 @@ class RestApiHandler(BaseHTTPRequestHandler):
             members = [m for m in cluster.members if m.name == candidate]
             if not members:
                 return 'candidate does not exists'
-        elif config.is_synchronous_mode and not config.is_quorum_commit_mode:
-            members = [m for m in cluster.members if cluster.sync.matches(m.name)]
-            if not members:
-                return action + ' is not possible: can not find sync_standby'
         else:
-            members = [m for m in cluster.members if not cluster.leader or m.name != cluster.leader.name and m.api_url]
-            if not members:
-                return action + ' is not possible: cluster does not have members except leader'
+            members = cluster.members
+            if site:
+                members = [m for m in cluster.members if m.site == site]
+                if not members:
+                    return action + ' is not possible: can not find members in site ' + site
+            if config.is_synchronous_mode and not config.is_quorum_commit_mode:
+                members = [m for m in members if cluster.sync.matches(m.name)]
+                if not members:
+                    return action + ' is not possible: can not find sync_standby'
+            else:
+                members = [m for m in members if not cluster.leader or m.name != cluster.leader.name and m.api_url]
+                if not members:
+                    return action + ' is not possible: cluster does not have members except leader'
+
         for st in self.server.patroni.ha.fetch_nodes_statuses(members):
             if st.failover_limitation() is None:
                 return None
@@ -1201,7 +1209,8 @@ class RestApiHandler(BaseHTTPRequestHandler):
             * ``leader``: name of the current leader in the cluster;
             * ``candidate``: name of the Patroni node to be promoted;
             * ``scheduled_at``: a string representing the timestamp when to execute the switchover/failover, e.g.
-                ``2023-04-14T20:27:00+00:00``.
+                ``2023-04-14T20:27:00+00:00``;
+            * ``site``: name of the cluster site to choose a candidate from.
 
         Response HTTP status codes:
 
@@ -1225,11 +1234,12 @@ class RestApiHandler(BaseHTTPRequestHandler):
         leader = request.get('leader')
         candidate = request.get('candidate') or request.get('member')
         scheduled_at = request.get('scheduled_at')
+        site = request.get('site') if not candidate else None
         cluster = self.server.patroni.dcs.get_cluster()
         config = global_config.from_cluster(cluster)
 
-        logger.info("received %s request with leader=%s candidate=%s scheduled_at=%s",
-                    action, leader, candidate, scheduled_at)
+        logger.info("received %s request with leader=%s candidate=%s site=%s scheduled_at=%s",
+                    action, leader, candidate, site, scheduled_at)
 
         if action == 'failover' and not candidate:
             data = 'Failover could be performed only to a specific candidate'
@@ -1251,16 +1261,16 @@ class RestApiHandler(BaseHTTPRequestHandler):
             logger.warning('received failover request with leader specified - performing switchover instead')
             action = 'switchover'
 
-        if not data and leader == candidate:
+        if not data and leader and candidate and leader == candidate:
             data = 'Switchover target and source are the same'
 
         if not data and not scheduled_at:
-            data = self.is_failover_possible(cluster, leader, candidate, action)
+            data = self.is_failover_possible(cluster, leader, candidate, site, action)
             if data:
                 status_code = 412
 
         if not data:
-            if self.server.patroni.dcs.manual_failover(leader, candidate, scheduled_at=scheduled_at):
+            if self.server.patroni.dcs.manual_failover(leader, candidate, scheduled_at=scheduled_at, site=site):
                 self.server.patroni.ha.wakeup()
                 if scheduled_at:
                     data = action.title() + ' scheduled'

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -1261,7 +1261,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
             logger.warning('received failover request with leader specified - performing switchover instead')
             action = 'switchover'
 
-        if not data and leader and candidate and leader == candidate:
+        if not data and leader == candidate:
             data = 'Switchover target and source are the same'
 
         if not data and not scheduled_at:

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -29,7 +29,7 @@ import time
 from collections import defaultdict
 from contextlib import contextmanager
 from enum import Enum
-from typing import Any, Dict, Generator, Iterator, List, Optional, Tuple, TYPE_CHECKING, Union
+from typing import Any, cast, Dict, Generator, Iterator, List, Optional, Tuple, TYPE_CHECKING, Union
 from urllib.parse import urlparse
 
 import click
@@ -1252,8 +1252,8 @@ def reinit(cluster_name: str, group: Optional[int], member_names: List[str], for
                 wait_on_members.remove(member)
 
 
-def _do_failover_or_switchover(action: str, cluster_name: str, group: Optional[int], candidate: Optional[str],
-                               force: bool, switchover_leader: Optional[str] = None,
+def _do_failover_or_switchover(action: str, cluster_name: str, group: Optional[int], site: Optional[str],
+                               candidate: Optional[str], force: bool, switchover_leader: Optional[str] = None,
                                switchover_scheduled: Optional[str] = None) -> None:
     """Perform a failover or a switchover operation in the cluster.
 
@@ -1275,6 +1275,7 @@ def _do_failover_or_switchover(action: str, cluster_name: str, group: Optional[i
 
     :raises:
         :class:`PatroniCtlException`: if:
+            * both *candidate* and *site* are provided; or
             * Patroni is running on a Citus cluster, but no *group* was specified; or
             * a switchover was requested by the cluster has no leader; or
             * *switchover_leader* does not match the current leader of the cluster; or
@@ -1286,6 +1287,9 @@ def _do_failover_or_switchover(action: str, cluster_name: str, group: Optional[i
             * trying to schedule a switchover in a cluster that is in maintenance mode; or
             * user aborts the operation.
     """
+    if candidate is not None and site is not None:
+        raise PatroniCtlException('--candidate and --site are mutually exclusive options')
+
     dcs = get_dcs(cluster_name, group)
     cluster = dcs.get_cluster()
     click.echo('Current cluster topology')
@@ -1317,8 +1321,13 @@ def _do_failover_or_switchover(action: str, cluster_name: str, group: Optional[i
         if cluster_leader != switchover_leader:
             raise PatroniCtlException(f'Member {switchover_leader} is not the leader of cluster {cluster_name}')
 
+    site_names = set(m.site for m in cluster.members if m.site)
+    if site and site not in site_names:
+        raise PatroniCtlException(f'Site {site} does not exist in cluster {cluster_name}')
+
+    candidates = [m for m in cluster.members if m.site == site] if site else cluster.members
     # excluding members with nofailover tag
-    candidate_names = [str(m.name) for m in cluster.members if m.name != cluster_leader and not m.nofailover]
+    candidate_names = [str(m.name) for m in candidates if m.name != cluster_leader and not m.nofailover]
     # We sort the names for consistent output to the client
     candidate_names.sort()
 
@@ -1335,8 +1344,9 @@ def _do_failover_or_switchover(action: str, cluster_name: str, group: Optional[i
         if candidate == cluster_leader:
             raise PatroniCtlException(
                 f'Member {candidate} is already the leader of cluster {cluster_name}')
+        location = f'site {site} of cluster {cluster_name}' if site else f'cluster {cluster_name}'
         raise PatroniCtlException(
-            f'Member {candidate} does not exist in cluster {cluster_name} or is tagged as nofailover')
+            f'Member {candidate} does not exist in {location} or is tagged as nofailover')
 
     if all((not force,
             action == 'failover',
@@ -1366,12 +1376,20 @@ def _do_failover_or_switchover(action: str, cluster_name: str, group: Optional[i
         failover_value['leader'] = switchover_leader
     if scheduled_at_str:
         failover_value['scheduled_at'] = scheduled_at_str
+    if site and action != 'failover':
+        failover_value['site'] = site
 
     logging.debug(failover_value)
 
-    # By now we have established that the leader exists and the candidate exists
     if not force:
         demote_msg = f', demoting current leader {cluster_leader}' if cluster_leader else ''
+        current_site = cluster.status.current_site
+        if candidate:
+            candidate_site = cast(Member, cluster.get_member(candidate, False)).site
+            if current_site and candidate_site and current_site != candidate_site:
+                demote_msg += f' in site {current_site} and switching to site {candidate_site}'
+        elif site and current_site and site != current_site:
+            demote_msg += f' in site {current_site} and switching to site {site}'
         if scheduled_at_str:
             # only switchover can be scheduled
             if not click.confirm(f'Are you sure you want to schedule switchover of cluster '
@@ -1379,7 +1397,7 @@ def _do_failover_or_switchover(action: str, cluster_name: str, group: Optional[i
                 # action as a var to catch a regression in the tests
                 raise PatroniCtlException('Aborting scheduled ' + action)
         else:
-            if not click.confirm(f'Are you sure you want to {action} cluster {cluster_name}{demote_msg}?'):
+            if not click.confirm(f'Are you sure you want to perform {action} in cluster {cluster_name}{demote_msg}?'):
                 raise PatroniCtlException('Aborting ' + action)
 
     r = None
@@ -1407,7 +1425,7 @@ def _do_failover_or_switchover(action: str, cluster_name: str, group: Optional[i
         logging.exception(r)
         logging.warning('Failing over to DCS')
         click.echo('{0} Could not {1} using Patroni api, falling back to DCS'.format(timestamp(), action))
-        dcs.manual_failover(switchover_leader, candidate, scheduled_at=scheduled_at)
+        dcs.manual_failover(switchover_leader, candidate, site, scheduled_at=scheduled_at)
 
     output_members(cluster, cluster_name, group=group)
 
@@ -1415,9 +1433,11 @@ def _do_failover_or_switchover(action: str, cluster_name: str, group: Optional[i
 @ctl.command('failover', help='Failover to a replica')
 @arg_cluster_name
 @option_citus_group
+@option_site
 @click.option('--candidate', help='The name of the candidate', default=None)
 @option_force
-def failover(cluster_name: str, group: Optional[int], candidate: Optional[str], force: bool) -> None:
+def failover(cluster_name: str, group: Optional[int], site: Optional[str],
+             candidate: Optional[str], force: bool) -> None:
     """Process ``failover`` command of ``patronictl`` utility.
 
     Perform a failover operation immediately in the cluster.
@@ -1431,18 +1451,19 @@ def failover(cluster_name: str, group: Optional[int], candidate: Optional[str], 
     :param candidate: name of a standby member to be promoted. Nodes that are tagged with ``nofailover`` cannot be used.
     :param force: perform the failover or switchover without asking for confirmations.
     """
-    _do_failover_or_switchover('failover', cluster_name, group, candidate, force)
+    _do_failover_or_switchover('failover', cluster_name, group, site, candidate, force)
 
 
 @ctl.command('switchover', help='Switchover to a replica')
 @arg_cluster_name
 @option_citus_group
+@option_site
 @click.option('--leader', '--primary', 'leader', help='The name of the current leader', default=None)
 @click.option('--candidate', help='The name of the candidate', default=None)
 @click.option('--scheduled', help='Timestamp of a scheduled switchover in unambiguous format (e.g. ISO 8601)',
               default=None)
 @option_force
-def switchover(cluster_name: str, group: Optional[int], leader: Optional[str],
+def switchover(cluster_name: str, group: Optional[int], site: Optional[str], leader: Optional[str],
                candidate: Optional[str], force: bool, scheduled: Optional[str]) -> None:
     """Process ``switchover`` command of ``patronictl`` utility.
 
@@ -1460,7 +1481,7 @@ def switchover(cluster_name: str, group: Optional[int], leader: Optional[str],
     :param force: perform the switchover without asking for confirmations.
     :param scheduled: timestamp when the switchover should be scheduled to occur. If ``now`` perform immediately.
     """
-    _do_failover_or_switchover('switchover', cluster_name, group, candidate, force, leader, scheduled)
+    _do_failover_or_switchover('switchover', cluster_name, group, site, candidate, force, leader, scheduled)
 
 
 def generate_topology(level: int, member: Dict[str, Any],
@@ -1827,7 +1848,7 @@ def flush(cluster_name: str, group: Optional[int],
 
         logging.warning('Failing over to DCS')
         click.echo('{0} Could not find any accessible member of cluster {1}'.format(timestamp(), cluster_name))
-        dcs.manual_failover('', '', version=failover.version)
+        dcs.manual_failover('', '', '', version=failover.version)
 
 
 def wait_until_pause_is_applied(dcs: AbstractDCS, paused: bool, old_cluster: Cluster) -> None:

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -2040,12 +2040,12 @@ class AbstractDCS(ClusterSite, abc.ABC):
 
         if candidate:
             failover_value['member'] = candidate
+        elif site:
+            failover_value['site'] = site
 
         if scheduled_at:
             failover_value['scheduled_at'] = scheduled_at.isoformat()
 
-        if not candidate and site:
-            failover_value['site'] = site
         return self.set_failover_value(json.dumps(failover_value, separators=(',', ':')), version)
 
     @abc.abstractmethod

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -453,6 +453,7 @@ class Failover(NamedTuple):
     :ivar candidate: the name of the member node to be considered as a failover candidate.
     :ivar scheduled_at: in the case of a switchover the :class:`~datetime.datetime` object to perform the scheduled
         switchover.
+    :ivar site: the name of the site to perform a cross-site switchover to.
 
     :Example:
 
@@ -488,6 +489,7 @@ class Failover(NamedTuple):
     leader: Optional[str]
     candidate: Optional[str]
     scheduled_at: Optional[datetime.datetime]
+    site: Optional[str]
 
     @staticmethod
     def from_node(version: _Version, value: Union[str, Dict[str, str]]) -> 'Failover':
@@ -515,14 +517,14 @@ class Failover(NamedTuple):
                 t = [a.strip() for a in value.split(':')]
                 leader = t[0]
                 candidate = t[1] if len(t) > 1 else None
-                return Failover(version, leader, candidate, None)
+                return Failover(version, leader, candidate, None, None)
         else:
             data = {}
 
         if data.get('scheduled_at'):
             data['scheduled_at'] = dateutil.parser.parse(data['scheduled_at'])
 
-        return Failover(version, data.get('leader'), data.get('member'), data.get('scheduled_at'))
+        return Failover(version, data.get('leader'), data.get('member'), data.get('scheduled_at'), data.get('site'))
 
     def __len__(self) -> int:
         """Implement ``len`` function capability.
@@ -543,7 +545,7 @@ class Failover(NamedTuple):
            This makes it easier to write ``if cluster.failover`` rather than the longer statement.
 
         """
-        return int(bool(self.leader)) + int(bool(self.candidate))
+        return int(bool(self.leader)) + int(bool(self.candidate)) + int(bool(self.site))
 
 
 class ClusterConfig(NamedTuple):
@@ -979,8 +981,8 @@ class Cluster(NamedTuple('Cluster',
 
         :returns: a randomly selected candidate member from available running members that are configured to as viable
                  sources for cloning (has tag ``clonefrom`` in configuration). If no member is appropriate the current
-                 leader is used. If there is neither replica nor leader in the requested site, chose among all available
-                 members.
+                 leader is used. If there is neither replica nor leader in the requested site, choose among all
+                 available members.
         """
         exclude = [exclude_name] + ([self.leader.name] if self.leader else [])
 
@@ -2020,12 +2022,13 @@ class AbstractDCS(ClusterSite, abc.ABC):
         :returns: ``True`` if successfully committed to DCS.
         """
 
-    def manual_failover(self, leader: Optional[str], candidate: Optional[str],
+    def manual_failover(self, leader: Optional[str], candidate: Optional[str], site: Optional[str],
                         scheduled_at: Optional[datetime.datetime] = None, version: Optional[Any] = None) -> bool:
         """Prepare dictionary with given values and set ``/failover`` key in DCS.
 
         :param leader: value to set for ``leader``.
         :param candidate: value to set for ``member``.
+        :param site: value to set for ``site``.
         :param scheduled_at: value converted to ISO date format for ``scheduled_at``.
         :param version: for conditional update of the key/object.
 
@@ -2040,6 +2043,9 @@ class AbstractDCS(ClusterSite, abc.ABC):
 
         if scheduled_at:
             failover_value['scheduled_at'] = scheduled_at.isoformat()
+
+        if not candidate and site:
+            failover_value['site'] = site
         return self.set_failover_value(json.dumps(failover_value, separators=(',', ':')), version)
 
     @abc.abstractmethod

--- a/patroni/dcs/kubernetes.py
+++ b/patroni/dcs/kubernetes.py
@@ -1347,10 +1347,11 @@ class Kubernetes(AbstractDCS):
         """Unused"""
         raise NotImplementedError  # pragma: no cover
 
-    def manual_failover(self, leader: Optional[str], candidate: Optional[str],
-                        scheduled_at: Optional[datetime.datetime] = None, version: Optional[str] = None) -> bool:
+    def manual_failover(self, leader: Optional[str], candidate: Optional[str], site: Optional[str],
+                        scheduled_at: Optional[datetime.datetime] = None, version: Optional[str] = None
+                        ) -> bool:
         annotations = {'leader': leader or None, 'member': candidate or None,
-                       'scheduled_at': scheduled_at and scheduled_at.isoformat()}
+                       'scheduled_at': scheduled_at and scheduled_at.isoformat(), 'site': site or None}
         patch = bool(self.cluster and isinstance(self.cluster.failover, Failover) and self.cluster.failover.version)
         return bool(self.patch_or_create(self.failover_path, annotations, version, bool(version or patch), False))
 

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1447,11 +1447,23 @@ class Ha(object):
 
         action = self._get_failover_action_name()
         if self.cluster.failover and self.cluster.failover.site:
-            eligible_members = [st for st in eligible_members if st.data.get('site') == self.cluster.failover.site]
-            if eligible_members and self.patroni.site != self.cluster.failover.site:
+            target_site_eligible = [st for st in eligible_members if st.data.get('site') == self.cluster.failover.site]
+            if target_site_eligible and self.patroni.site != self.cluster.failover.site:
                 logger.info('%s to the requested site %s is possible, while my site is %s',
                             action.capitalize(), self.cluster.failover.site, self.patroni.site)
                 return False
+            elif self.patroni.site == self.cluster.failover.site:
+                eligible_members = target_site_eligible
+            elif current_site and current_site != self.cluster.failover.site:
+                # failover to a remote site requested, while no eligible members in the requested site
+                remote_sites_eligible = [st for st in eligible_members if st.data.get('site') != current_site]
+                if remote_sites_eligible and self.patroni.site == current_site:
+                    logger.info('%s to the requested site %s is not possible, I am in the last leader\'s site '
+                                '%s, prefer failover to a remote site',
+                                action, self.cluster.failover.site, self.patroni.site)
+                    return False
+                elif self.patroni.site != current_site:
+                    eligible_members = remote_sites_eligible
         elif current_site:
             current_site_eligible = [st for st in eligible_members if st.data.get('site') == current_site]
             if current_site_eligible and self.patroni.site != current_site:
@@ -1882,9 +1894,9 @@ class Ha(object):
     def process_unhealthy_cluster(self) -> str:
         """Cluster has no leader key"""
         # First, we want to handle primary_race_backoff. Do it only for non-standby cluster,
-        # not in maintenance mode and when there is no manual failover/switchover in progress.
+        # not in maintenance mode and when there is no manual failover/switchover to a candidate in progress.
         if not self.is_paused() and not self.is_standby_cluster() and \
-                not (self.cluster.failover and (self.cluster.failover.candidate or self.cluster.failover.site)) and \
+                not (self.cluster.failover and self.cluster.failover.candidate) and \
                 global_config.primary_race_backoff > 0 and self._prev_wal_lsn is not None:
             if self._primary_race_backoff_timestamp == 0:
                 self._primary_race_backoff_timestamp = time.time()
@@ -2638,13 +2650,14 @@ class Ha(object):
             if self.sync_mode_is_active() and not self.cluster.sync.matches(node.name)\
                     and not (failover and not failover.leader):
                 return False
-            # Don't spend time on "nofailover" nodes checking.
-            # We also don't need nodes which we can't query with the api in the list.
-            # And, if exclude_failover_candidate is True we want to skip  node.name == failover.candidate check.
-            return node.name not in exclude and not node.nofailover and bool(node.api_url) and \
-                (exclude_failover_candidate or not failover
-                 or not failover.candidate or node.name == failover.candidate)
+            if node.name in exclude:
+                return False
+            if node.nofailover or not bool(node.api_url):
+                return False
+            if not exclude_failover_candidate and failover and failover.candidate and node.name != failover.candidate:
+                return False
+            if filter_failover_site and failover and failover.site and node.site != failover.site:
+                return False
+            return True
 
-        members = [m for m in self.cluster.members if not failover or not failover.site
-                   or m.site == failover.site] if filter_failover_site else self.cluster.members
-        return list(filter(is_eligible, members))
+        return list(filter(is_eligible, self.cluster.members))

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1422,6 +1422,8 @@ class Ha(object):
         else:
             leader_name = leader and leader.name
 
+        current_site = self.cluster.status.current_site
+        eligible_members: List[_MemberStatus] = []
         for st in self.fetch_nodes_statuses(members):
             if st.failover_limitation() is None:
                 if st.in_recovery is False:
@@ -1437,24 +1439,45 @@ class Ha(object):
                     logger.info('Ignoring the former leader being ahead of us')
                 elif st.wal_position > 0:  # we want to count votes only from nodes with postgres up and running!
                     quorum_vote = st.member.name in voting_set
-                    low_priority = my_wal_position == st.wal_position \
-                        and self.patroni.failover_priority < st.failover_priority
-
-                    if low_priority and leader_name and leader_name == st.member.name:
-                        logger.info('Ignoring former leader %s having priority %s higher than this nodes %s priority',
-                                    leader_name, st.failover_priority, self.patroni.failover_priority)
-                        low_priority = False
-
-                    if low_priority and (not self.quorum_commit_mode_is_active() or quorum_vote):
-                        # There's a higher priority non-lagging replica
-                        logger.info(
-                            '%s has equally tolerable WAL position and priority %s, while this node has priority %s',
-                            st.member.name, st.failover_priority, self.patroni.failover_priority)
-                        return False
-
                     if quorum_vote:
                         logger.info('Got quorum vote from %s', st.member.name)
                         quorum_votes += 1
+                    if my_wal_position == st.wal_position:
+                        eligible_members.append(st)
+
+        action = self._get_failover_action_name()
+        if self.cluster.failover and self.cluster.failover.site:
+            eligible_members = [st for st in eligible_members if st.data.get('site') == self.cluster.failover.site]
+            if eligible_members and self.patroni.site != self.cluster.failover.site:
+                logger.info('%s to the requested site %s is possible, while my site is %s',
+                            action.capitalize(), self.cluster.failover.site, self.patroni.site)
+                return False
+        elif current_site:
+            current_site_eligible = [st for st in eligible_members if st.data.get('site') == current_site]
+            if current_site_eligible and self.patroni.site != current_site:
+                logger.info('Local %s in the current site %s is possible, while my site is %s',
+                            action, current_site, self.patroni.site)
+                return False
+            elif self.patroni.site == current_site:
+                eligible_members = current_site_eligible
+            else:
+                logger.info('No members in the curent site. Performing cross-site %s', action)
+
+        for st in eligible_members:
+            low_priority = my_wal_position == st.wal_position \
+                and self.patroni.failover_priority < st.failover_priority
+
+            if low_priority and leader_name and leader_name == st.member.name:
+                logger.info('Ignoring former leader %s having priority %s higher than this nodes %s priority',
+                            leader_name, st.failover_priority, self.patroni.failover_priority)
+                low_priority = False
+
+            if low_priority and (not self.quorum_commit_mode_is_active() or st.member.name in voting_set):
+                # There's a higher priority non-lagging replica
+                logger.info(
+                    '%s has equally tolerable WAL position and priority %s, while this node has priority %s',
+                    st.member.name, st.failover_priority, self.patroni.failover_priority)
+                return False
 
         # When not in quorum commit we just want to return `True`.
         # In quorum commit the former leader is special and counted healthy even when there are no other nodes.
@@ -1525,7 +1548,7 @@ class Ha(object):
                 if not self.cluster.get_member(failover.candidate, fallback_to_leader=False)\
                         and self.state_handler.is_primary():
                     logger.warning("%s: removing failover key because failover candidate is not running", action)
-                    self.dcs.manual_failover('', '', version=failover.version)
+                    self.dcs.manual_failover('', '', '', version=failover.version)
                     return None
                 return False
 
@@ -1827,7 +1850,7 @@ class Ha(object):
         # it is not the time for the scheduled switchover yet, do nothing
         if (failover.scheduled_at and not
             self.should_run_scheduled_action(bare_action, failover.scheduled_at, lambda:
-                                             self.dcs.manual_failover('', '', version=failover.version))):
+                                             self.dcs.manual_failover('', '', '', version=failover.version))):
             return
 
         if not failover.leader or failover.leader == self.state_handler.name:
@@ -1846,14 +1869,14 @@ class Ha(object):
             logger.warning('%s: leader name does not match: %s != %s', action, failover.leader, self.state_handler.name)
 
         logger.info('Cleaning up failover key')
-        self.dcs.manual_failover('', '', version=failover.version)
+        self.dcs.manual_failover('', '', '', version=failover.version)
 
     def process_unhealthy_cluster(self) -> str:
         """Cluster has no leader key"""
         # First, we want to handle primary_race_backoff. Do it only for non-standby cluster,
         # not in maintenance mode and when there is no manual failover/switchover in progress.
         if not self.is_paused() and not self.is_standby_cluster() and \
-                not (self.cluster.failover and self.cluster.failover.candidate) and \
+                not (self.cluster.failover and (self.cluster.failover.candidate or self.cluster.failover.site)) and \
                 global_config.primary_race_backoff > 0 and self._prev_wal_lsn is not None:
             if self._primary_race_backoff_timestamp == 0:
                 self._primary_race_backoff_timestamp = time.time()
@@ -1871,12 +1894,13 @@ class Ha(object):
             if self.acquire_lock():
                 failover = self.cluster.failover
                 if failover:
-                    if self.is_paused() and failover.leader and failover.candidate:
+                    if self.is_paused() and failover.leader and (failover.candidate or failover.site):
                         logger.info('Updating failover key after acquiring leader lock...')
-                        self.dcs.manual_failover('', failover.candidate, failover.scheduled_at, failover.version)
+                        self.dcs.manual_failover('', failover.candidate, failover.site, failover.scheduled_at,
+                                                 failover.version)
                     else:
                         logger.info('Cleaning up failover key after acquiring leader lock...')
-                        self.dcs.manual_failover('', '')
+                        self.dcs.manual_failover('', '', '')
                 self.load_cluster_from_dcs()
 
                 if self.is_standby_cluster():

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1485,15 +1485,17 @@ class Ha(object):
         return not self.quorum_commit_mode_is_active() or quorum_votes >= quorum\
             or nodes_ahead == 0 and self.cluster.sync.leader == self.state_handler.name
 
-    def is_failover_possible(self, *, cluster_lsn: int = 0, exclude_failover_candidate: bool = False) -> bool:
+    def is_failover_possible(self, *, cluster_lsn: int = 0,
+                             exclude_failover_candidate: bool = False, filter_failover_site: bool = False) -> bool:
         """Checks whether any of the cluster members is allowed to promote and is healthy enough for that.
 
         :param cluster_lsn: to calculate replication lag and exclude member if it is lagging.
         :param exclude_failover_candidate: if ``True``, exclude :attr:`failover.candidate` from the members
                                            list against which the failover possibility checks are run.
+        :param filter_failover_site: if ``True``, only consider members that are located in the :attr:`failover.site`.
         :returns: `True` if there are members eligible to become the new leader.
         """
-        candidates = self.get_failover_candidates(exclude_failover_candidate)
+        candidates = self.get_failover_candidates(exclude_failover_candidate, filter_failover_site)
 
         action = self._get_failover_action_name()
         if self.is_synchronous_mode() and self.cluster.failover and self.cluster.failover.candidate and not candidates:
@@ -1554,7 +1556,7 @@ class Ha(object):
 
             # in synchronous mode (except quorum commit!) when our name is not in the
             # /sync key we shouldn't take any action even if the candidate is unhealthy
-            if self.is_synchronous_mode() and not self.is_quorum_commit_mode()\
+            if self.sync_mode_is_active() and not self.is_quorum_commit_mode()\
                     and not self.cluster.sync.matches(self.state_handler.name, True):
                 return False
 
@@ -1573,6 +1575,12 @@ class Ha(object):
             # i.e. we assume that failover.candidate is None
         elif self.is_paused():
             return False
+        elif failover.site:
+            # in synchronous mode (except quorum commit!) when our name is not in the
+            # /sync key we shouldn't take any action even if the candidate is unhealthy
+            if self.sync_mode_is_active() and not self.is_quorum_commit_mode()\
+                    and not self.cluster.sync.matches(self.state_handler.name, True):
+                return False
 
         # try to pick some other members for switchover and check that they are healthy
         if failover.leader:
@@ -1857,7 +1865,7 @@ class Ha(object):
             if not failover.candidate or failover.candidate != self.state_handler.name:
                 if not failover.candidate and self.is_paused():
                     logger.warning('%s is possible only to a specific candidate in a paused state', action.title())
-                elif self.is_failover_possible():
+                elif self.is_failover_possible(filter_failover_site=True):
                     ret = self._async_executor.try_run_async(f'{action}: demote', self.demote, ('graceful',))
                     return ret or f'{action}: demoting myself'
                 else:
@@ -1894,7 +1902,7 @@ class Ha(object):
             if self.acquire_lock():
                 failover = self.cluster.failover
                 if failover:
-                    if self.is_paused() and failover.leader and (failover.candidate or failover.site):
+                    if self.is_paused() and failover.leader and failover.candidate:
                         logger.info('Updating failover key after acquiring leader lock...')
                         self.dcs.manual_failover('', failover.candidate, failover.site, failover.scheduled_at,
                                                  failover.version)
@@ -2607,7 +2615,8 @@ class Ha(object):
         name = member.name if member else 'remote_member:{}'.format(uuid.uuid1())
         return RemoteMember(name, data)
 
-    def get_failover_candidates(self, exclude_failover_candidate: bool) -> List[Member]:
+    def get_failover_candidates(self,
+                                exclude_failover_candidate: bool, filter_failover_site: bool = False) -> List[Member]:
         """Return a list of candidates for either manual or automatic failover.
 
         Exclude non-sync members when in synchronous mode, the current node (its checks are always performed earlier)
@@ -2617,6 +2626,7 @@ class Ha(object):
         healthy enough and is allowed to poromote.
 
         :param exclude_failover_candidate: if ``True``, exclude :attr:`failover.candidate` from the candidates.
+        :param filter_failover_site: if ``True``, only consider members that are located in the :attr:`failover.site`.
 
         :returns: a list of :class:`Member` objects or an empty list if there is no candidate available.
         """
@@ -2635,4 +2645,6 @@ class Ha(object):
                 (exclude_failover_candidate or not failover
                  or not failover.candidate or node.name == failover.candidate)
 
-        return list(filter(is_eligible, self.cluster.members))
+        members = [m for m in self.cluster.members if not failover or not failover.site
+                   or m.site == failover.site] if filter_failover_site else self.cluster.members
+        return list(filter(is_eligible, members))

--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -1002,6 +1002,8 @@ def cluster_as_json(cluster: 'Cluster') -> Dict[str, Any]:
             ret['scheduled_switchover']['from'] = cluster.failover.leader
         if cluster.failover.candidate:
             ret['scheduled_switchover']['to'] = cluster.failover.candidate
+        elif cluster.failover.site:
+            ret['scheduled_switchover']['to'] = 'site ' + cluster.failover.site
     return ret
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -728,6 +728,28 @@ class TestRestApiHandler(unittest.TestCase):
             response_mock.assert_called_with(
                 422, 'Unable to parse scheduled timestamp. It should be in an unambiguous format, e.g. ISO 8601')
 
+        # [Multi-site switchover]
+
+        # site and candidate
+        request = post + '114\n\n{"leader": "postgresql1", "candidate": "postgresql2", "site": "dc1"}'
+        with patch.object(RestApiHandler, 'write_response') as response_mock:
+            MockRestApiServer(RestApiHandler, request)
+            dcs.manual_failover.assert_called_with('postgresql1', 'postgresql2', scheduled_at=None, site=None)
+
+        # no members in site
+        request = post + '53\n\n{"leader": "postgresql1", "site": "dc1"}'
+        with patch.object(RestApiHandler, 'write_response') as response_mock:
+            MockRestApiServer(RestApiHandler, request)
+            response_mock.assert_called_with(412, 'switchover is not possible: can not find members in site dc1')
+
+            cluster.members = [Member(0, 'postgresql0', 30, {'api_url': 'http', 'site': 'dc1'}),
+                               Member(0, 'postgresql2', 30, {'api_url': 'http'})]
+            cluster2.leader.name = 'postgresql0'
+            dcs.get_cluster.side_effect = [cluster, cluster2]
+            dcs.manual_failover.return_value = True
+            MockRestApiServer(RestApiHandler, request)
+            response_mock.assert_called_with(200, 'Successfully switched over to "postgresql0"')
+
     def test_do_POST_failover(self):
         post = 'POST /failover HTTP/1.0' + self._authorization + '\nContent-Length: '
 

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -128,7 +128,7 @@ class TestCtl(unittest.TestCase):
         with click.Context(click.Command('list')) as ctx:
             ctx.obj = {'__config': {}, '__mpp': get_mpp({})}
             scheduled_at = datetime.now(tzutc) + timedelta(seconds=600)
-            cluster = get_cluster_initialized_with_leader(Failover(1, 'foo', 'bar', scheduled_at))
+            cluster = get_cluster_initialized_with_leader(Failover(1, 'foo', 'bar', scheduled_at, None))
             del cluster.members[1].data['conn_url']
             cluster.members[1].data['replication_state'] = 'streaming'
             cluster.members[1].data['xlog_location'] = 3
@@ -149,6 +149,11 @@ class TestCtl(unittest.TestCase):
                 mock_echo.reset_mock()
                 self.assertIsNone(output_members(cluster, name='abc', site='foo', fmt='tsv'))
                 self.assertEqual(len(mock_echo.call_args_list), 1)
+
+                mock_echo.reset_mock()
+                cluster = get_cluster_initialized_with_leader(Failover(1, 'foo', None, scheduled_at, 'dc2'))
+                self.assertIsNone(output_members(cluster, name='abc'))
+                self.assertIn('to: site dc2', mock_echo.call_args_list[1][0][0])
 
     @patch('patroni.dcs.AbstractDCS.set_failover_value', Mock())
     def test_switchover(self):
@@ -215,8 +220,8 @@ class TestCtl(unittest.TestCase):
 
         # Errors while sending Patroni REST API request
         with patch('patroni.ctl.request_patroni', Mock(side_effect=Exception)):
-            result = self.runner.invoke(ctl, ['switchover', 'dummy', '--group', '0'],
-                                        input='leader\nother\n2300-01-01T12:23:00\ny')
+            result = self.runner.invoke(ctl, ['switchover', 'dummy', '--group', '0', '--site', 'dc1'],
+                                        input='leader\n\n2300-01-01T12:23:00\ny')
             self.assertIn('falling back to DCS', result.output)
 
         with patch('patroni.ctl.request_patroni') as mock_api_request:
@@ -253,11 +258,41 @@ class TestCtl(unittest.TestCase):
         self.assertEqual(result.exit_code, 1)
         self.assertIn('For Citus clusters the --group must me specified', result.output)
 
+        # --candidate + --site
+        result = self.runner.invoke(ctl, ['switchover', 'dummy',
+                                          '--candidate', 'other', '--site', 'site', '--group', '0'], input='\n')
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn('--candidate and --site are mutually exclusive options', result.output)
+
+        # does not exist
+        result = self.runner.invoke(ctl, ['switchover', 'dummy', '--site', 'site', '--group', '0'], input='\n')
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn('Site site does not exist in cluster dummy', result.output)
+
+        # cross-site
+        cluster = get_cluster_initialized_with_leader()
+        cluster.members[1].data['site'] = 'dc2'
+        with patch('patroni.dcs.AbstractDCS.get_cluster', Mock(return_value=cluster)):
+            result = self.runner.invoke(ctl, ['switchover', 'dummy', '--group', '0', '--site', 'dc2'],
+                                        input='leader\nother\n\ny')
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn('demoting current leader leader in site dc1 and switching to site dc2', result.output)
+
+            result = self.runner.invoke(ctl, ['switchover', 'dummy', '--group', '0', '--site', 'dc2'],
+                                        input='leader\n\n\ny')
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn('demoting current leader leader in site dc1 and switching to site dc2', result.output)
+
     @patch('patroni.dcs.AbstractDCS.set_failover_value', Mock())
     def test_failover(self):
         # No candidate specified
         result = self.runner.invoke(ctl, ['failover', 'dummy'], input='0\n\n')
         self.assertIn('Failover could be performed only to a specific candidate', result.output)
+
+        # Site specified
+        with patch('patroni.ctl.request_patroni') as mock_request:
+            result = self.runner.invoke(ctl, ['failover', 'dummy', '--site', 'dc1', '--group', '0'], input='other\ny')
+            self.assertNotIn('site', mock_request.call_args_list[0][0][3])
 
         # Candidate is the same as the leader
         result = self.runner.invoke(ctl, ['failover', 'dummy', '--group', '0'], input='leader\n')
@@ -592,7 +627,7 @@ class TestCtl(unittest.TestCase):
 
         scheduled_at = datetime.now(tzutc) + timedelta(seconds=600)
         with patch('patroni.dcs.AbstractDCS.get_cluster',
-                   Mock(return_value=get_cluster_initialized_with_leader(Failover(1, 'a', 'b', scheduled_at)))):
+                   Mock(return_value=get_cluster_initialized_with_leader(Failover(1, 'a', 'b', scheduled_at, None)))):
             result = self.runner.invoke(ctl, ['-k', 'flush', 'dummy', 'switchover'])
             assert result.output.startswith('Success: ')
 

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -888,6 +888,7 @@ class TestHa(PostgresInit):
 
         # other members with failover_limitation_s
         with patch('patroni.ha.logger.info') as mock_info:
+            self.ha.cluster.members[0].data['api_url'] = None  # to test is_eligible
             self.ha.fetch_node_status = get_node_status(nofailover=True)
             self.assertEqual(self.ha.run_cycle(), 'no action. I am (postgresql0), the leader with the lock')
             self.assertEqual(mock_info.call_args_list[0][0][0::2], ('Member %s is %s', 'not allowed to promote'))
@@ -1281,9 +1282,23 @@ class TestHa(PostgresInit):
                              ('Local %s in the current site %s is possible, while my site is %s',
                               'failover', 'dc1', 'dc2'))
             # manual switchover to a site
+            # to my site
             mock_info.reset_mock()
             self.ha.fetch_node_status = get_node_status(wal_position=12, site='dc2')
             self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, 'leader', None, None, 'dc2'))
+            self.assertTrue(self.ha._is_healthiest_node(self.ha.old_cluster.members))
+            # to a remote site with no eligible members, while I am in another remote site
+            self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, 'leader', None, None, 'dc3'))
+            self.assertTrue(self.ha._is_healthiest_node(self.ha.old_cluster.members))
+            # to a remote site, while I am in the last leader's site
+            self.ha.patroni.site = 'dc1'
+            self.assertFalse(self.ha._is_healthiest_node(self.ha.old_cluster.members))
+            self.assertEqual(mock_info.call_args_list[0][0],
+                             ('%s to the requested site %s is not possible, I am in the last leader\'s site '
+                              '%s, prefer failover to a remote site', 'switchover', 'dc3', 'dc1'))
+            # to the last leader's site with no eligible members, while I am in a remote site
+            self.ha.patroni.site = 'dc2'
+            self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, 'leader', None, None, 'dc1'))
             self.assertTrue(self.ha._is_healthiest_node(self.ha.old_cluster.members))
 
     def test_fetch_node_status(self):

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -47,8 +47,8 @@ def get_cluster(initialize, leader, members, failover, sync, cluster_config=None
     history = TimelineHistory(1, '[[1,67197376,"no recovery target specified","' + t + '","foo"]]',
                               [(1, 67197376, 'no recovery target specified', t, 'foo')])
     cluster_config = cluster_config or ClusterConfig(1, {'check_timeline': True, 'member_slots_ttl': 0}, 1)
-    return Cluster(initialize, cluster_config, leader, Status(10, None, [], None),
-                   members, failover, sync, history, failsafe)
+    return Cluster(initialize, cluster_config, leader,
+                   Status(10, None, [], 'dc1'), members, failover, sync, history, failsafe)
 
 
 def get_cluster_not_initialized_without_leader(cluster_config=None):
@@ -111,7 +111,8 @@ def _check_timeline_and_lsn(self, *args):
 
 def get_node_status(reachable=True, in_recovery=True, dcs_last_seen=0,
                     timeline=2, wal_position=10, nofailover=False,
-                    watchdog_failed=False, failover_priority=1, sync_priority=1):
+                    watchdog_failed=False, failover_priority=1, sync_priority=1,
+                    site='dc1'):
     def fetch_node_status(e):
         tags = {}
         if nofailover:
@@ -120,7 +121,7 @@ def get_node_status(reachable=True, in_recovery=True, dcs_last_seen=0,
         tags['sync_priority'] = sync_priority
         return _MemberStatus(e, reachable, in_recovery, wal_position,
                              {'tags': tags, 'watchdog_failed': watchdog_failed,
-                              'dcs_last_seen': dcs_last_seen, 'timeline': timeline})
+                              'dcs_last_seen': dcs_last_seen, 'timeline': timeline, 'site': site})
     return fetch_node_status
 
 
@@ -673,7 +674,7 @@ class TestHa(PostgresInit):
         self.ha.cluster.members.pop(2)
         self.assertEqual(self.ha.bootstrap(), "trying to bootstrap from replica 'yetanother'")
 
-        # I do not have site, chose replica with site specified instead of leader with no site
+        # I do not have site, choose replica with site specified instead of leader with no site
         self.ha.patroni.site = None
         self.ha.cluster.members[2].data['site'] = None
         self.assertEqual(self.ha.bootstrap(), "trying to bootstrap from replica 'yetanother'")
@@ -824,20 +825,20 @@ class TestHa(PostgresInit):
 
         # to me
         with patch('patroni.ha.logger.warning') as mock_warning:
-            self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, '', self.p.name, None))
+            self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, '', self.p.name, None, None))
             self.assertEqual(self.ha.run_cycle(), 'no action. I am (postgresql0), the leader with the lock')
             mock_warning.assert_called_with('%s: I am already the leader, no need to %s', 'manual failover', 'failover')
 
         # to a non-existent candidate
         with patch('patroni.ha.logger.warning') as mock_warning:
-            self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, '', 'blabla', None))
+            self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, '', 'blabla', None, None))
             self.assertEqual(self.ha.run_cycle(), 'no action. I am (postgresql0), the leader with the lock')
             mock_warning.assert_called_with(
                 '%s: no healthy members found, %s is not possible', 'manual failover', 'failover')
 
         # to an existent candidate
         self.ha.fetch_node_status = get_node_status()
-        self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, '', 'b', None))
+        self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, '', 'b', None, None))
         self.ha.cluster.members.append(Member(0, 'b', 28, {'api_url': 'http://127.0.0.1:8011/patroni'}))
         self.assertEqual(self.ha.run_cycle(), 'manual failover: demoting myself')
 
@@ -865,13 +866,13 @@ class TestHa(PostgresInit):
 
         # different leader specified in failover key, no candidate
         with patch('patroni.ha.logger.warning') as mock_warning:
-            self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, 'blabla', '', None))
+            self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, 'blabla', '', None, None))
             self.assertEqual(self.ha.run_cycle(), 'no action. I am (postgresql0), the leader with the lock')
             mock_warning.assert_called_with(
                 '%s: leader name does not match: %s != %s', 'switchover', 'blabla', 'postgresql0')
 
         # no candidate
-        self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, self.p.name, '', None))
+        self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, self.p.name, '', None, None))
         self.assertEqual(self.ha.run_cycle(), 'switchover: demoting myself')
 
         self.ha._rewind.rewind_or_reinitialize_needed_and_possible = true
@@ -907,27 +908,27 @@ class TestHa(PostgresInit):
         # switchover scheduled time must include timezone
         with patch('patroni.ha.logger.warning') as mock_warning:
             scheduled = datetime.datetime.now()
-            self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, self.p.name, 'blabla', scheduled))
+            self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, self.p.name, 'blabla', scheduled, None))
             self.assertEqual(self.ha.run_cycle(), 'no action. I am (postgresql0), the leader with the lock')
             self.assertIn('Incorrect value of scheduled_at: %s', mock_warning.call_args_list[0][0])
 
         # scheduled now
         scheduled = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=tzutc)
-        self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, self.p.name, 'b', scheduled))
+        self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, self.p.name, 'b', scheduled, None))
         self.ha.cluster.members.append(Member(0, 'b', 28, {'api_url': 'http://127.0.0.1:8011/patroni'}))
         self.assertEqual('switchover: demoting myself', self.ha.run_cycle())
 
         # scheduled in the future
         with patch('patroni.ha.logger.info') as mock_info:
             scheduled = scheduled + datetime.timedelta(seconds=30)
-            self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, self.p.name, 'blabla', scheduled))
+            self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, self.p.name, 'blabla', scheduled, None))
             self.assertEqual('no action. I am (postgresql0), the leader with the lock', self.ha.run_cycle())
             self.assertIn('Awaiting %s at %s (in %.0f seconds)', mock_info.call_args_list[0][0])
 
         # stale value
         with patch('patroni.ha.logger.warning') as mock_warning:
             scheduled = scheduled + datetime.timedelta(seconds=-600)
-            self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, self.p.name, 'b', scheduled))
+            self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, self.p.name, 'b', scheduled, None))
             self.ha.cluster.members.append(Member(0, 'b', 28, {'api_url': 'http://127.0.0.1:8011/patroni'}))
             self.assertEqual('no action. I am (postgresql0), the leader with the lock', self.ha.run_cycle())
             self.assertIn('Found a stale %s value, cleaning up: %s', mock_warning.call_args_list[0][0])
@@ -937,7 +938,7 @@ class TestHa(PostgresInit):
         self.ha.is_paused = true
 
         # no candidate
-        self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, self.p.name, '', None))
+        self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, self.p.name, '', None, None))
         with patch('patroni.ha.logger.warning') as mock_warning:
             self.assertEqual('PAUSE: no action. I am (postgresql0), the leader with the lock', self.ha.run_cycle())
             mock_warning.assert_called_with(
@@ -949,7 +950,7 @@ class TestHa(PostgresInit):
         self.ha.is_paused = true
 
         # failover from me, candidate is healthy
-        self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, None, 'b', None))
+        self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, None, 'b', None, None))
         self.ha.cluster.members.append(Member(0, 'b', 28, {'api_url': 'http://127.0.0.1:8011/patroni'}))
         self.assertEqual('PAUSE: manual failover: demoting myself', self.ha.run_cycle())
         self.ha.cluster.members.pop()
@@ -964,7 +965,8 @@ class TestHa(PostgresInit):
         self.ha.has_lock = true
 
         # the candidate is not in sync members but we allow failover to an async candidate
-        self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, None, 'b', None), sync=(self.p.name, 'a'))
+        self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, None, 'b', None, None),
+                                                              sync=(self.p.name, 'a'))
         self.ha.cluster.members.append(Member(0, 'b', 28, {'api_url': 'http://127.0.0.1:8011/patroni'}))
         self.assertEqual('manual failover: demoting myself', self.ha.run_cycle())
         self.ha.cluster.members.pop()
@@ -979,7 +981,7 @@ class TestHa(PostgresInit):
 
         # candidate specified is not in sync members
         with patch('patroni.ha.logger.warning') as mock_warning:
-            self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, self.p.name, 'a', None),
+            self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, self.p.name, 'a', None, None),
                                                                   sync=(self.p.name, 'blabla'))
             self.assertEqual('no action. I am (postgresql0), the leader with the lock', self.ha.run_cycle())
             self.assertEqual(mock_warning.call_args_list[0][0],
@@ -987,7 +989,7 @@ class TestHa(PostgresInit):
 
         # the candidate is in sync members and is healthy
         self.ha.fetch_node_status = get_node_status(wal_position=305419896)
-        self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, self.p.name, 'a', None),
+        self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, self.p.name, 'a', None, None),
                                                               sync=(self.p.name, 'a'))
         self.ha.cluster.members.append(Member(0, 'a', 28, {'api_url': 'http://127.0.0.1:8011/patroni'}))
         self.assertEqual('switchover: demoting myself', self.ha.run_cycle())
@@ -1004,7 +1006,7 @@ class TestHa(PostgresInit):
 
         # failover to another member, fetch_node_status for candidate fails
         with patch('patroni.ha.logger.warning') as mock_warning:
-            self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, '', 'leader', None))
+            self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, '', 'leader', None, None))
             self.assertEqual(self.ha.run_cycle(), 'promoted self to leader by acquiring session lock')
             self.assertEqual(mock_warning.call_args_list[1][0],
                              ('%s: member %s is %s', 'manual failover', 'leader', 'not reachable'))
@@ -1016,13 +1018,13 @@ class TestHa(PostgresInit):
 
         # set nofailover flag to True for all members of the cluster
         # this should elect the current member, as we are not going to call the API for it.
-        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, '', 'other', None))
+        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, '', 'other', None, None))
         self.ha.fetch_node_status = get_node_status(nofailover=True)
         self.assertEqual(self.ha.run_cycle(), 'promoted self to leader by acquiring session lock')
 
         # failover to me but I am set to nofailover. In no case I should be elected as a leader
         self.p.set_role(PostgresqlRole.REPLICA)
-        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, '', 'postgresql0', None))
+        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, '', 'postgresql0', None, None))
         self.ha.patroni.nofailover = True
         self.assertEqual(self.ha.run_cycle(), 'following a different leader because I am not allowed to promote')
 
@@ -1030,7 +1032,7 @@ class TestHa(PostgresInit):
 
         # failover to another member that is on an older timeline (only failover_limitation() is checked)
         with patch('patroni.ha.logger.info') as mock_info:
-            self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, '', 'b', None))
+            self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, '', 'b', None, None))
             self.ha.cluster.members.append(Member(0, 'b', 28, {'api_url': 'http://127.0.0.1:8011/patroni'}))
             self.ha.fetch_node_status = get_node_status(timeline=1)
             self.assertEqual(self.ha.run_cycle(), 'following a different leader because i am not the healthiest node')
@@ -1049,7 +1051,7 @@ class TestHa(PostgresInit):
 
         # I was the leader, other members are healthy
         self.ha.fetch_node_status = get_node_status()
-        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, self.p.name, '', None))
+        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, self.p.name, '', None, None))
         self.assertEqual(self.ha.run_cycle(), 'following a different leader because i am not the healthiest node')
 
         # I was the leader, I am the only healthy member
@@ -1058,20 +1060,42 @@ class TestHa(PostgresInit):
             self.assertEqual(self.ha.run_cycle(), 'promoted self to leader by acquiring session lock')
             self.assertEqual(mock_info.call_args_list[0][0][0::2], ('Member %s is %s', 'not reachable'))
 
+        # same but with no members in target failover site
+        with patch('patroni.ha.logger.info') as mock_info:
+            self.ha.fetch_node_status = get_node_status(reachable=False)
+            self.p.set_role(PostgresqlRole.REPLICA)
+            self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, self.p.name, '', None, 'dc2'))
+            self.assertEqual(self.ha.run_cycle(), 'promoted self to leader by acquiring session lock')
+
+        # switchover to a different site
+        with patch('patroni.ha.logger.info') as mock_info:
+            self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, 'leader', None, None, 'dc2'))
+            self.ha.cluster.members[1].data['site'] = 'dc2'
+            self.ha.fetch_node_status = get_node_status(site='dc2')
+            self.p.set_role(PostgresqlRole.REPLICA)
+            self.assertEqual(self.ha.run_cycle(), 'following a different leader because i am not the healthiest node')
+            mock_info.assert_called_with('%s to the requested site %s is possible, while my site is %s',
+                                         'Switchover', 'dc2', 'dc1')
+
+        # switchover to my site
+        with patch('patroni.ha.logger.info') as mock_info:
+            self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, 'leader', None, None, 'dc1'))
+            self.assertEqual(self.ha.run_cycle(), 'promoted self to leader by acquiring session lock')
+
     def test_manual_failover_process_no_leader_in_synchronous_mode(self):
         self.ha.is_synchronous_mode = true
         self.p.is_primary = false
         self.ha.fetch_node_status = get_node_status(nofailover=True)  # other nodes are not healthy
 
         # manual failover when our name (postgresql0) isn't in the /sync key and the candidate node is not available
-        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, '', 'other', None),
+        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, '', 'other', None, None),
                                                                  sync=('leader1', 'blabla'))
         self.assertEqual(self.ha.run_cycle(), 'following a different leader because i am not the healthiest node')
 
         # manual failover when the candidate node isn't available but our name is in the /sync key
         # while other sync node is nofailover
         with patch('patroni.ha.logger.warning') as mock_warning:
-            self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, '', 'other', None),
+            self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, '', 'other', None, None),
                                                                      sync=('leader1', 'postgresql0'))
             self.ha.dcs.write_sync_state = Mock(return_value=SyncState.empty())
             self.assertEqual(self.ha.run_cycle(), 'promoted self to leader by acquiring session lock')
@@ -1081,7 +1105,7 @@ class TestHa(PostgresInit):
         # manual failover to our node (postgresql0),
         # which name is not in sync nodes list (some sync nodes are available)
         self.p.set_role(PostgresqlRole.REPLICA)
-        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, '', 'postgresql0', None),
+        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, '', 'postgresql0', None, None),
                                                                  sync=('leader1', 'other'))
         self.assertEqual(self.ha.run_cycle(), 'promoted self to leader by acquiring session lock')
 
@@ -1090,21 +1114,29 @@ class TestHa(PostgresInit):
         self.p.is_primary = false
 
         # to a specific node, which name doesn't match our name (postgresql0)
-        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, 'leader', 'other', None))
+        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, 'leader', 'other', None, None),
+                                                                 sync=('leader1', 'blabla'))
+        self.assertEqual(self.ha.run_cycle(), 'following a different leader because i am not the healthiest node')
+
+        # to my site, but my name is not in sync nodes list
+        self.ha.patroni.nofailover = False
+        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, 'leader', None, None, 'dc1'),
+                                                                 sync=('leader1', 'blabla'))
         self.assertEqual(self.ha.run_cycle(), 'following a different leader because i am not the healthiest node')
 
         # to our node (postgresql0), which name is not in sync nodes list
-        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, 'leader', 'postgresql0', None),
+        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, 'leader', 'postgresql0',
+                                                                                   None, None),
                                                                  sync=('leader1', 'blabla'))
         self.assertEqual(self.ha.run_cycle(), 'following a different leader because i am not the healthiest node')
 
         # without candidate, our name (postgresql0) is not in the sync nodes list
-        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, 'leader', '', None),
+        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, 'leader', '', None, None),
                                                                  sync=('leader', 'blabla'))
         self.assertEqual(self.ha.run_cycle(), 'following a different leader because i am not the healthiest node')
 
         # switchover from a specific leader, but the only sync node (us, postgresql0) has nofailover tag
-        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, 'leader', '', None),
+        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, 'leader', '', None, None),
                                                                  sync=('postgresql0', None))
         self.ha.patroni.nofailover = True
         self.assertEqual(self.ha.run_cycle(), 'following a different leader because I am not allowed to promote')
@@ -1114,19 +1146,20 @@ class TestHa(PostgresInit):
 
         # I am running as primary, cluster is unlocked, the candidate is allowed to promote
         # but we are in pause
-        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, '', 'other', None))
+        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, '', 'other', None, None))
         self.assertEqual(self.ha.run_cycle(), 'PAUSE: continue to run as primary without lock')
 
     def test_manual_switchover_process_no_leader_in_pause(self):
         self.ha.is_paused = true
 
         # I am running as primary, cluster is unlocked, no candidate specified
-        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, 'leader', '', None))
+        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, 'leader', '', None, None))
         self.assertEqual(self.ha.run_cycle(), 'PAUSE: continue to run as primary without lock')
 
         # the candidate is not running
         with patch('patroni.ha.logger.warning') as mock_warning:
-            self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, 'leader', 'blabla', None))
+            self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, 'leader', 'blabla',
+                                                                                       None, None))
             self.assertEqual('PAUSE: acquired session lock as a leader', self.ha.run_cycle())
             self.assertEqual(
                 mock_warning.call_args_list[0][0],
@@ -1135,8 +1168,16 @@ class TestHa(PostgresInit):
         # switchover to me, I am not leader
         self.p.is_primary = false
         self.p.set_role(PostgresqlRole.REPLICA)
-        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, 'leader', self.p.name, None))
+        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, 'leader', self.p.name,
+                                                                                   None, None))
         self.assertEqual(self.ha.run_cycle(), 'PAUSE: promoted self to leader by acquiring session lock')
+
+        # to my site
+        self.p.is_primary = false
+        self.p.set_role(PostgresqlRole.REPLICA)
+        self.ha.patroni.site = 'dc2'
+        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, 'leader', None, None, 'dc2'))
+        self.assertEqual(self.ha.run_cycle(), 'PAUSE: no action. I am (postgresql0)')
 
     def test_is_healthiest_node(self):
         self.ha.is_failsafe_mode = true
@@ -1200,6 +1241,38 @@ class TestHa(PostgresInit):
         self.ha.patroni.nofailover = None
         self.ha.patroni.failover_priority = 0
         self.assertFalse(self.ha._is_healthiest_node(self.ha.old_cluster.members))
+        # multisite
+        with patch('patroni.ha.logger.info') as mock_info, \
+             patch('patroni.postgresql.Postgresql.last_operation', return_value=12):
+            # local failover to my site (other node is nofailover)
+            self.ha.fetch_node_status = get_node_status(wal_position=12, nofailover=True)
+            self.assertTrue(self.ha._is_healthiest_node(self.ha.old_cluster.members))
+            mock_info.reset_mock()
+
+            self.ha.patroni.site = 'dc2'
+            # no eligible local memebers (local node is nofailover)
+            self.assertTrue(self.ha._is_healthiest_node(self.ha.old_cluster.members))
+            self.assertEqual(mock_info.call_args_list[0][0],
+                             ('No members in the curent site. Performing cross-site %s', 'failover'))
+            mock_info.reset_mock()
+            # local node is behind some remote node (me), lag is tolerable
+            self.ha.fetch_node_status = get_node_status(wal_position=10)
+            self.assertTrue(self.ha._is_healthiest_node(self.ha.old_cluster.members))
+            self.assertEqual(mock_info.call_args_list[0][0],
+                             ('No members in the curent site. Performing cross-site %s', 'failover'))
+            mock_info.reset_mock()
+            # local failover possible (although my failover priority is higher)
+            self.ha.patroni.failover_priority = 2
+            self.ha.fetch_node_status = get_node_status(wal_position=12, failover_priority=1)
+            self.assertFalse(self.ha._is_healthiest_node(self.ha.old_cluster.members))
+            self.assertEqual(mock_info.call_args_list[0][0],
+                             ('Local %s in the current site %s is possible, while my site is %s',
+                              'failover', 'dc1', 'dc2'))
+            # manual switchover to a site
+            mock_info.reset_mock()
+            self.ha.fetch_node_status = get_node_status(wal_position=12, site='dc2')
+            self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, 'leader', None, None, 'dc2'))
+            self.assertTrue(self.ha._is_healthiest_node(self.ha.old_cluster.members))
 
     def test_fetch_node_status(self):
         member = Member(0, 'test', 1, {'api_url': 'http://127.0.0.1:8011/patroni'})
@@ -1283,7 +1356,7 @@ class TestHa(PostgresInit):
         self.p.name = 'leader'
         self.ha.cluster = get_cluster_initialized_with_leader()
         self.assertEqual(self.ha.run_cycle(), 'PAUSE: removed leader lock because postgres is not running as primary')
-        self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, '', self.p.name, None))
+        self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, '', self.p.name, None, None))
         self.assertEqual(self.ha.run_cycle(), 'PAUSE: waiting to become primary after promote...')
 
     @patch('patroni.postgresql.mtime', Mock(return_value=1588316884))
@@ -1410,7 +1483,7 @@ class TestHa(PostgresInit):
     def test_manual_failover_while_starting(self):
         self.ha.has_lock = true
         self.p.check_for_startup = true
-        f = Failover(0, self.p.name, '', None)
+        f = Failover(0, self.p.name, '', None, None)
         self.ha.cluster = get_cluster_initialized_with_leader(f)
         self.ha.fetch_node_status = get_node_status()  # accessible, in_recovery
         self.assertEqual(self.ha.run_cycle(), 'switchover: demoting myself')
@@ -1989,7 +2062,7 @@ class TestHa(PostgresInit):
         self.p.set_role(PostgresqlRole.REPLICA)
         self.p.name = 'nonsync'
         self.ha.cluster = get_cluster_initialized_without_leader(sync=('other', 'postgresql0,foo'),
-                                                                 failover=Failover(0, None, self.p.name, None))
+                                                                 failover=Failover(0, None, self.p.name, None, None))
         self.ha.fetch_node_status = get_node_status()
         # Postgres 15, Non-sync node promoted manually. Our name is written to leader of the sync key.
         # Voters and synchronous_standby_names are set based on the old value of /sync key.
@@ -2129,7 +2202,7 @@ class TestHa(PostgresInit):
         self.p.name = 'leader'
         self.ha.fetch_node_status = get_node_status()
         self.ha.cluster = get_cluster_initialized_with_leader(sync=('leader', 'foo,other', 1),
-                                                              failover=Failover(0, 'leader', 'other', None))
+                                                              failover=Failover(0, 'leader', 'other', None, None))
         self.ha.cluster.members.append(Member(0, 'foo', 28, {'api_url': 'http://127.0.0.1:8011/patroni'}))
         # switchover when synchronous_mode = off
         self.assertTrue(self.ha.is_failover_possible())
@@ -2147,12 +2220,12 @@ class TestHa(PostgresInit):
                     self.assertTrue(self.ha.is_failover_possible(exclude_failover_candidate=True))
 
         self.ha.cluster = get_cluster_initialized_with_leader(sync=('leader', 'foo,other', 1),
-                                                              failover=Failover(0, '', 'foo', None))
+                                                              failover=Failover(0, '', 'foo', None, None))
         # failover to missing node foo
         self.assertFalse(self.ha.is_failover_possible())
 
         self.ha.cluster = get_cluster_initialized_with_leader(sync=('leader', 'foo,other', 1),
-                                                              failover=Failover(0, 'leader', '', None))
+                                                              failover=Failover(0, 'leader', '', None, None))
         # switchover from leader when synchronous_mode = off
         self.assertTrue(self.ha.is_failover_possible())
 

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -829,6 +829,10 @@ class TestHa(PostgresInit):
             self.assertEqual(self.ha.run_cycle(), 'no action. I am (postgresql0), the leader with the lock')
             mock_warning.assert_called_with('%s: I am already the leader, no need to %s', 'manual failover', 'failover')
 
+        # to a site with no members
+        self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, '', 'dc3', None, None))
+        self.assertEqual(self.ha.run_cycle(), 'no action. I am (postgresql0), the leader with the lock')
+
         # to a non-existent candidate
         with patch('patroni.ha.logger.warning') as mock_warning:
             self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, '', 'blabla', None, None))
@@ -870,6 +874,10 @@ class TestHa(PostgresInit):
             self.assertEqual(self.ha.run_cycle(), 'no action. I am (postgresql0), the leader with the lock')
             mock_warning.assert_called_with(
                 '%s: leader name does not match: %s != %s', 'switchover', 'blabla', 'postgresql0')
+
+        # to a site with no members
+        self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, self.p.name, 'dc3', None, None))
+        self.assertEqual(self.ha.run_cycle(), 'no action. I am (postgresql0), the leader with the lock')
 
         # no candidate
         self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, self.p.name, '', None, None))
@@ -1092,6 +1100,11 @@ class TestHa(PostgresInit):
                                                                  sync=('leader1', 'blabla'))
         self.assertEqual(self.ha.run_cycle(), 'following a different leader because i am not the healthiest node')
 
+        # to my site, but my name is not in sync nodes list
+        self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, '', None, None, 'dc1'),
+                                                                 sync=('leader1', 'blabla'))
+        self.assertEqual(self.ha.run_cycle(), 'following a different leader because i am not the healthiest node')
+
         # manual failover when the candidate node isn't available but our name is in the /sync key
         # while other sync node is nofailover
         with patch('patroni.ha.logger.warning') as mock_warning:
@@ -1119,7 +1132,6 @@ class TestHa(PostgresInit):
         self.assertEqual(self.ha.run_cycle(), 'following a different leader because i am not the healthiest node')
 
         # to my site, but my name is not in sync nodes list
-        self.ha.patroni.nofailover = False
         self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, 'leader', None, None, 'dc1'),
                                                                  sync=('leader1', 'blabla'))
         self.assertEqual(self.ha.run_cycle(), 'following a different leader because i am not the healthiest node')
@@ -2235,3 +2247,9 @@ class TestHa(PostgresInit):
             with patch.object(global_config.__class__, 'is_quorum_commit_mode', PropertyMock(return_value=True)):
                 # switchover from leader when synchronous_mode = quorum
                 self.assertFalse(self.ha.is_failover_possible())  # failure, because quorum is low
+
+        # switchover to a site with no members
+        self.ha.cluster = get_cluster_initialized_with_leader(sync=('leader', 'foo,other', 1),
+                                                              failover=Failover(0, 'leader', '', None, 'dc3'))
+        self.ha.fetch_node_status = get_node_status(site='dc2')
+        self.assertFalse(self.ha.is_failover_possible(filter_failover_site=True))

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -325,7 +325,7 @@ class TestKubernetesConfigMaps(BaseTestKubernetes):
     def test_manual_failover(self):
         with patch.object(k8s_client.CoreV1Api, 'patch_namespaced_config_map',
                           Mock(side_effect=RetryFailedError('')), create=True):
-            self.k.manual_failover('foo', 'bar')
+            self.k.manual_failover('foo', 'bar', None)
 
     def test_set_config_value(self):
         with patch.object(k8s_client.CoreV1Api, 'patch_namespaced_config_map',

--- a/tests/test_raft.py
+++ b/tests/test_raft.py
@@ -239,7 +239,7 @@ class TestRaft(unittest.TestCase):
         self.assertTrue(raft.write_sync_state('foo', 'bar', 0))
         self.assertFalse(raft.write_sync_state('foo', 'bar', 0, 1))
         raft._mpp = get_mpp({'citus': {'group': 1, 'database': 'postgres'}})
-        self.assertTrue(raft.manual_failover('foo', 'bar'))
+        self.assertTrue(raft.manual_failover('foo', 'bar', ''))
         raft._mpp = get_mpp({'citus': {'group': 0, 'database': 'postgres'}})
         self.assertTrue(raft.take_leader())
         cluster = raft.get_cluster()


### PR DESCRIPTION
- site-aware automatic failover
  - prefer local site members
  - if no local members, perform cross-site failover
  - if local members are lagging (even if lag is under `maximum_lag_on_failover`), prefer remote replicas with lower lag
  - failover priority is validated within the local site first, remote member's priority is only considered when no local members left
- manual switchover to a site without specific candidate
  - in case of a switchover to a remote site, when there are no eligible local candidates in the specified site after primary is already demoted, prefer other remote sites over previous leader site's members to failover to
- manual failover still can only be performed to a specific candidate but there is an additional `--site` option for `patronictl` to filter candidates selection list