### PR TITLE
Expose cert expiry date for patroni api in metrics

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -367,6 +367,9 @@ Retrieve the Patroni metrics in Prometheus format through the ``GET /metrics`` e
 	# HELP patroni_failover_priority Failover priority of this node.
 	# TYPE patroni_failover_priority gauge
 	patroni_failover_priority{scope="batman",name="patroni1"} 1
+	# HELP patroni_restapi_certificate_expiry Epoch timestamp when the REST API certificate expires.
+	# TYPE patroni_restapi_certificate_expiry gauge
+	patroni_restapi_certificate_expiry{scope="batman",name="patroni1"} 1788336638
 
 PostgreSQL State Values
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -774,11 +774,11 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# TYPE patroni_failover_priority gauge")
         metrics.append("patroni_failover_priority{0} {1}".format(labels, patroni.failover_priority))
 
-        if self.server._ssl_not_after is not None:
+        if self.server.ssl_not_after is not None:
             metrics.append("# HELP patroni_restapi_certificate_expiry Epoch timestamp when the REST API"
                            " certificate expires.")
             metrics.append("# TYPE patroni_restapi_certificate_expiry gauge")
-            metrics.append("patroni_restapi_certificate_expiry{0} {1}".format(labels, self.server._ssl_not_after))
+            metrics.append("patroni_restapi_certificate_expiry{0} {1}".format(labels, self.server.ssl_not_after))
 
         self.write_response(200, '\n'.join(metrics) + '\n', content_type='text/plain')
 
@@ -1540,10 +1540,19 @@ class RestApiServer(ThreadingMixIn, HTTPServer):
         self._executor = PatroniThreadPoolExecutor(max_workers=thread_pool_size + 1, thread_name_prefix='RestAPI')
         self.__ssl_options: Dict[str, Any] = {}
         self.__ssl_serial_number = None
-        self._ssl_not_after: Optional[float] = None
+        self.__ssl_not_after: Optional[int] = None
         self._received_new_cert = False
         self.reload_config(config)
         self.daemon = True
+
+    @property
+    def ssl_not_after(self) -> Optional[int]:
+        """Epoch timestamp when the certificate used by the REST API expires.
+
+        It is ``None`` when the REST API is not running in HTTPS mode, or when the expiry could not be read from the
+        certificate.
+        """
+        return self.__ssl_not_after
 
     def construct_server_tokens(self, token_config: str) -> str:
         """Construct the value for the ``Server`` HTTP header based on *server_tokens*.
@@ -1813,7 +1822,7 @@ class RestApiServer(ThreadingMixIn, HTTPServer):
         # wrap socket with ssl if 'certfile' is defined in a config.yaml
         # Sometime it's also needed to pass reference to a 'keyfile'.
         self.__protocol = 'https' if ssl_options.get('certfile') else 'http'
-        self._ssl_not_after = None
+        self.__ssl_not_after = None
         if self.__protocol == 'https':
             import ssl
             ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH, cafile=ssl_options.get('cafile'))
@@ -1828,7 +1837,7 @@ class RestApiServer(ThreadingMixIn, HTTPServer):
                     ctx.verify_mode = modes[verify_client]
                 else:
                     logger.error('Bad value in the "restapi.verify_client": %s', verify_client)
-            self.__ssl_serial_number, self._ssl_not_after = self.parse_certificate()
+            self.__ssl_serial_number, self.__ssl_not_after = self.parse_certificate()
             self.socket = ctx.wrap_socket(self.socket, server_side=True, do_handshake_on_connect=False)
         if reloading_config:
             self.start()
@@ -1913,26 +1922,37 @@ class RestApiServer(ThreadingMixIn, HTTPServer):
                 logger.debug('Failed to shutdown SSL connection: %r', e)
         super(RestApiServer, self).shutdown_request(request)
 
-    def parse_certificate(self) -> Tuple[Optional[str], Optional[float]]:
+    def parse_certificate(self) -> Tuple[Optional[str], Optional[int]]:
         """Parse the certificate used by the REST API.
 
-        :returns: serial number of the certificate configured through ``restapi.certfile`` setting and the
-            epoch timestamp when it expires.
+        :returns: a tuple composed of 2 items:
+
+            * serial number of the certificate configured through ``restapi.certfile`` setting, or ``None`` if it
+              could not be read;
+            * epoch timestamp when that certificate expires, or ``None`` if it could not be read.
         """
         certfile: Optional[str] = self.__ssl_options.get('certfile')
-        if certfile:
-            import ssl
+        if not certfile:
+            return None, None
+
+        import ssl
+        try:
+            crt = cast(Dict[str, Any], ssl._ssl._test_decode_cert(certfile))  # pyright: ignore
+        except ssl.SSLError as e:
+            logger.error('Failed to decode certificate %s: %r', certfile, e)
+            return None, None
+
+        serial_number: Optional[str] = crt.get('serialNumber')
+        not_after = crt.get('notAfter')
+        expiry: Optional[int] = None
+        if isinstance(not_after, str):
             try:
-                crt = cast(Dict[str, Any], ssl._ssl._test_decode_cert(certfile))  # pyright: ignore
-            except ssl.SSLError as e:
-                logger.error('Failed to decode certificate %s: %r', certfile, e)
-            else:
-                try:
-                    return crt.get('serialNumber'), float(ssl.cert_time_to_seconds(crt.get('notAfter')))
-                except (TypeError, ValueError) as e:
-                    logger.error('Failed to get expiry from certificate %s: %r', certfile, e)
-                    return crt.get('serialNumber'), None
-        return None, None
+                expiry = ssl.cert_time_to_seconds(not_after)
+            except ValueError as e:
+                logger.error('Failed to get expiry from certificate %s: %r', certfile, e)
+        else:
+            logger.error('Certificate %s does not have the "notAfter" field', certfile)
+        return serial_number, expiry
 
     def reload_local_certificate(self) -> Optional[bool]:
         """Reload the SSL certificate used by the REST API.
@@ -1941,7 +1961,7 @@ class RestApiServer(ThreadingMixIn, HTTPServer):
             otherwise.
         """
         if self.__protocol == 'https':
-            on_disk_cert_serial_number = self.parse_certificate()[0]
+            on_disk_cert_serial_number, self.__ssl_not_after = self.parse_certificate()
             if on_disk_cert_serial_number != self.__ssl_serial_number:
                 self._received_new_cert = True
                 self.__ssl_serial_number = on_disk_cert_serial_number

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -625,6 +625,10 @@ class RestApiHandler(BaseHTTPRequestHandler):
             * ``patroni_pending_restart``: ``1`` if this PostgreSQL node is pending a restart, else ``0``;
             * ``patroni_is_paused``: ``1`` if Patroni is in maintenance node, else ``0``.
 
+        If the REST API is running in HTTPS mode the response will also have the following:
+
+            * ``patroni_restapi_certificate_expiry``: epoch timestamp when the REST API certificate expires.
+
         For PostgreSQL v9.6+ the response will also have the following:
 
             * ``patroni_postgres_streaming``: 1 if Postgres is streaming from another node, else ``0``;
@@ -769,6 +773,12 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# HELP patroni_failover_priority Failover priority of this node.")
         metrics.append("# TYPE patroni_failover_priority gauge")
         metrics.append("patroni_failover_priority{0} {1}".format(labels, patroni.failover_priority))
+
+        if self.server._ssl_not_after is not None:
+            metrics.append("# HELP patroni_restapi_certificate_expiry Epoch timestamp when the REST API"
+                           " certificate expires.")
+            metrics.append("# TYPE patroni_restapi_certificate_expiry gauge")
+            metrics.append("patroni_restapi_certificate_expiry{0} {1}".format(labels, self.server._ssl_not_after))
 
         self.write_response(200, '\n'.join(metrics) + '\n', content_type='text/plain')
 
@@ -1530,6 +1540,7 @@ class RestApiServer(ThreadingMixIn, HTTPServer):
         self._executor = PatroniThreadPoolExecutor(max_workers=thread_pool_size + 1, thread_name_prefix='RestAPI')
         self.__ssl_options: Dict[str, Any] = {}
         self.__ssl_serial_number = None
+        self._ssl_not_after: Optional[float] = None
         self._received_new_cert = False
         self.reload_config(config)
         self.daemon = True
@@ -1802,6 +1813,7 @@ class RestApiServer(ThreadingMixIn, HTTPServer):
         # wrap socket with ssl if 'certfile' is defined in a config.yaml
         # Sometime it's also needed to pass reference to a 'keyfile'.
         self.__protocol = 'https' if ssl_options.get('certfile') else 'http'
+        self._ssl_not_after = None
         if self.__protocol == 'https':
             import ssl
             ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH, cafile=ssl_options.get('cafile'))
@@ -1816,7 +1828,7 @@ class RestApiServer(ThreadingMixIn, HTTPServer):
                     ctx.verify_mode = modes[verify_client]
                 else:
                     logger.error('Bad value in the "restapi.verify_client": %s', verify_client)
-            self.__ssl_serial_number = self.get_certificate_serial_number()
+            self.__ssl_serial_number, self._ssl_not_after = self.parse_certificate()
             self.socket = ctx.wrap_socket(self.socket, server_side=True, do_handshake_on_connect=False)
         if reloading_config:
             self.start()
@@ -1901,19 +1913,26 @@ class RestApiServer(ThreadingMixIn, HTTPServer):
                 logger.debug('Failed to shutdown SSL connection: %r', e)
         super(RestApiServer, self).shutdown_request(request)
 
-    def get_certificate_serial_number(self) -> Optional[str]:
-        """Get serial number of the certificate used by the REST API.
+    def parse_certificate(self) -> Tuple[Optional[str], Optional[float]]:
+        """Parse the certificate used by the REST API.
 
-        :returns: serial number of the certificate configured through ``restapi.certfile`` setting.
+        :returns: serial number of the certificate configured through ``restapi.certfile`` setting and the
+            epoch timestamp when it expires.
         """
         certfile: Optional[str] = self.__ssl_options.get('certfile')
         if certfile:
             import ssl
             try:
                 crt = cast(Dict[str, Any], ssl._ssl._test_decode_cert(certfile))  # pyright: ignore
-                return crt.get('serialNumber')
             except ssl.SSLError as e:
-                logger.error('Failed to get serial number from certificate %s: %r', self.__ssl_options['certfile'], e)
+                logger.error('Failed to decode certificate %s: %r', certfile, e)
+            else:
+                try:
+                    return crt.get('serialNumber'), float(ssl.cert_time_to_seconds(crt.get('notAfter')))
+                except (TypeError, ValueError) as e:
+                    logger.error('Failed to get expiry from certificate %s: %r', certfile, e)
+                    return crt.get('serialNumber'), None
+        return None, None
 
     def reload_local_certificate(self) -> Optional[bool]:
         """Reload the SSL certificate used by the REST API.
@@ -1922,7 +1941,7 @@ class RestApiServer(ThreadingMixIn, HTTPServer):
             otherwise.
         """
         if self.__protocol == 'https':
-            on_disk_cert_serial_number = self.get_certificate_serial_number()
+            on_disk_cert_serial_number = self.parse_certificate()[0]
             if on_disk_cert_serial_number != self.__ssl_serial_number:
                 self._received_new_cert = True
                 self.__ssl_serial_number = on_disk_cert_serial_number

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -447,7 +447,7 @@ class TestRestApiHandler(unittest.TestCase):
     def test_do_GET_metrics_certificate_expiry(self):
         with patch.object(RestApiHandler, 'write_response') as response_mock:
             MockRestApiServer(RestApiHandler, 'GET /metrics')
-            self.assertIn('patroni_restapi_certificate_expiry{scope="dummy",name="test"} 1786828238.0',
+            self.assertIn('patroni_restapi_certificate_expiry{scope="dummy",name="test"} 1786828238',
                           response_mock.call_args[0][1])
 
         with patch.object(RestApiHandler, 'write_response') as response_mock:
@@ -877,6 +877,19 @@ class TestRestApiServer(unittest.TestCase):
     def test_reload_local_certificate(self):
         self.assertTrue(self.srv.reload_local_certificate())
 
+    def test_reload_local_certificate_updates_expiry(self):
+        with patch.object(RestApiServer, '_RestApiServer__ssl_options', {'certfile': 'foo.crt'}, create=True):
+            with patch('ssl._ssl._test_decode_cert',
+                       Mock(return_value={'serialNumber': 'FF', 'notAfter': 'Aug 15 21:10:38 2026 GMT'})):
+                self.assertTrue(self.srv.reload_local_certificate())
+                self.assertEqual(self.srv.ssl_not_after, 1786828238)
+
+            # the expiry must follow the certificate on disk even when its serial number did not change
+            with patch('ssl._ssl._test_decode_cert',
+                       Mock(return_value={'serialNumber': 'FF', 'notAfter': 'Aug 15 21:10:38 2027 GMT'})):
+                self.assertIsNone(self.srv.reload_local_certificate())
+                self.assertEqual(self.srv.ssl_not_after, 1818364238)
+
     def test_parse_certificate(self):
         self.assertEqual(self.srv.parse_certificate(), (None, None))
 
@@ -886,7 +899,7 @@ class TestRestApiServer(unittest.TestCase):
         with patch.object(RestApiServer, '_RestApiServer__ssl_options', {'certfile': 'foo.crt'}, create=True):
             with patch('ssl._ssl._test_decode_cert',
                        Mock(return_value={'serialNumber': 'FF', 'notAfter': 'Aug 15 21:10:38 2026 GMT'})):
-                self.assertEqual(self.srv.parse_certificate(), ('FF', 1786828238.0))
+                self.assertEqual(self.srv.parse_certificate(), ('FF', 1786828238))
 
             with patch('ssl._ssl._test_decode_cert', Mock(return_value={'serialNumber': 'FF', 'notAfter': 'bad'})):
                 self.assertEqual(self.srv.parse_certificate(), ('FF', None))
@@ -901,10 +914,10 @@ class TestRestApiServer(unittest.TestCase):
     def test_certificate_expiry_is_reset_when_switching_to_http(self):
         with patch.object(MockRestApiServer, 'server_close', Mock()):
             self.srv.reload_config({'listen': ':8008', 'certfile': 'a'})
-            self.assertEqual(self.srv._ssl_not_after, 1786828238.0)
+            self.assertEqual(self.srv.ssl_not_after, 1786828238)
 
             self.srv.reload_config({'listen': ':8008'})
-            self.assertIsNone(self.srv._ssl_not_after)
+            self.assertIsNone(self.srv.ssl_not_after)
 
     def test_query(self):
         with patch.object(MockConnection, 'get', Mock(side_effect=OperationalError)):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -442,6 +442,19 @@ class TestRestApiHandler(unittest.TestCase):
         type(mock_dcs).failsafe = PropertyMock(return_value=None)
         self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /metrics'))
 
+    @patch.object(MockPatroni, 'dcs', Mock())
+    @patch('ssl._ssl._test_decode_cert', Mock(return_value={'notAfter': 'Aug 15 21:10:38 2026 GMT'}))
+    def test_do_GET_metrics_certificate_expiry(self):
+        with patch.object(RestApiHandler, 'write_response') as response_mock:
+            MockRestApiServer(RestApiHandler, 'GET /metrics')
+            self.assertIn('patroni_restapi_certificate_expiry{scope="dummy",name="test"} 1786828238.0',
+                          response_mock.call_args[0][1])
+
+        with patch.object(RestApiHandler, 'write_response') as response_mock:
+            MockRestApiServer(RestApiHandler, 'GET /metrics',
+                              {'listen': '127.0.0.1:8008', 'auth': 'test:test'})
+            self.assertNotIn('patroni_restapi_certificate_expiry', response_mock.call_args[0][1])
+
     @patch.object(MockPatroni, 'dcs')
     def test_do_PATCH_config(self, mock_dcs):
         config = {'postgresql': {'use_slots': False, 'use_pg_rewind': True, 'parameters': {'wal_level': 'logical'}}}
@@ -864,8 +877,34 @@ class TestRestApiServer(unittest.TestCase):
     def test_reload_local_certificate(self):
         self.assertTrue(self.srv.reload_local_certificate())
 
-    def test_get_certificate_serial_number(self):
-        self.assertIsNone(self.srv.get_certificate_serial_number())
+    def test_parse_certificate(self):
+        self.assertEqual(self.srv.parse_certificate(), (None, None))
+
+        with patch.object(RestApiServer, '_RestApiServer__ssl_options', {}, create=True):
+            self.assertEqual(self.srv.parse_certificate(), (None, None))
+
+        with patch.object(RestApiServer, '_RestApiServer__ssl_options', {'certfile': 'foo.crt'}, create=True):
+            with patch('ssl._ssl._test_decode_cert',
+                       Mock(return_value={'serialNumber': 'FF', 'notAfter': 'Aug 15 21:10:38 2026 GMT'})):
+                self.assertEqual(self.srv.parse_certificate(), ('FF', 1786828238.0))
+
+            with patch('ssl._ssl._test_decode_cert', Mock(return_value={'serialNumber': 'FF', 'notAfter': 'bad'})):
+                self.assertEqual(self.srv.parse_certificate(), ('FF', None))
+
+            with patch('ssl._ssl._test_decode_cert', Mock(return_value={})):
+                self.assertEqual(self.srv.parse_certificate(), (None, None))
+
+    @patch.object(HTTPServer, '__init__', Mock())
+    @patch('ssl.SSLContext.load_cert_chain', Mock())
+    @patch('ssl.SSLContext.wrap_socket', Mock(return_value=0))
+    @patch('ssl._ssl._test_decode_cert', Mock(return_value={'notAfter': 'Aug 15 21:10:38 2026 GMT'}))
+    def test_certificate_expiry_is_reset_when_switching_to_http(self):
+        with patch.object(MockRestApiServer, 'server_close', Mock()):
+            self.srv.reload_config({'listen': ':8008', 'certfile': 'a'})
+            self.assertEqual(self.srv._ssl_not_after, 1786828238.0)
+
+            self.srv.reload_config({'listen': ':8008'})
+            self.assertIsNone(self.srv._ssl_not_after)
 
     def test_query(self):
         with patch.object(MockConnection, 'get', Mock(side_effect=OperationalError)):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -878,7 +878,7 @@ class TestRestApiServer(unittest.TestCase):
         self.assertTrue(self.srv.reload_local_certificate())
 
     def test_reload_local_certificate_updates_expiry(self):
-        with patch.object(RestApiServer, '_RestApiServer__ssl_options', {'certfile': 'foo.crt'}, create=True):
+        with patch.object(self.srv, '_RestApiServer__ssl_options', {'certfile': 'foo.crt'}):
             with patch('ssl._ssl._test_decode_cert',
                        Mock(return_value={'serialNumber': 'FF', 'notAfter': 'Aug 15 21:10:38 2026 GMT'})):
                 self.assertTrue(self.srv.reload_local_certificate())
@@ -891,12 +891,13 @@ class TestRestApiServer(unittest.TestCase):
                 self.assertEqual(self.srv.ssl_not_after, 1818364238)
 
     def test_parse_certificate(self):
+        # the certificate configured in setUp() does not exist, therefore it can not be decoded
         self.assertEqual(self.srv.parse_certificate(), (None, None))
 
-        with patch.object(RestApiServer, '_RestApiServer__ssl_options', {}, create=True):
+        with patch.object(self.srv, '_RestApiServer__ssl_options', {}):
             self.assertEqual(self.srv.parse_certificate(), (None, None))
 
-        with patch.object(RestApiServer, '_RestApiServer__ssl_options', {'certfile': 'foo.crt'}, create=True):
+        with patch.object(self.srv, '_RestApiServer__ssl_options', {'certfile': 'foo.crt'}):
             with patch('ssl._ssl._test_decode_cert',
                        Mock(return_value={'serialNumber': 'FF', 'notAfter': 'Aug 15 21:10:38 2026 GMT'})):
                 self.assertEqual(self.srv.parse_certificate(), ('FF', 1786828238))


### PR DESCRIPTION
in addition to #3695 a proposal to have an expiry date for the patroni API cert exposed in metrics so it can be monitored. 