### PR TITLE
Reload REST API certificate when local config also changed

### DIFF
--- a/patroni/__main__.py
+++ b/patroni/__main__.py
@@ -184,7 +184,8 @@ class Patroni(AbstractPatroniDaemon, ClusterSite, Tags):
             if local:
                 self._tags = self._get_tags()
                 self.request.reload_config(self.config)
-            if local or sighup and self.api.reload_local_certificate():
+            received_new_cert = sighup and self.api.reload_local_certificate()
+            if local or received_new_cert:
                 self.api.reload_config(self.config['restapi'])
             self.watchdog.reload_config(self.config)
             self._last_effective_role = ROLE_CONFIG_SUFFIX_MAP.get(self.postgresql.role)

--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -284,6 +284,12 @@ class TestPatroni(unittest.TestCase):
         self.p._get_tags = Mock(side_effect=Exception)
         self.p.reload_config(local=True)
 
+    def test_reload_config_checks_certificate_when_local_config_changed(self):
+        """A renewed certificate must be detected even when the local config changed too."""
+        self.p.api.reload_local_certificate = Mock(return_value=True)
+        self.p.reload_config(sighup=True, local=True)
+        self.p.api.reload_local_certificate.assert_called_once()
+
     def test_reload_config_updates_effective_role(self):
         """Test that reload_config updates _last_effective_role based on current role."""
         # When role is UNINITIALIZED, _last_effective_role should be None


### PR DESCRIPTION
```
if local or sighup and self.api.reload_local_certificate():
```

This parses as `local or (sighup and ...)`, so when the local config changed, reload_local_certificate() is never called. 

This is particularly painful when you have IaaC: you pushed changes to patroni config and at the same time cert expiration triggered a cert renewal, which will never be loaded.