### PR TITLE
Log a warning while the leader's Postgres is still in recovery

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1217,6 +1217,10 @@ class Ha(object):
             self.state_handler.mpp_handler.sync_meta_data(self.cluster)
             return message
         elif self.state_handler.role in (PostgresqlRole.PRIMARY, PostgresqlRole.PROMOTED):
+            # We hold the leader lock and promotion was already triggered, but Postgres is still
+            # running as a standby (in recovery), e.g. because a hanging restore_command blocks
+            # promotion from completing. The cluster has no writable node while this persists.
+            logger.warning('Postgres is still running as a standby (in recovery), promotion has not completed')
             self.process_sync_replication()
             return message
         else:

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1217,12 +1217,8 @@ class Ha(object):
             self.state_handler.mpp_handler.sync_meta_data(self.cluster)
             return message
         elif self.state_handler.role in (PostgresqlRole.PRIMARY, PostgresqlRole.PROMOTED):
-            # We hold the leader lock and promotion was already triggered, but Postgres is still
-            # running as a standby (in recovery), e.g. because a hanging restore_command blocks
-            # promotion from completing. The cluster has no writable node while this persists.
-            logger.warning('Postgres is still running as a standby (in recovery), promotion has not completed')
             self.process_sync_replication()
-            return message
+            return message + ', in recovery (promotion has not completed)'
         else:
             if not self.process_sync_replication_prepromote():
                 # Somebody else updated sync state, it may be due to us losing the lock. To be safe,

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -441,6 +441,27 @@ class TestHa(PostgresInit):
         self.p.set_role(PostgresqlRole.PRIMARY)
         self.assertEqual(self.ha.run_cycle(), 'no action. I am (postgresql0), the leader with the lock')
 
+    @patch.object(Cluster, 'is_unlocked', Mock(return_value=False))
+    @patch('patroni.ha.logger.warning')
+    def test_warning_when_promotion_not_completed(self, mock_warning):
+        in_recovery_warning = 'Postgres is still running as a standby (in recovery), promotion has not completed'
+        self.ha.has_lock = true
+        self.p.is_primary = false
+        self.p.set_role(PostgresqlRole.PROMOTED)
+        self.assertEqual(self.ha.run_cycle(), 'no action. I am (postgresql0), the leader with the lock')
+        mock_warning.assert_any_call(in_recovery_warning)
+
+        # the warning is repeated on every HA loop while promotion has not completed
+        mock_warning.reset_mock()
+        self.assertEqual(self.ha.run_cycle(), 'no action. I am (postgresql0), the leader with the lock')
+        mock_warning.assert_any_call(in_recovery_warning)
+
+        # no warning once Postgres has left recovery
+        mock_warning.reset_mock()
+        self.p.is_primary = true
+        self.assertEqual(self.ha.run_cycle(), 'no action. I am (postgresql0), the leader with the lock')
+        self.assertNotIn(in_recovery_warning, [call.args[0] for call in mock_warning.call_args_list])
+
     def test_demote_after_failing_to_obtain_lock(self):
         self.ha.acquire_lock = false
         self.assertEqual(self.ha.run_cycle(), 'demoted self after trying and failing to obtain lock')

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -439,28 +439,8 @@ class TestHa(PostgresInit):
         self.ha.has_lock = true
         self.p.is_primary = false
         self.p.set_role(PostgresqlRole.PRIMARY)
-        self.assertEqual(self.ha.run_cycle(), 'no action. I am (postgresql0), the leader with the lock')
-
-    @patch.object(Cluster, 'is_unlocked', Mock(return_value=False))
-    @patch('patroni.ha.logger.warning')
-    def test_warning_when_promotion_not_completed(self, mock_warning):
-        in_recovery_warning = 'Postgres is still running as a standby (in recovery), promotion has not completed'
-        self.ha.has_lock = true
-        self.p.is_primary = false
-        self.p.set_role(PostgresqlRole.PROMOTED)
-        self.assertEqual(self.ha.run_cycle(), 'no action. I am (postgresql0), the leader with the lock')
-        mock_warning.assert_any_call(in_recovery_warning)
-
-        # the warning is repeated on every HA loop while promotion has not completed
-        mock_warning.reset_mock()
-        self.assertEqual(self.ha.run_cycle(), 'no action. I am (postgresql0), the leader with the lock')
-        mock_warning.assert_any_call(in_recovery_warning)
-
-        # no warning once Postgres has left recovery
-        mock_warning.reset_mock()
-        self.p.is_primary = true
-        self.assertEqual(self.ha.run_cycle(), 'no action. I am (postgresql0), the leader with the lock')
-        self.assertNotIn(in_recovery_warning, [call.args[0] for call in mock_warning.call_args_list])
+        self.assertEqual(self.ha.run_cycle(), 'no action. I am (postgresql0), the leader with the lock'
+                                              + ', in recovery (promotion has not completed)')
 
     def test_demote_after_failing_to_obtain_lock(self):
         self.ha.acquire_lock = false


### PR DESCRIPTION
## What problem does this solve?

Fixes the logging half of #3603.

After a failover, a node can win the leader lock and receive the promote
request, yet Postgres never finishes the promotion because
`restore_command` hangs. Postgres keeps running as a standby,
`pg_is_in_recovery()` stays `true`, and the cluster has no writable node.

Meanwhile the Patroni log on that node shows only the healthy

```
INFO: no action. I am (node2), the leader with the lock
```

so there is no signal in the log that anything is wrong.

## What does this PR do?

While the lock-holding leader's Postgres has not completed promotion
(role is `promoted`/`primary` but `is_primary()` is still false), the
not-yet-primary branch of `Ha.enforce_primary_role()` now logs:

```
WARNING: Postgres is still running as a standby (in recovery), promotion has not completed
```

The warning is emitted on every HA loop, alongside the existing
"no action" line, matching that line's own repetition. During a normal
promotion it appears at most for a cycle or two and is harmless; if it
persists, it is the visible signal that the cluster is stuck read-only.

No behavior change beyond the log line.

## Repro / verification

Verified live against this branch (PG 18.4, etcd v3.5, 2-node local
cluster, `loop_wait: 5`): the hanging `restore_command` was simulated
with a script that sleeps forever on timeline-history requests, then
Patroni was `kill -9`'d on the leader. node2's Patroni log:

```
2026-08-18 17:45:36,649 INFO: promoted self to leader by acquiring session lock
2026-08-18 17:45:36,653 INFO: updated leader lock during promote
server promoting
2026-08-18 17:45:37.143 -03 [68919] LOG:  received promote request
2026-08-18 17:45:37.143 -03 [68968] FATAL:  terminating walreceiver process due to administrator command
2026-08-18 17:45:46,655 INFO: Lock owner: node2; I am node2
2026-08-18 17:45:46,665 WARNING: Postgres is still running as a standby (in recovery), promotion has not completed
2026-08-18 17:45:46,666 INFO: no action. I am (node2), the leader with the lock
2026-08-18 17:45:51,655 INFO: Lock owner: node2; I am node2
2026-08-18 17:45:51,665 WARNING: Postgres is still running as a standby (in recovery), promotion has not completed
2026-08-18 17:45:51,665 INFO: no action. I am (node2), the leader with the lock
```

`pg_is_in_recovery()` returned `t` throughout. Once the restore_command
hang was released, promotion completed (`selected new timeline ID: 2`)
and the log went back to the plain "no action" line with no WARNING.

## Tests

`test_warning_when_promotion_not_completed` in `tests/test_ha.py`:
asserts the warning fires while stuck, repeats on the next loop, and
stops once Postgres leaves recovery.