### PR TITLE
Show Postgres recovery status in `patronictl list` and warn when a leader is stuck in recovery

### DIFF
--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -448,21 +448,21 @@ Fail over to node ``postgresql2``:
 
     $ patronictl -c postgres0.yml failover batman --candidate postgresql2 --force
     Current cluster topology
-    + Cluster: batman (7277694203142172922) -+-----------+----+-------------+-----+------------+-----+
-    | Member      | Host           | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
-    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  3 |             |     |            |     |
-    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  3 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  3 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
+    + Cluster: batman (7277694203142172922) -+-----------+-------------+----+-------------+-----+------------+-----+
+    | Member      | Host           | Role    | State     | In Recovery | TL | Receive LSN | Lag | Replay LSN | Lag |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   | No          |  3 |             |     |            |     |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming | Yes         |  3 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming | Yes         |  3 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
     2023-09-12 11:52:27.50978 Successfully failed over to "postgresql2"
-    + Cluster: batman (7277694203142172922) -+---------+----+-------------+---------+------------+---------+
-    | Member      | Host           | Role    | State   | TL | Receive LSN |     Lag | Replay LSN |     Lag |
-    +-------------+----------------+---------+---------+----+-------------+---------+------------+---------+
-    | postgresql0 | 127.0.0.1:5432 | Replica | stopped |    |     unknown | unknown |    unknown | unknown |
-    | postgresql1 | 127.0.0.1:5433 | Replica | running |  3 |   0/4000188 |       0 |  0/4000188 |       0 |
-    | postgresql2 | 127.0.0.1:5434 | Leader  | running |  3 |             |         |            |         |
-    +-------------+----------------+---------+---------+----+-------------+---------+------------+---------+
+    + Cluster: batman (7277694203142172922) -+---------+-------------+----+-------------+---------+------------+---------+
+    | Member      | Host           | Role    | State   | In Recovery | TL | Receive LSN |     Lag | Replay LSN |     Lag |
+    +-------------+----------------+---------+---------+-------------+----+-------------+---------+------------+---------+
+    | postgresql0 | 127.0.0.1:5432 | Replica | stopped | -           |    |     unknown | unknown |    unknown | unknown |
+    | postgresql1 | 127.0.0.1:5433 | Replica | running | Yes         |  3 |   0/4000188 |       0 |  0/4000188 |       0 |
+    | postgresql2 | 127.0.0.1:5434 | Leader  | running | No          |  3 |             |         |            |         |
+    +-------------+----------------+---------+---------+-------------+----+-------------+---------+------------+---------+
 
 .. _patronictl_flush:
 
@@ -555,13 +555,13 @@ Discard scheduled restart of all standby nodes:
 .. code:: bash
 
     $ patronictl -c postgres0.yml flush batman restart -r replica --force
-    + Cluster: batman (7277694203142172922) -+-----------+----+-------------+-----+------------+-----+---------------------------+
-    | Member      | Host           | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag | Scheduled restart         |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+---------------------------+
-    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  5 |             |     |            |     | 2025-03-23T18:00:00-03:00 |
-    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  5 |   0/4000400 |   0 |  0/4000400 |   0 | 2025-03-23T18:00:00-03:00 |
-    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  5 |   0/4000400 |   0 |  0/4000400 |   0 | 2025-03-23T18:00:00-03:00 |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+---------------------------+
+    + Cluster: batman (7277694203142172922) -+-----------+-------------+----+-------------+-----+------------+-----+---------------------------+
+    | Member      | Host           | Role    | State     | In Recovery | TL | Receive LSN | Lag | Replay LSN | Lag | Scheduled restart         |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+---------------------------+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   | No          |  5 |             |     |            |     | 2025-03-23T18:00:00-03:00 |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming | Yes         |  5 |   0/4000400 |   0 |  0/4000400 |   0 | 2025-03-23T18:00:00-03:00 |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming | Yes         |  5 |   0/4000400 |   0 |  0/4000400 |   0 | 2025-03-23T18:00:00-03:00 |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+---------------------------+
     Success: flush scheduled restart for member postgresql1
     Success: flush scheduled restart for member postgresql2
 
@@ -570,13 +570,13 @@ Discard scheduled restart of nodes ``postgresql0`` and ``postgresql1``:
 .. code:: bash
 
     $ patronictl -c postgres0.yml flush batman postgresql0 postgresql1 restart --force
-    + Cluster: batman (7277694203142172922) -+-----------+----+-------------+-----+------------+-----+---------------------------+
-    | Member      | Host           | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag | Scheduled restart         |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+---------------------------+
-    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  5 |             |     |            |     | 2025-03-23T18:00:00-03:00 |
-    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  5 |   0/4000400 |   0 |  0/4000400 |   0 | 2025-03-23T18:00:00-03:00 |
-    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  5 |   0/4000400 |   0 |  0/4000400 |   0 | 2025-03-23T18:00:00-03:00 |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+---------------------------+
+    + Cluster: batman (7277694203142172922) -+-----------+-------------+----+-------------+-----+------------+-----+---------------------------+
+    | Member      | Host           | Role    | State     | In Recovery | TL | Receive LSN | Lag | Replay LSN | Lag | Scheduled restart         |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+---------------------------+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   | No          |  5 |             |     |            |     | 2025-03-23T18:00:00-03:00 |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming | Yes         |  5 |   0/4000400 |   0 |  0/4000400 |   0 | 2025-03-23T18:00:00-03:00 |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming | Yes         |  5 |   0/4000400 |   0 |  0/4000400 |   0 | 2025-03-23T18:00:00-03:00 |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+---------------------------+
     Success: flush scheduled restart for member postgresql0
     Success: flush scheduled restart for member postgresql1
 
@@ -764,6 +764,17 @@ The following information is included in the output:
     * ``stopped``: if Postgres had been shut down;
     * ``crashed``: if Postgres has crashed.
 
+``In Recovery``
+    Whether Postgres on this member last reported being in recovery mode (``pg_catalog.pg_is_in_recovery()``),
+    as of its last update to the DCS. Because this value is only refreshed once per HA loop cycle, it can lag
+    the real state of Postgres by up to a few seconds.
+
+    * ``Yes``: Postgres is in recovery -- expected for ``Replica``/``Standby Leader`` rows; if shown for a
+      ``Leader`` row it means the node holds the leader lock but Postgres has not confirmed leaving recovery
+      (see the ``Leader %s is in recovery mode`` warning in the Patroni log);
+    * ``No``: Postgres is not in recovery -- the expected, healthy state for a primary;
+    * ``-``: recovery status not currently known (e.g. Postgres stopped).
+
 ``TL``
     Current Postgres timeline in the Patroni member.
 
@@ -908,26 +919,26 @@ Show information about the cluster in pretty format:
 .. code:: bash
 
     $ patronictl -c postgres0.yml list batman
-    + Cluster: batman (7277694203142172922) --------+-----------+----+-------------+-----+------------+-----+
-    | Site | Member      | Host           | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag |
-    +------+-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
-    | dc1  | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  5 |             |     |            |     |
-    | dc1  | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    | dc2  | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    +------+-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
+    + Cluster: batman (7277694203142172922) --------+-----------+-------------+----+-------------+-----+------------+-----+
+    | Site | Member      | Host           | Role    | State     | In Recovery | TL | Receive LSN | Lag | Replay LSN | Lag |
+    +------+-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
+    | dc1  | postgresql0 | 127.0.0.1:5432 | Leader  | running   | No          |  5 |             |     |            |     |
+    | dc1  | postgresql1 | 127.0.0.1:5433 | Replica | streaming | Yes         |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    | dc2  | postgresql2 | 127.0.0.1:5434 | Replica | streaming | Yes         |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    +------+-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
 
 Show information about the cluster in pretty format with extended columns:
 
 .. code:: bash
 
     $ patronictl -c postgres0.yml list batman -e
-    + Cluster: batman (7277694203142172922) --------+-----------+----+-------------+-----+------------+-----+-----------------+------------------------+-------------------+------+
-    | Site | Member      | Host           | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag | Pending restart | Pending restart reason | Scheduled restart | Tags |
-    +------+-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+-----------------+------------------------+-------------------+------+
-    | dc1  | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  5 |             |     |            |     |                 |                        |                   |      |
-    | dc1  | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |                 |                        |                   |      |
-    | dc2  | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |                 |                        |                   |      |
-    +------+-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+-----------------+------------------------+-------------------+------+
+    + Cluster: batman (7277694203142172922) --------+-----------+-------------+----+-------------+-----+------------+-----+-----------------+------------------------+-------------------+------+
+    | Site | Member      | Host           | Role    | State     | In Recovery | TL | Receive LSN | Lag | Replay LSN | Lag | Pending restart | Pending restart reason | Scheduled restart | Tags |
+    +------+-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+-----------------+------------------------+-------------------+------+
+    | dc1  | postgresql0 | 127.0.0.1:5432 | Leader  | running   | No          |  5 |             |     |            |     |                 |                        |                   |      |
+    | dc1  | postgresql1 | 127.0.0.1:5433 | Replica | streaming | Yes         |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |                 |                        |                   |      |
+    | dc2  | postgresql2 | 127.0.0.1:5434 | Replica | streaming | Yes         |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |                 |                        |                   |      |
+    +------+-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+-----------------+------------------------+-------------------+------+
 
 Show information about the cluster in YAML format, with timestamp of execution:
 
@@ -1317,13 +1328,13 @@ Request a rebuild of all replica members of the Patroni cluster and immediately 
 .. code:: bash
 
     $ patronictl -c postgres0.yml reinit batman postgresql1 postgresql2 --force
-    + Cluster: batman (7277694203142172922) -+-----------+----+-------------+-----+------------+-----+
-    | Member      | Host           | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
-    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  5 |             |     |            |     |
-    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
+    + Cluster: batman (7277694203142172922) -+-----------+-------------+----+-------------+-----+------------+-----+
+    | Member      | Host           | Role    | State     | In Recovery | TL | Receive LSN | Lag | Replay LSN | Lag |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   | No          |  5 |             |     |            |     |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming | Yes         |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming | Yes         |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
     Success: reinitialize for member postgresql1
     Success: reinitialize for member postgresql2
 
@@ -1332,13 +1343,13 @@ Request a rebuild of ``postgresql2`` and wait for it to complete:
 .. code:: bash
 
     $ patronictl -c postgres0.yml reinit batman postgresql2 --wait --force
-    + Cluster: batman (7277694203142172922) -+-----------+----+-------------+-----+------------+-----+
-    | Member      | Host           | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
-    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  5 |             |     |            |     |
-    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
+    + Cluster: batman (7277694203142172922) -+-----------+-------------+----+-------------+-----+------------+-----+
+    | Member      | Host           | Role    | State     | In Recovery | TL | Receive LSN | Lag | Replay LSN | Lag |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   | No          |  5 |             |     |            |     |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming | Yes         |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming | Yes         |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
     Success: reinitialize for member postgresql2
     Waiting for reinitialize to complete on: postgresql2
     Reinitialize is completed on: postgresql2
@@ -1348,13 +1359,13 @@ Request a rebuild of ``postgresql2`` and get basebackup from leader directly:
 .. code:: bash
 
     $ patronictl -c postgres0.yml reinit batman postgresql2 --from-leader
-    + Cluster: batman (7277694203142172922) -+-----------+----+-------------+-----+------------+-----+
-    | Member      | Host           | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
-    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  5 |             |     |            |     |
-    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
+    + Cluster: batman (7277694203142172922) -+-----------+-------------+----+-------------+-----+------------+-----+
+    | Member      | Host           | Role    | State     | In Recovery | TL | Receive LSN | Lag | Replay LSN | Lag |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   | No          |  5 |             |     |            |     |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming | Yes         |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming | Yes         |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
     Success: reinitialize for member postgresql2
 
 .. _patronictl_reload:
@@ -1430,13 +1441,13 @@ Request a reload of the local configuration of all members of the Patroni cluste
 .. code:: bash
 
     $ patronictl -c postgres0.yml reload batman --force
-    + Cluster: batman (7277694203142172922) -+-----------+----+-------------+-----+------------+-----+
-    | Member      | Host           | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
-    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  5 |             |     |            |     |
-    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
+    + Cluster: batman (7277694203142172922) -+-----------+-------------+----+-------------+-----+------------+-----+
+    | Member      | Host           | Role    | State     | In Recovery | TL | Receive LSN | Lag | Replay LSN | Lag |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   | No          |  5 |             |     |            |     |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming | Yes         |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming | Yes         |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
     Reload request received for member postgresql0 and will be processed within 10 seconds
     Reload request received for member postgresql1 and will be processed within 10 seconds
     Reload request received for member postgresql2 and will be processed within 10 seconds
@@ -1505,13 +1516,13 @@ Remove information about Patroni cluster ``batman`` from the DCS:
 .. code:: bash
 
     $ patronictl -c postgres0.yml remove batman
-    + Cluster: batman (7277694203142172922) -+-----------+----+-------------+-----+------------+-----+
-    | Member      | Host           | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
-    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  5 |             |     |            |     |
-    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
+    + Cluster: batman (7277694203142172922) -+-----------+-------------+----+-------------+-----+------------+-----+
+    | Member      | Host           | Role    | State     | In Recovery | TL | Receive LSN | Lag | Replay LSN | Lag |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   | No          |  5 |             |     |            |     |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming | Yes         |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming | Yes         |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
     Please confirm the cluster name to remove: batman
     You are about to remove all information in DCS for batman, please type: "Yes I am aware": Yes I am aware
     This cluster currently is healthy. Please specify the leader name to continue: postgresql0
@@ -1610,13 +1621,13 @@ Restart all members of the cluster immediately:
 .. code:: bash
 
     $ patronictl -c postgres0.yml restart batman --force
-    + Cluster: batman (7277694203142172922) -+-----------+----+-------------+-----+------------+-----+
-    | Member      | Host           | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
-    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  6 |             |     |            |     |
-    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  6 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  6 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
+    + Cluster: batman (7277694203142172922) -+-----------+-------------+----+-------------+-----+------------+-----+
+    | Member      | Host           | Role    | State     | In Recovery | TL | Receive LSN | Lag | Replay LSN | Lag |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   | No          |  6 |             |     |            |     |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming | Yes         |  6 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming | Yes         |  6 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
     Success: restart on member postgresql0
     Success: restart on member postgresql1
     Success: restart on member postgresql2
@@ -1626,13 +1637,13 @@ Restart a random member of the cluster immediately:
 .. code:: bash
 
     $ patronictl -c postgres0.yml restart batman --any --force
-    + Cluster: batman (7277694203142172922) -+-----------+----+-------------+-----+------------+-----+
-    | Member      | Host           | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
-    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  6 |             |     |            |     |
-    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  6 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  6 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
+    + Cluster: batman (7277694203142172922) -+-----------+-------------+----+-------------+-----+------------+-----+
+    | Member      | Host           | Role    | State     | In Recovery | TL | Receive LSN | Lag | Replay LSN | Lag |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   | No          |  6 |             |     |            |     |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming | Yes         |  6 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming | Yes         |  6 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
     Success: restart on member postgresql1
 
 Schedule a restart to occur at ``2023-09-13T18:00-03:00``:
@@ -1640,13 +1651,13 @@ Schedule a restart to occur at ``2023-09-13T18:00-03:00``:
 .. code:: bash
 
     $ patronictl -c postgres0.yml restart batman --scheduled 2023-09-13T18:00-03:00 --force
-    + Cluster: batman (7277694203142172922) -+-----------+----+-------------+-----+------------+-----+
-    | Member      | Host           | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
-    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  6 |             |     |            |     |
-    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  6 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  6 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
+    + Cluster: batman (7277694203142172922) -+-----------+-------------+----+-------------+-----+------------+-----+
+    | Member      | Host           | Role    | State     | In Recovery | TL | Receive LSN | Lag | Replay LSN | Lag |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   | No          |  6 |             |     |            |     |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming | Yes         |  6 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming | Yes         |  6 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
     Success: restart scheduled on member postgresql0
     Success: restart scheduled on member postgresql1
     Success: restart scheduled on member postgresql2
@@ -1850,21 +1861,21 @@ Switch over with node ``postgresql2``:
 
     $ patronictl -c postgres0.yml switchover batman --leader postgresql0 --candidate postgresql2 --force
     Current cluster topology
-    + Cluster: batman (7277694203142172922) -+-----------+----+-------------+-----+------------+-----+
-    | Member      | Host           | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
-    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  6 |             |     |            |     |
-    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  6 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  6 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
+    + Cluster: batman (7277694203142172922) -+-----------+-------------+----+-------------+-----+------------+-----+
+    | Member      | Host           | Role    | State     | In Recovery | TL | Receive LSN | Lag | Replay LSN | Lag |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   | No          |  6 |             |     |            |     |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming | Yes         |  6 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming | Yes         |  6 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
     2023-09-13 14:15:23.07497 Successfully switched over to "postgresql2"
-    + Cluster: batman (7277694203142172922) -+---------+----+-------------+---------+------------+---------+
-    | Member      | Host           | Role    | State   | TL | Receive LSN |     Lag | Replay LSN |     Lag |
-    +-------------+----------------+---------+---------+----+-------------+---------+------------+---------+
-    | postgresql0 | 127.0.0.1:5432 | Replica | stopped |    |     unknown | unknown |    unknown | unknown |
-    | postgresql1 | 127.0.0.1:5433 | Replica | running |  6 |   0/4000188 |       0 |  0/4000188 |       0 |
-    | postgresql2 | 127.0.0.1:5434 | Leader  | running |  6 |             |         |            |         |
-    +-------------+----------------+---------+---------+----+-------------+---------+------------+---------+
+    + Cluster: batman (7277694203142172922) -+---------+-------------+----+-------------+---------+------------+---------+
+    | Member      | Host           | Role    | State   | In Recovery | TL | Receive LSN |     Lag | Replay LSN |     Lag |
+    +-------------+----------------+---------+---------+-------------+----+-------------+---------+------------+---------+
+    | postgresql0 | 127.0.0.1:5432 | Replica | stopped | -           |    |     unknown | unknown |    unknown | unknown |
+    | postgresql1 | 127.0.0.1:5433 | Replica | running | Yes         |  6 |   0/4000188 |       0 |  0/4000188 |       0 |
+    | postgresql2 | 127.0.0.1:5434 | Leader  | running | No          |  6 |             |         |            |         |
+    +-------------+----------------+---------+---------+-------------+----+-------------+---------+------------+---------+
 
 Schedule a switchover between ``postgresql0`` and ``postgresql2`` to occur at ``2023-09-13T18:00:00-03:00``:
 
@@ -1872,21 +1883,21 @@ Schedule a switchover between ``postgresql0`` and ``postgresql2`` to occur at ``
 
     $ patronictl -c postgres0.yml switchover batman --leader postgresql0 --candidate postgresql2 --scheduled 2023-09-13T18:00-03:00 --force
     Current cluster topology
-    + Cluster: batman (7277694203142172922) -+-----------+----+-------------+-----+------------+-----+
-    | Member      | Host           | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
-    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  8 |             |     |            |     |
-    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  8 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  8 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
+    + Cluster: batman (7277694203142172922) -+-----------+-------------+----+-------------+-----+------------+-----+
+    | Member      | Host           | Role    | State     | In Recovery | TL | Receive LSN | Lag | Replay LSN | Lag |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   | No          |  8 |             |     |            |     |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming | Yes         |  8 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming | Yes         |  8 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
     2023-09-13 14:18:11.20661 Switchover scheduled
-    + Cluster: batman (7277694203142172922) -+-----------+----+-------------+-----+------------+-----+
-    | Member      | Host           | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
-    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  8 |             |     |            |     |
-    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  8 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  8 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
+    + Cluster: batman (7277694203142172922) -+-----------+-------------+----+-------------+-----+------------+-----+
+    | Member      | Host           | Role    | State     | In Recovery | TL | Receive LSN | Lag | Replay LSN | Lag |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   | No          |  8 |             |     |            |     |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming | Yes         |  8 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming | Yes         |  8 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    +-------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
     Switchover scheduled at: 2023-09-13T18:00:00-03:00
                         from: postgresql0
                         to: postgresql2
@@ -1958,6 +1969,17 @@ The following information is included in the output:
     * ``in archive recovery``: if a replica and Postgres is currently fetching WALs from the archive;
     * ``stopped``: if Postgres had been shut down;
     * ``crashed``: if Postgres has crashed.
+
+``In Recovery``
+    Whether Postgres on this member last reported being in recovery mode (``pg_catalog.pg_is_in_recovery()``),
+    as of its last update to the DCS. Because this value is only refreshed once per HA loop cycle, it can lag
+    the real state of Postgres by up to a few seconds.
+
+    * ``Yes``: Postgres is in recovery -- expected for ``Replica``/``Standby Leader`` rows; if shown for a
+      ``Leader`` row it means the node holds the leader lock but Postgres has not confirmed leaving recovery
+      (see the ``Leader %s is in recovery mode`` warning in the Patroni log);
+    * ``No``: Postgres is not in recovery -- the expected, healthy state for a primary;
+    * ``-``: recovery status not currently known (e.g. Postgres stopped).
 
 ``TL``
     Current Postgres timeline in the Patroni member.
@@ -2058,13 +2080,13 @@ Show topology of the cluster ``batman`` -- ``postgresql1`` and ``postgresql2`` a
 .. code:: bash
 
     $ patronictl -c postgres0.yml topology batman
-    + Cluster: batman (7277694203142172922) ---+-----------+----+-------------+-----+------------+-----+
-    | Member        | Host           | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag |
-    +---------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
-    | postgresql0   | 127.0.0.1:5432 | Leader  | running   |  8 |             |     |            |     |
-    | + postgresql1 | 127.0.0.1:5433 | Replica | streaming |  8 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    | + postgresql2 | 127.0.0.1:5434 | Replica | streaming |  8 |   0/40004E8 |   0 |  0/40004E8 |   0 |
-    +---------------+----------------+---------+-----------+----+-------------+-----+------------+-----+
+    + Cluster: batman (7277694203142172922) ---+-----------+-------------+----+-------------+-----+------------+-----+
+    | Member        | Host           | Role    | State     | In Recovery | TL | Receive LSN | Lag | Replay LSN | Lag |
+    +---------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
+    | postgresql0   | 127.0.0.1:5432 | Leader  | running   | No          |  8 |             |     |            |     |
+    | + postgresql1 | 127.0.0.1:5433 | Replica | streaming | Yes         |  8 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    | + postgresql2 | 127.0.0.1:5434 | Replica | streaming | Yes         |  8 |   0/40004E8 |   0 |  0/40004E8 |   0 |
+    +---------------+----------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
 
 .. _patronictl_version:
 

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -445,6 +445,7 @@ Cluster status endpoints
           "role": "leader",
           "state": "running",
           "api_url": "http://10.89.0.4:8008/patroni",
+          "in_recovery": false,
           "host": "10.89.0.4",
           "port": 5432,
           "timeline": 5,
@@ -457,6 +458,7 @@ Cluster status endpoints
           "role": "replica",
           "state": "streaming",
           "api_url": "http://10.89.0.6:8008/patroni",
+          "in_recovery": true,
           "host": "10.89.0.6",
           "port": 5433,
           "timeline": 5,
@@ -478,6 +480,13 @@ Cluster status endpoints
         "to": "patroni3"
       }
     }
+
+Each member's ``in_recovery`` is ``True``/``False`` if Postgres recovery status (``pg_catalog.pg_is_in_recovery()``)
+is known for that member as of its last update to the DCS, omitted if unknown. The top-level response may also
+contain a ``leader_in_recovery: true`` key -- present only when the current leader's Postgres has not confirmed
+leaving recovery (e.g. a stalled ``restore_command`` during promotion), omitted otherwise. A DCS leader lock does
+not by itself guarantee Postgres has left recovery; these fields make that distinction visible without having to
+separately query ``GET /patroni`` on the leader.
 
 
 - The ``GET /history`` endpoint provides a view on the history of cluster switchovers/failovers. The format is very similar to the content of history files in the ``pg_wal`` directory. The only difference is the timestamp field showing when the new timeline was created.

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -551,11 +551,19 @@ class RestApiHandler(BaseHTTPRequestHandler):
 
         Write an HTTP response with JSON content based on the output of :func:`~patroni.utils.cluster_as_json`, with
         HTTP status ``200`` and the JSON representation of the cluster topology.
+
+        In addition to the keys documented in :func:`~patroni.utils.cluster_as_json`, the response may contain:
+
+            * ``leader_in_recovery``: ``True`` if the current leader's Postgres has not confirmed leaving
+              recovery (``pg_is_in_recovery()``), omitted otherwise.
         """
         cluster = self.server.patroni.dcs.get_cluster()
 
         response = cluster_as_json(cluster)
         response['scope'] = self.server.patroni.postgresql.scope
+        leader = next((m for m in response['members'] if m['role'] == 'leader'), None)
+        if leader is not None and leader.get('in_recovery'):
+            response['leader_in_recovery'] = True
         self._write_json_response(200, response)
 
     def do_GET_history(self) -> None:

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -1603,7 +1603,7 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
     logging.debug(cluster)
 
     initialize = {None: 'uninitialized', '': 'initializing'}.get(cluster.initialize, cluster.initialize)
-    columns = ['Cluster', 'Member', 'Host', 'Role', 'In Recovery', 'State', 'TL',
+    columns = ['Cluster', 'Member', 'Host', 'Role', 'State', 'In Recovery', 'TL',
                'Receive LSN', 'Receive Lag', 'Replay LSN', 'Replay Lag']
 
     clusters = {group or 0: cluster_as_json(cluster)}

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -1603,7 +1603,7 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
     logging.debug(cluster)
 
     initialize = {None: 'uninitialized', '': 'initializing'}.get(cluster.initialize, cluster.initialize)
-    columns = ['Cluster', 'Member', 'Host', 'Role', 'State', 'TL',
+    columns = ['Cluster', 'Member', 'Host', 'Role', 'In Recovery', 'State', 'TL',
                'Receive LSN', 'Receive Lag', 'Replay LSN', 'Replay Lag']
 
     clusters = {group or 0: cluster_as_json(cluster)}
@@ -1656,9 +1656,13 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
             replay_lag = round(replay_lag / 1024 / 1024) if isinstance(replay_lag, int) \
                 else '' if replay_lag == 'unknown' else replay_lag
 
+            in_recovery = member.get('in_recovery')
+            in_recovery_display = 'Yes' if in_recovery is True else 'No' if in_recovery is False else '-'
+
             member.update(cluster=name, member=member['name'], group=g,
                           host=member.get('host', ''), tl=member.get('timeline', ''),
                           role=member['role'].replace('_', ' ').title(),
+                          in_recovery=in_recovery_display,
                           receive_lag=receive_lag, replay_lag=replay_lag,
                           receive_lsn=receive_lsn, replay_lsn=replay_lsn,
                           pending_restart='*' if member.get('pending_restart') else '',

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1217,6 +1217,7 @@ class Ha(object):
             self.state_handler.mpp_handler.sync_meta_data(self.cluster)
             return message
         elif self.state_handler.role in (PostgresqlRole.PRIMARY, PostgresqlRole.PROMOTED):
+            logger.warning('Leader %s is in recovery mode', self.state_handler.name)
             self.process_sync_replication()
             return message
         else:

--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -923,6 +923,8 @@ def cluster_as_json(cluster: 'Cluster') -> Dict[str, Any]:
 
             * ``name``: the name of the host (unique in the cluster). The ``members`` list is sorted by this key;
             * ``role``: ``leader``, ``standby_leader``, ``sync_standby``, ``quorum_standby``, or ``replica``;
+            * ``in_recovery``: ``True``/``False`` if Postgres recovery status is known for this member (based
+                on ``pg_is_in_recovery()`` as last reported to the DCS), omitted if unknown;
             * ``state``: one of :class:`~patroni.postgresql.misc.PostgresqlState`;
             * ``api_url``: REST API URL based on ``restapi->connect_address`` configuration;
             * ``host``: PostgreSQL host based on ``postgresql->connect_address``;
@@ -948,7 +950,7 @@ def cluster_as_json(cluster: 'Cluster') -> Dict[str, Any]:
             * ``to``: name of the member to be promoted.
     """
     from . import global_config
-    from .postgresql.misc import format_lsn
+    from .postgresql.misc import format_lsn, PostgresqlRole
 
     config = global_config.from_cluster(cluster)
     leader_name = cluster.leader.name if cluster.leader else None
@@ -965,7 +967,20 @@ def cluster_as_json(cluster: 'Cluster') -> Dict[str, Any]:
             role = 'replica'
 
         state = (m.data.get('replication_state', '') if role != 'leader' else '') or m.data.get('state', '')
+
+        raw_role = m.data.get('role')
+        try:
+            raw_role = PostgresqlRole(raw_role)
+        except ValueError:
+            raw_role = None
+
         member = {'name': m.name, 'role': role, 'state': state, 'api_url': m.api_url}
+        if raw_role in (PostgresqlRole.PRIMARY, PostgresqlRole.MASTER):
+            member['in_recovery'] = False
+        elif raw_role in (PostgresqlRole.REPLICA, PostgresqlRole.STANDBY_LEADER, PostgresqlRole.PROMOTED):
+            member['in_recovery'] = True
+        # DEMOTED / UNINITIALIZED / missing -> key omitted, matches how other optional fields
+        # (pending_restart, tags, ...) are only added when known.
         conn_kwargs = m.conn_kwargs()
         if conn_kwargs.get('host'):
             member['host'] = conn_kwargs['host']

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,7 +19,7 @@ from patroni.utils import RetryFailedError, tzutc
 
 from . import MockConnect, psycopg_connect
 from .test_etcd import socket_getaddrinfo
-from .test_ha import get_cluster_initialized_without_leader
+from .test_ha import get_cluster_initialized_with_leader, get_cluster_initialized_without_leader
 
 future_restart_time = datetime.datetime.now(tzutc) + datetime.timedelta(days=5)
 postmaster_start_time = datetime.datetime.now(tzutc)
@@ -413,6 +413,18 @@ class TestRestApiHandler(unittest.TestCase):
         mock_dcs.get_cluster.return_value = get_cluster_initialized_without_leader()
         mock_dcs.get_cluster.return_value.members[1].data['xlog_location'] = 11
         self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /cluster'))
+
+        mock_dcs.get_cluster.return_value = get_cluster_initialized_with_leader()
+        with patch.object(RestApiHandler, 'write_response') as response_mock:
+            MockRestApiServer(RestApiHandler, 'GET /cluster')
+            self.assertNotIn('leader_in_recovery', json.loads(response_mock.call_args[0][1]))
+
+        cluster = get_cluster_initialized_with_leader()
+        cluster.members[0].data['role'] = PostgresqlRole.PROMOTED
+        mock_dcs.get_cluster.return_value = cluster
+        with patch.object(RestApiHandler, 'write_response') as response_mock:
+            MockRestApiServer(RestApiHandler, 'GET /cluster')
+            self.assertTrue(json.loads(response_mock.call_args[0][1])['leader_in_recovery'])
 
     @patch.object(MockPatroni, 'dcs')
     def test_do_GET_history(self, mock_dcs):

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -141,9 +141,9 @@ class TestCtl(unittest.TestCase):
             with patch('click.echo') as mock_echo:
                 self.assertIsNone(output_members(cluster, name='abc', fmt='tsv'))
                 self.assertEqual(mock_echo.call_args_list[3][0][0],
-                                 'abc\tother\t\tReplica\tstreaming\t\t0/3\t0\tunknown\t')
+                                 'abc\tother\t\tReplica\tstreaming\t-\t\t0/3\t0\tunknown\t')
                 self.assertEqual(mock_echo.call_args_list[1][0][0],
-                                 'abc\tfoo\t\tReplica\tin archive recovery\t\tunknown\t\t0/3\t0')
+                                 'abc\tfoo\t\tReplica\tin archive recovery\t-\t\tunknown\t\t0/3\t0')
 
                 cluster = get_cluster_initialized_with_leader()
                 mock_echo.reset_mock()
@@ -537,6 +537,17 @@ class TestCtl(unittest.TestCase):
             cluster.members[1].data['pending_restart_reason'] = {'param': get_param_diff('', 'new')}
             result = self.runner.invoke(ctl, ['list', 'dummy'])
             self.assertIn('param: ->new', result.output)
+
+    def test_list_in_recovery(self):
+        result = self.runner.invoke(ctl, ['list'])
+        self.assertIn('In Recovery', result.output)
+        self.assertIn('No', result.output)
+
+        cluster = get_cluster_initialized_with_leader()
+        cluster.members[0].data['role'] = PostgresqlRole.PROMOTED
+        with patch('patroni.dcs.AbstractDCS.get_cluster', Mock(return_value=cluster)):
+            result = self.runner.invoke(ctl, ['list'])
+            self.assertIn('Yes', result.output)
 
     def test_list_extended(self):
         result = self.runner.invoke(ctl, ['list', 'dummy', '--extended', '--timestamp'])

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -438,7 +438,9 @@ class TestHa(PostgresInit):
         self.ha.has_lock = true
         self.p.is_primary = false
         self.p.set_role(PostgresqlRole.PRIMARY)
-        self.assertEqual(self.ha.run_cycle(), 'no action. I am (postgresql0), the leader with the lock')
+        with patch('patroni.ha.logger.warning') as mock_logger:
+            self.assertEqual(self.ha.run_cycle(), 'no action. I am (postgresql0), the leader with the lock')
+            self.assertEqual(mock_logger.call_args_list[0][0], ('Leader %s is in recovery mode', 'postgresql0'))
 
     def test_demote_after_failing_to_obtain_lock(self):
         self.ha.acquire_lock = false


### PR DESCRIPTION
## The Problem and Gap

During a failover on a cluster, the newly-promoted node held the DCS leader lock while Postgres was still in recovery and `patronictl list` showed a healthy `Leader`/`running` row the whole time. Every write to it failed. Looking into why Patroni never flagged this, I found [patroni#3603](https://github.com/patroni/patroni/issues/3603), an existing issue describing the similar same gap

A DCS "Leader" can hold the lock while PostgreSQL is still `pg_is_in_recovery() = true`.  Today Patroni gives no signal of this: `patronictl list` shows a plain `Leader`/`running` row, and the log repeats `"no action. I am (X), the leader with the lock"` every cycle — both look completely healthy while every write to that node fails with `cannot execute ... in a read-only transaction`.


## Proposal 

Patroni already computes both facts involved every HA cycle. Basically DCS lock ownership via `has_lock()`, and Postgres recovery status via `is_primary()`. **Four small, additive changes, all reusing existing state (zero new queries):**

1. `patronictl list` gains an `In Recovery` column (`Yes`/`No`/`-`), sourced from the `role` Patroni
   already writes to the DCS every cycle.
2. `GET /cluster` gains `in_recovery: true/false` per member — same `cluster_as_json()` code path as 1,
   so any node, not just the leader, can report cluster-wide recovery status.
3. `GET /cluster` additionally gains a top-level `leader_in_recovery: true` flag, present only when the
   current leader's recovery status is exactly this problem — sparing monitoring/alerting scripts the
   per-member lookup (`jq .leader_in_recovery`), directly replacing the role-string-comparison logic the
   external `cluster_health.sh` script had to hand-roll.
4. Patroni logs `Leader %s is in recovery mode` once per HA cycle for as long as the node holding the
   leader lock hasn't confirmed Postgres left recovery — reusing the `is_primary()` check
   `enforce_primary_role()` already performs.


## Output of the Change

Healthy baseline:
```
+----------+------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
| Member   | Host       | Role    | State     | In Recovery | TL | Receive LSN | Lag | Replay LSN | Lag |
+----------+------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
| patroni1 | 172.20.0.6 | Leader  | running   | No          |  1 |             |     |            |     |
| patroni2 | 172.20.0.7 | Replica | streaming | Yes         |  1 |   0/4000060 |   0 |  0/4000060 |   0 |
| patroni3 | 172.20.0.3 | Replica | streaming | Yes         |  1 |   0/4000060 |   0 |  0/4000060 |   0 |
+----------+------------+---------+-----------+-------------+----+-------------+-----+------------+-----+
```

Immediately after failover onto the node with the hung `restore_command`. 
```
+----------+------------+---------+---------+-------------+----+-------------+-----+------------+-----+
| Member   | Host       | Role    | State   | In Recovery | TL | Receive LSN | Lag | Replay LSN | Lag |
+----------+------------+---------+---------+-------------+----+-------------+-----+------------+-----+
| patroni1 | 172.20.0.6 | Replica | stopped | -           |    |     unknown |     |    unknown |     |
| patroni2 | 172.20.0.7 | Leader  | running | Yes         |  1 |             |     |            |     |
| patroni3 | 172.20.0.3 | Replica | running | Yes         |  1 |   0/40001A8 |   0 |  0/40001A8 |   0 |
+----------+------------+---------+---------+-------------+----+-------------+-----+------------+-----+
```


`GET /cluster` on any node during the stuck window:
```json
{
  "members": [
    {"name": "patroni2", "role": "leader", "state": "running", "in_recovery": true, "timeline": 1, ...}
  ],
  "scope": "demo",
  "leader_in_recovery": true
}
```

Patroni's own log during the stuck window — the new warning sits right next to the previously-misleading
line that gave this issue its name:
```
2026-08-15 11:14:25,750 WARNING: Leader patroni2 is in recovery mode
2026-08-15 11:14:25,750 INFO: no action. I am (patroni2), the leader with the lock
```

After clearing the hung `restore_command` — clean self-recovery, no manual intervention beyond fixing the
underlying cause:
```
+----------+------------+---------+----------+-------------+----+-------------+-----+------------+-----+
| Member   | Host       | Role    | State    | In Recovery | TL | Receive LSN | Lag | Replay LSN | Lag |
+----------+------------+---------+----------+-------------+----+-------------+-----+------------+-----+
| patroni1 | 172.20.0.6 | Replica | starting | Yes         |    |     unknown |     |    unknown |     |
| patroni2 | 172.20.0.7 | Leader  | running  | No          |  2 |             |     |            |     |
| patroni3 | 172.20.0.3 | Replica | running  | Yes         |  1 |   0/40001A8 |   0 |  0/40001A8 |   0 |
+----------+------------+---------+----------+-------------+----+-------------+-----+------------+-----+
```
(Timeline advanced `1` → `2`, confirming promotion genuinely completed this time; `leader_in_recovery` no
longer present in `/cluster`; the warning stopped appearing in the log.)
