### PR TITLE
Report 'promoted' role in patronictl list and /cluster endpoint

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -479,6 +479,7 @@ Cluster status endpoints
       }
     }
 
+  The ``role`` of a member is one of ``leader``, ``promoted``, ``standby_leader``, ``sync_standby``, ``quorum_standby``, or ``replica``. The ``promoted`` role is reported for a member that already holds the leader lock while PostgreSQL promotion has not completed yet, i.e. PostgreSQL is still running in recovery and therefore is read-only.
 
 - The ``GET /history`` endpoint provides a view on the history of cluster switchovers/failovers. The format is very similar to the content of history files in the ``pg_wal`` directory. The only difference is the timestamp field showing when the new timeline was created.
 

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -1593,7 +1593,8 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
         * ``Site``: site of the Patroni node, as per ``site`` configuration;
         * ``Member``: name of the Patroni node, as per ``name`` configuration;
         * ``Host``: hostname (or IP) and port, as per ``postgresql.listen`` configuration;
-        * ``Role``: ``Leader``, ``Standby Leader``, ``Sync Standby`` or ``Replica``;
+        * ``Role``: ``Leader``, ``Promoted`` (holds the leader lock but promotion has not completed yet),
+          ``Standby Leader``, ``Sync Standby`` or ``Replica``;
         * ``State``: one of :class:`~patroni.postgresql.misc.PostgresqlState`;
         * ``TL``: current timeline in Postgres;
         * ``Receive LSN``: last received LSN (``pg_catalog.pg_last_(xlog|wal)_receive_(location|lsn)()``);

--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -922,7 +922,8 @@ def cluster_as_json(cluster: 'Cluster') -> Dict[str, Any]:
         * ``members``: list of members in the cluster. Each value is a :class:`dict` that may have the following keys:
 
             * ``name``: the name of the host (unique in the cluster). The ``members`` list is sorted by this key;
-            * ``role``: ``leader``, ``standby_leader``, ``sync_standby``, ``quorum_standby``, or ``replica``;
+            * ``role``: ``leader``, ``promoted`` (holds the leader lock but promotion has not completed yet),
+                ``standby_leader``, ``sync_standby``, ``quorum_standby``, or ``replica``;
             * ``state``: one of :class:`~patroni.postgresql.misc.PostgresqlState`;
             * ``api_url``: REST API URL based on ``restapi->connect_address`` configuration;
             * ``host``: PostgreSQL host based on ``postgresql->connect_address``;
@@ -948,7 +949,7 @@ def cluster_as_json(cluster: 'Cluster') -> Dict[str, Any]:
             * ``to``: name of the member to be promoted.
     """
     from . import global_config
-    from .postgresql.misc import format_lsn
+    from .postgresql.misc import format_lsn, PostgresqlRole
 
     config = global_config.from_cluster(cluster)
     leader_name = cluster.leader.name if cluster.leader else None
@@ -958,7 +959,13 @@ def cluster_as_json(cluster: 'Cluster') -> Dict[str, Any]:
     sync_role = 'quorum_standby' if config.is_quorum_commit_mode else 'sync_standby'
     for m in cluster.members:
         if m.name == leader_name:
-            role = 'standby_leader' if config.is_standby_cluster else 'leader'
+            if config.is_standby_cluster:
+                role = 'standby_leader'
+            elif m.data.get('role') == PostgresqlRole.PROMOTED:
+                # the member holds the leader lock, but Postgres promotion has not completed yet (still in recovery)
+                role = 'promoted'
+            else:
+                role = 'leader'
         elif config.is_synchronous_mode and cluster.sync.matches(m.name):
             role = sync_role
         else:

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -155,6 +155,13 @@ class TestCtl(unittest.TestCase):
                 self.assertIsNone(output_members(cluster, name='abc'))
                 self.assertIn('to: site dc2', mock_echo.call_args_list[1][0][0])
 
+                # the lock holder is shown as 'Promoted' while Postgres promotion has not completed yet
+                mock_echo.reset_mock()
+                cluster = get_cluster_initialized_with_leader()
+                cluster.members[0].data['role'] = PostgresqlRole.PROMOTED
+                self.assertIsNone(output_members(cluster, name='abc', fmt='tsv'))
+                self.assertIn('\tPromoted\t', mock_echo.call_args_list[1][0][0])
+
     @patch('patroni.dcs.AbstractDCS.set_failover_value', Mock())
     def test_switchover(self):
         # Confirm


### PR DESCRIPTION
## What problem does this solve?

Fixes the visibility half of #3603 (the log warning is sent as a separate PR).

After a failover, a node can win the leader lock and receive the promote
request, yet Postgres never finishes the promotion because
`restore_command` hangs (in my case: a stalled NFS mount behind
pgBackRest's `archive-get`). Postgres keeps running as a standby,
`pg_is_in_recovery()` stays `true`, and the cluster has no writable node.

Meanwhile `patronictl list` and the `/cluster` REST endpoint show a
healthy `Leader` / `role: leader`, because `cluster_as_json()` hardcodes
the role for whichever member holds the lock. The DCS itself tells the
truth: the member key keeps `"role": "promoted"` until promotion
completes. That signal was being dropped at the presentation layer.

## What does this PR do?

In `cluster_as_json()` (`patroni/utils.py`), when the lock holder's
member key still reports `role: promoted`, pass it through instead of
hardcoding `leader`:

- `patronictl list` shows `Promoted` in the Role column while promotion
  has not completed, reverting to `Leader` once it does.
- `GET /cluster` returns `"role": "promoted"` for that member.

Side effect (arguably a second fix): since `replication_state` is only
suppressed for role `leader`, the State column for a stuck member now
shows the actual state (e.g. `in archive recovery`) instead of
`running` — which is exactly what the operator needs to see to find the
hanging `restore_command`.

During a normal failover the `Promoted` role is visible for at most a
cycle or two, same as the `promoted` role in the DCS member key today.

Standby clusters are unaffected (`standby_leader` takes precedence, as
before). All other surfaces (`/patroni`, `/primary`, `/metrics`, the DCS
member key) already report this state correctly and are untouched.

## Repro / verification

Original repro from the issue: 2-node cluster with pgBackRest over NFS,
block NFS return traffic on the replica with iptables, `kill -9` Patroni
on the leader. The replica takes the lock, promote is issued,
`archive-get 00000002.history` hangs forever, `pg_is_in_recovery()`
stays true.

Verified live against this branch (PG 18.4, etcd v3.5, 2-node local
cluster): the hanging `restore_command` was simulated with a script that
sleeps forever on timeline-history requests, then Patroni was `kill -9`'d
on the leader. While node2 was stuck (`pg_is_in_recovery()` = `t`):

```
$ patronictl list
+ Cluster: repro3603 (7675475385382874329) ----------------+----+-------------+-----+------------+-----+
| Member | Host           | Role     | State               | TL | Receive LSN | Lag | Replay LSN | Lag |
+--------+----------------+----------+---------------------+----+-------------+-----+------------+-----+
| node2  | 127.0.0.1:5434 | Promoted | in archive recovery |  1 |             |     |            |     |
+--------+----------------+----------+---------------------+----+-------------+-----+------------+-----+

$ curl -s http://127.0.0.1:8009/cluster
{"members": [{"name": "node2", "role": "promoted", "state": "in archive recovery", ...}], "scope": "repro3603"}
```

Once the restore_command hang was released, promotion completed and both
surfaces reverted on the next loop:

```
$ patronictl list
| node2  | 127.0.0.1:5434 | Leader | running |  2 | ...

$ curl -s http://127.0.0.1:8009/cluster
{"members": [{"name": "node2", "role": "leader", "state": "running", ...}], "scope": "repro3603"}
```

## Tests

Extended `test_output_members` in `tests/test_ctl.py`: a cluster whose
lock holder has `role: promoted` in its member data renders `Promoted`
in the Role column. Full suite passes (706 tests). Docs updated:
`docs/rest_api.rst` role enumeration, `cluster_as_json` and
`output_members` docstrings.