### PR TITLE
Add restapi.authentication.mode for staged auth rollout

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -28,6 +28,8 @@ From the point of view of security, REST API contains safe (``GET`` requests, on
 
 The unsafe endpoints can be protected with HTTP basic-auth by setting the ``restapi.authentication.username`` and ``restapi.authentication.password`` parameters. There is no way to protect the safe endpoints without enabling TLS.
 
+By default, setting ``restapi.authentication.username`` and ``restapi.authentication.password`` enforces authentication on the unsafe endpoints immediately. On a running cluster this is effectively all-or-nothing: while some nodes require credentials and others do not, the REST API calls members make to each other during leader races and failsafe checks can fail. The ``restapi.authentication.mode`` parameter allows enabling authentication gradually. ``disabled`` (the default) does not enforce authentication. ``permissive`` accepts both authenticated and unauthenticated requests and logs the unauthenticated ones; it is intended only as a transition state during a rolling upgrade. ``strict`` requires valid credentials. Roll every node to ``permissive`` first, then to ``strict`` once all nodes have credentials configured, so authentication can be enabled without a cluster-wide flag-day cutover.
+
 When TLS for the REST API is enabled and a PKI is established, mutual authentication of the API server and API client is possible for all endpoints.
 
 The ``restapi`` section parameters enable TLS client authentication to the server. Depending on the value of the ``verify_client`` parameter, the API server requires a successful client certificate verification for both safe and unsafe API calls (``verify_client: required``), or only for unsafe API calls (``verify_client: optional``), or for no API calls (``verify_client: none``).

--- a/docs/yaml_configuration.rst
+++ b/docs/yaml_configuration.rst
@@ -373,6 +373,7 @@ REST API
 
       -  **username**: Basic-auth username to protect unsafe REST API endpoints.
       -  **password**: Basic-auth password to protect unsafe REST API endpoints.
+      -  **mode**: (optional): ``disabled`` (default), ``permissive`` or ``strict``. Controls how Basic-auth is enforced on protected REST API endpoints. ``disabled`` preserves the historical behavior. ``strict`` requires valid credentials. ``permissive`` accepts both authenticated and unauthenticated requests and logs the unauthenticated ones, and is intended only as a transition state while performing a rolling upgrade from ``disabled`` to ``strict``. ``permissive`` and ``strict`` require ``username`` and ``password`` to be set.
    -  **certfile**: (optional): Specifies the file with the certificate in the PEM format. If the certfile is not specified or is left empty, the API server will work without SSL.
    -  **keyfile**: (optional): Specifies the file with the secret key in the PEM format.
    -  **keyfile\_password**: (optional): Specifies a password for decrypting the keyfile.

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -20,7 +20,8 @@ import traceback
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from ipaddress import ip_address, ip_network, IPv4Network, IPv6Network
 from socketserver import ThreadingMixIn
-from typing import Any, Callable, cast, Dict, Iterator, List, Optional, Tuple, TYPE_CHECKING, Union
+from threading import Lock
+from typing import Any, Callable, cast, Dict, Iterator, List, NamedTuple, Optional, Tuple, TYPE_CHECKING, Union
 from urllib.parse import parse_qs, urlparse
 
 import dateutil.parser
@@ -35,6 +36,18 @@ from .utils import cluster_as_json, deep_compare, enable_keepalive, parse_bool, 
     parse_int, patch_config, Retry, RetryFailedError, split_host_port, tzutc, uri
 
 logger = logging.getLogger(__name__)
+
+_AUTH_MODE_DISABLED = 'disabled'
+_AUTH_MODE_PERMISSIVE = 'permissive'
+_AUTH_MODE_STRICT = 'strict'
+_AUTH_MODES = (_AUTH_MODE_DISABLED, _AUTH_MODE_PERMISSIVE, _AUTH_MODE_STRICT)
+
+
+class _RestApiAuthSnapshot(NamedTuple):
+    """Immutable authentication state swapped atomically during configuration reload."""
+
+    key: Optional[bytes]
+    mode: str
 
 
 def check_access(*args: Any, **kwargs: Any) -> Callable[..., Any]:
@@ -577,6 +590,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
         cluster = self.server.patroni.dcs.cluster or self.server.patroni.dcs.get_cluster()
         self._write_json_response(200, cluster.history and cluster.history.lines or [])
 
+    @check_access
     def do_GET_config(self) -> None:
         """Handle a ``GET`` request to ``/config`` path.
 
@@ -1295,7 +1309,6 @@ class RestApiHandler(BaseHTTPRequestHandler):
         """
         self.do_POST_failover(action='switchover')
 
-    @check_access
     def do_POST_citus(self) -> None:
         """Handle a ``POST`` request to ``/citus`` path.
 
@@ -1304,6 +1317,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
         """
         self.do_POST_mpp()
 
+    @check_access
     def do_POST_mpp(self) -> None:
         """Handle a ``POST`` request to ``/mpp`` path.
 
@@ -1515,6 +1529,10 @@ class RestApiServer(ThreadingMixIn, HTTPServer):
     An asynchronous thread-pool-based HTTP server.
     """
 
+    _last_permissive_warning_at: Optional[float] = None
+    _permissive_warning_lock = Lock()
+    _PERMISSIVE_WARNING_INTERVAL_SECONDS = 60.0
+
     def __init__(self, patroni: Patroni, config: Dict[str, Any]) -> None:
         """Establish patroni configuration for the REST API daemon.
 
@@ -1524,7 +1542,7 @@ class RestApiServer(ThreadingMixIn, HTTPServer):
         :param config: ``restapi`` section of Patroni configuration.
         """
         self.connection_string: str
-        self.__auth_key = None
+        self.__auth = _RestApiAuthSnapshot(None, _AUTH_MODE_DISABLED)
         self.__allowlist_include_members: Optional[bool] = None
         self.__allowlist: Tuple[Union[IPv4Network, IPv6Network], ...] = ()
         self.http_extra_headers: Dict[str, str] = {}
@@ -1618,6 +1636,11 @@ class RestApiServer(ThreadingMixIn, HTTPServer):
             flags = fcntl.fcntl(fd, fcntl.F_GETFD)
             fcntl.fcntl(fd, fcntl.F_SETFD, flags | fcntl.FD_CLOEXEC)
 
+    @staticmethod
+    def _check_basic_auth_key(auth_key: bytes, key: str) -> bool:
+        """Compare a configured Basic authentication key with a request key in constant time."""
+        return hmac.compare_digest(auth_key, key.encode('utf-8'))
+
     def check_basic_auth_key(self, key: str) -> bool:
         """Check if *key* matches the password configured for the REST API.
 
@@ -1625,23 +1648,76 @@ class RestApiServer(ThreadingMixIn, HTTPServer):
 
         :returns: ``True`` if *key* matches the password configured for the REST API.
         """
-        # pyright -- ``__auth_key`` was already checked through the caller method (:func:`check_auth_header`).
-        if TYPE_CHECKING:  # pragma: no cover
-            assert self.__auth_key is not None
-        return hmac.compare_digest(self.__auth_key, key.encode('utf-8'))
+        auth_key = self.__auth.key
+        return auth_key is not None and self._check_basic_auth_key(auth_key, key)
+
+    @staticmethod
+    def _build_auth_snapshot(config: Dict[str, Any]) -> _RestApiAuthSnapshot:
+        """Resolve credentials and mode into one immutable authentication state."""
+        auth_config_value: Any = config.get('authentication')
+        if auth_config_value is None:
+            auth_config_value = {}
+        if not isinstance(auth_config_value, dict):
+            raise ValueError('restapi.authentication must be a mapping')
+        auth_config = cast(Dict[str, Any], auth_config_value)
+
+        mode_is_configured = 'mode' in auth_config
+        mode = auth_config.get('mode')
+        if mode_is_configured and mode not in _AUTH_MODES:
+            raise ValueError('restapi.authentication.mode must be one of {0}, got {1!r}'
+                             .format(_AUTH_MODES, mode))
+
+        auth_string = config.get('auth')
+        if auth_string is not None and not isinstance(auth_string, str):
+            raise ValueError('restapi.auth must be a string')
+        if not auth_string:
+            username = auth_config.get('username')
+            password = auth_config.get('password')
+            if username and password:
+                if not isinstance(username, str) or not isinstance(password, str):
+                    raise ValueError('restapi.authentication username and password must be strings')
+                auth_string = '{0}:{1}'.format(username, password)
+
+        if not auth_string and mode in (_AUTH_MODE_PERMISSIVE, _AUTH_MODE_STRICT):
+            raise ValueError('restapi.authentication.mode={0} requires complete username and password credentials'
+                             .format(mode))
+        if not auth_string:
+            return _RestApiAuthSnapshot(None, _AUTH_MODE_DISABLED)
+
+        effective_mode = cast(str, mode) if mode_is_configured else _AUTH_MODE_STRICT
+        return _RestApiAuthSnapshot(base64.b64encode(auth_string.encode('utf-8')), effective_mode)
+
+    def _log_permissive_warning_throttled(self) -> None:
+        """Warn about anonymous permissive-mode access at most once per interval."""
+        now = time.monotonic()
+        with RestApiServer._permissive_warning_lock:
+            last_warning = RestApiServer._last_permissive_warning_at
+            if last_warning is not None and now - last_warning < self._PERMISSIVE_WARNING_INTERVAL_SECONDS:
+                return
+            RestApiServer._last_permissive_warning_at = now
+        logger.warning('REST API: unauthenticated request allowed '
+                       '(restapi.authentication.mode=permissive). Switch to strict once the rolling upgrade '
+                       'is complete.')
 
     def check_auth_header(self, auth_header: Optional[str]) -> Optional[str]:
-        """Validate HTTP Basic authorization header, if present.
+        """Validate an HTTP Basic authorization header against the current authentication snapshot.
 
         :param auth_header: value of ``Authorization`` HTTP header, if present, else ``None``.
 
         :returns: an error message if any issue is found, ``None`` otherwise.
         """
-        if self.__auth_key:
-            if auth_header is None:
-                return 'no auth header received'
-            if not auth_header.startswith('Basic ') or not self.check_basic_auth_key(auth_header[6:]):
-                return 'not authenticated'
+        auth = self.__auth
+        if auth.mode == _AUTH_MODE_DISABLED:
+            return None
+        if auth_header is None:
+            if auth.mode == _AUTH_MODE_PERMISSIVE:
+                self._log_permissive_warning_throttled()
+                return None
+            return 'no auth header received'
+        if not auth_header.startswith('Basic ') or auth.key is None \
+                or not self._check_basic_auth_key(auth.key, auth_header[6:]):
+            return 'not authenticated'
+        return None
 
     @staticmethod
     def __resolve_ips(host: str, port: int) -> Iterator[Union[IPv4Network, IPv6Network]]:
@@ -1968,6 +2044,8 @@ class RestApiServer(ThreadingMixIn, HTTPServer):
         if 'listen' not in config:  # changing config in runtime
             raise ValueError('Can not find "restapi.listen" config')
 
+        auth = self._build_auth_snapshot(config)
+
         self.__allowlist = tuple(self._build_allowlist(config.get('allowlist')))
         self.__allowlist_include_members = config.get('allowlist_include_members')
 
@@ -1983,7 +2061,7 @@ class RestApiServer(ThreadingMixIn, HTTPServer):
         if self.__listen != config['listen'] or self.__ssl_options != ssl_options or self._received_new_cert:
             self.__initialize(config['listen'], ssl_options)
 
-        self.__auth_key = base64.b64encode(config['auth'].encode('utf-8')) if 'auth' in config else None
+        self.__auth = auth
         # pyright -- ``__listen`` is initially created as ``None``, but right after that it is replaced with a string
         # through :func:`__initialize`.
         if TYPE_CHECKING:  # pragma: no cover

--- a/patroni/request.py
+++ b/patroni/request.py
@@ -1,7 +1,7 @@
 """Facilities for handling communication with Patroni's REST API."""
 import json
 
-from typing import Any, Dict, Optional, Union
+from typing import Any, cast, Dict, Optional, Union
 
 import urllib3
 
@@ -66,6 +66,19 @@ class PatroniRequest(object):
         """
         return config.get('restapi', {}).get(name)
 
+    @staticmethod
+    def _get_restapi_auth_from_authentication(config: Union[Config, Dict[str, Any]]) -> Optional[str]:
+        """Build a Basic authentication value from structured REST API credentials."""
+        authentication_value: Any = config.get('restapi', {}).get('authentication') or {}
+        if not isinstance(authentication_value, dict):
+            return None
+        authentication = cast(Dict[str, Any], authentication_value)
+        username = authentication.get('username')
+        password = authentication.get('password')
+        if isinstance(username, str) and username and isinstance(password, str) and password:
+            return '{0}:{1}'.format(username, password)
+        return None
+
     def _apply_pool_param(self, param: str, value: Any) -> None:
         """Configure *param* as *value* in the request manager.
 
@@ -112,7 +125,9 @@ class PatroniRequest(object):
         """
         # ``ctl -> auth`` is equivalent to ``ctl -> authentication -> username`` + ``:`` +
         # ``ctl -> authentication -> password``. And the same for ``restapi -> auth``
-        basic_auth = self._get_ctl_value(config, 'auth') or self._get_restapi_value(config, 'auth')
+        basic_auth = self._get_ctl_value(config, 'auth') \
+            or self._get_restapi_value(config, 'auth') \
+            or self._get_restapi_auth_from_authentication(config)
         self._pool.headers = urllib3.make_headers(basic_auth=basic_auth, user_agent=USER_AGENT)
         self._pool.connection_pool_kw['cert_reqs'] = 'CERT_REQUIRED'
 

--- a/patroni/validator.py
+++ b/patroni/validator.py
@@ -1111,6 +1111,8 @@ schema = Schema({
         "listen": validate_host_port_listen,
         "connect_address": validate_connect_address,
         Optional("authentication"): {
+            Optional("mode"): EnumValidator(
+                ('disabled', 'permissive', 'strict'), case_sensitive=True, raise_assert=True),
             "username": str,
             "password": str
         },

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,7 @@ import json
 import socket
 import unittest
 
+from concurrent.futures import ThreadPoolExecutor
 from http.server import HTTPServer
 from io import BytesIO as IO
 from unittest.mock import Mock, patch, PropertyMock
@@ -422,9 +423,16 @@ class TestRestApiHandler(unittest.TestCase):
     @patch.object(MockPatroni, 'dcs')
     def test_do_GET_config(self, mock_dcs):
         mock_dcs.cluster.config.data = {}
-        self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /config'))
+        self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /config' + self._authorization))
         mock_dcs.cluster.config = None
-        self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /config'))
+        self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /config' + self._authorization))
+
+    @patch.object(MockPatroni, 'dcs')
+    def test_protected_get_config_requires_auth(self, mock_dcs):
+        with patch.object(RestApiHandler, 'write_response', return_value=None) as response_mock:
+            MockRestApiServer(RestApiHandler, 'GET /config')
+            response_mock.assert_called_once_with(
+                401, 'no auth header received', headers={'WWW-Authenticate': 'Basic realm="MockPatroni"'})
 
     @patch.object(MockPatroni, 'dcs')
     def test_do_GET_metrics(self, mock_dcs):
@@ -777,6 +785,20 @@ class TestRestApiHandler(unittest.TestCase):
         MockRestApiServer(RestApiHandler, post + '0\n\n')
         MockRestApiServer(RestApiHandler, post + '14\n\n{"leader":"1"}')
 
+    def test_mpp_and_citus_require_auth(self):
+        for endpoint in ('mpp', 'citus'):
+            with self.subTest(endpoint=endpoint), \
+                    patch.object(RestApiHandler, 'write_response', return_value=None) as response_mock:
+                MockRestApiServer(RestApiHandler, 'POST /{0} HTTP/1.0'.format(endpoint))
+                response_mock.assert_called_once_with(
+                    401, 'no auth header received', headers={'WWW-Authenticate': 'Basic realm="MockPatroni"'})
+
+    def test_public_status_endpoint_does_not_check_access(self):
+        MockPatroni.dcs.cluster = get_cluster_initialized_without_leader()
+        with patch.object(RestApiServer, 'check_access') as check_access_mock:
+            MockRestApiServer(RestApiHandler, 'GET /health HTTP/1.0')
+            check_access_mock.assert_not_called()
+
 
 class TestRestApiServer(unittest.TestCase):
 
@@ -800,6 +822,117 @@ class TestRestApiServer(unittest.TestCase):
         with patch.object(socket.socket, 'setsockopt', Mock(side_effect=socket.error)), \
                 patch.object(MockRestApiServer, 'server_close', Mock()):
             self.srv.reload_config({'listen': ':8008'})
+
+    @staticmethod
+    def _auth_config(mode=None, username='test', password='test'):
+        authentication = {'username': username, 'password': password}
+        if mode is not None:
+            authentication['mode'] = mode
+        return {'listen': '*:8008', 'certfile': 'a', 'verify_client': 'required',
+                'ciphers': '!SSLv1:!SSLv2:!SSLv3:!TLSv1:!TLSv1.1',
+                'allowlist': ['127.0.0.1'],
+                'authentication': authentication}
+
+    def test_authentication_modes(self):
+        valid = 'Basic dGVzdDp0ZXN0'
+        invalid = 'Basic aW52YWxpZA=='
+        cases = (
+            ('disabled', None, None),
+            ('disabled', valid, None),
+            ('disabled', invalid, None),
+            ('permissive', None, None),
+            ('permissive', valid, None),
+            ('permissive', invalid, 'not authenticated'),
+            ('strict', None, 'no auth header received'),
+            ('strict', valid, None),
+            ('strict', invalid, 'not authenticated'),
+        )
+        for mode, header, expected in cases:
+            with self.subTest(mode=mode, header=header):
+                self.srv.reload_config(self._auth_config(mode))
+                self.assertEqual(expected, self.srv.check_auth_header(header))
+
+        self.srv.reload_config(self._auth_config())
+        self.assertEqual('no auth header received', self.srv.check_auth_header(None))
+        self.assertIsNone(self.srv.check_auth_header(valid))
+
+        config = self._auth_config()
+        config.pop('authentication')
+        self.srv.reload_config(config)
+        self.assertIsNone(self.srv.check_auth_header(None))
+        self.assertIsNone(self.srv.check_auth_header(invalid))
+
+    @patch('patroni.api.logger.warning')
+    @patch('patroni.api.time.monotonic', side_effect=(10.0, 20.0, 71.0))
+    def test_permissive_warning_is_throttled(self, mock_monotonic, mock_warning):
+        self.srv.reload_config(self._auth_config('permissive'))
+        with patch.object(RestApiServer, '_last_permissive_warning_at', None):
+            self.assertIsNone(self.srv.check_auth_header(None))
+            self.assertIsNone(self.srv.check_auth_header(None))
+            self.assertIsNone(self.srv.check_auth_header(None))
+        self.assertEqual(3, mock_monotonic.call_count)
+        self.assertEqual(2, mock_warning.call_count)
+
+    def test_authentication_reload_is_atomic(self):
+        old_valid = 'Basic dGVzdDp0ZXN0'
+        new_valid = 'Basic bmV3OmNyZWRlbnRpYWw='
+        self.srv.reload_config(self._auth_config('strict'))
+
+        with self.assertRaises(ValueError):
+            self.srv.reload_config(self._auth_config('invalid', 'new', 'credential'))
+
+        self.assertIsNone(self.srv.check_auth_header(old_valid))
+        self.assertEqual('not authenticated', self.srv.check_auth_header(new_valid))
+
+    def test_strict_and_permissive_modes_require_complete_credentials(self):
+        for mode in ('permissive', 'strict'):
+            for username, password in (('', ''), ('test', ''), ('', 'test')):
+                with self.subTest(mode=mode, username=username, password=password):
+                    with self.assertRaises(ValueError):
+                        self.srv.reload_config(self._auth_config(mode, username, password))
+
+        config = self._auth_config('invalid')
+        config['authentication'] = {'mode': 'invalid'}
+        with self.assertRaises(ValueError):
+            self.srv.reload_config(config)
+
+        for authentication in ('', [], 0, False):
+            with self.subTest(authentication=authentication), self.assertRaises(ValueError):
+                config = self._auth_config()
+                config['authentication'] = authentication
+                self.srv.reload_config(config)
+
+        self.srv.reload_config(self._auth_config('disabled', '', ''))
+        self.assertIsNone(self.srv.check_auth_header(None))
+
+    @patch('patroni.api.logger.warning')
+    @patch('patroni.api.time.monotonic', return_value=10.0)
+    def test_permissive_warning_is_thread_safe(self, mock_monotonic, mock_warning):
+        self.srv.reload_config(self._auth_config('permissive'))
+        with patch.object(RestApiServer, '_last_permissive_warning_at', None), ThreadPoolExecutor(16) as executor:
+            results = list(executor.map(lambda _: self.srv.check_auth_header(None), range(64)))
+        self.assertEqual([None] * 64, results)
+        self.assertEqual(64, mock_monotonic.call_count)
+        mock_warning.assert_called_once()
+
+    def test_auth_modes_do_not_bypass_allowlist_or_client_certificates(self):
+        for mode in ('disabled', 'permissive'):
+            with self.subTest(mode=mode):
+                self.srv.reload_config(self._auth_config(mode))
+                request_handler = Mock()
+                request_handler.headers = {}
+                request_handler.write_response.return_value = None
+                request_handler.client_address = ('127.0.0.2',)
+                request_handler.request.getpeercert.return_value = {'subject': 'client'}
+
+                self.assertIsNone(self.srv.check_access(request_handler))
+                request_handler.write_response.assert_called_once_with(403, 'Access is denied')
+
+                request_handler.write_response.reset_mock()
+                request_handler.client_address = ('127.0.0.1',)
+                request_handler.request.getpeercert.return_value = None
+                self.assertIsNone(self.srv.check_access(request_handler))
+                request_handler.write_response.assert_called_once_with(403, 'client certificate required')
 
     @patch('socket.getaddrinfo', socket_getaddrinfo)
     @patch.object(MockPatroni, 'dcs')

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,0 +1,50 @@
+import base64
+import unittest
+
+from patroni.request import PatroniRequest
+
+
+class TestPatroniRequestAuthentication(unittest.TestCase):
+
+    @staticmethod
+    def _authorization(config):
+        return PatroniRequest(config)._pool.headers.get('authorization')
+
+    @staticmethod
+    def _basic(value):
+        return 'Basic {0}'.format(base64.b64encode(value.encode('utf-8')).decode('ascii'))
+
+    def test_outgoing_auth_precedence(self):
+        config = {
+            'ctl': {'auth': 'ctl:secret'},
+            'restapi': {
+                'auth': 'flat:secret',
+                'authentication': {'username': 'nested', 'password': 'secret', 'mode': 'permissive'},
+            },
+        }
+        self.assertEqual(self._basic('ctl:secret'), self._authorization(config))
+
+        del config['ctl']['auth']
+        self.assertEqual(self._basic('flat:secret'), self._authorization(config))
+
+        del config['restapi']['auth']
+        self.assertEqual(self._basic('nested:secret'), self._authorization(config))
+
+    def test_structured_auth_is_sent_in_every_mode(self):
+        for mode in ('disabled', 'permissive', 'strict'):
+            with self.subTest(mode=mode):
+                config = {'restapi': {'authentication': {
+                    'username': 'patroni', 'password': 'secret', 'mode': mode}}}
+                self.assertEqual(self._basic('patroni:secret'), self._authorization(config))
+
+    def test_incomplete_structured_auth_is_not_sent(self):
+        for authentication in ({}, {'username': 'patroni'}, {'password': 'secret'},
+                               {'username': '', 'password': 'secret'},
+                               {'username': 'patroni', 'password': ''}, 'invalid'):
+            with self.subTest(authentication=authentication):
+                config = {'restapi': {'authentication': authentication}}
+                self.assertIsNone(self._authorization(config))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -206,6 +206,26 @@ class TestValidator(unittest.TestCase):
         output = "\n".join(errors)
         self.assertEqual(['postgresql.bin_dir', 'raft.bind_addr', 'raft.self_addr'], parse_output(output))
 
+    def test_restapi_authentication_mode(self, mock_out, mock_err):
+        for mode in ('disabled', 'permissive', 'strict'):
+            with self.subTest(mode=mode):
+                c = copy.deepcopy(config)
+                c['restapi']['authentication'] = {'username': 'patroni', 'password': 'secret', 'mode': mode}
+                errors = parse_output('\n'.join(schema(c)))
+                self.assertNotIn('restapi.authentication.mode', errors)
+
+        for mode in ('', 'STRICT', 'invalid', True, None):
+            with self.subTest(invalid_mode=mode):
+                c = copy.deepcopy(config)
+                c['restapi']['authentication'] = {'username': 'patroni', 'password': 'secret', 'mode': mode}
+                errors = parse_output('\n'.join(schema(c)))
+                self.assertIn('restapi.authentication.mode', errors)
+
+        c = copy.deepcopy(config)
+        c['restapi']['authentication'] = {'username': 'patroni', 'password': 'secret'}
+        errors = parse_output('\n'.join(schema(c)))
+        self.assertNotIn('restapi.authentication.mode', errors)
+
     def test_bin_dir_is_file(self, mock_out, mock_err):
         files.append(config["postgresql"]["data_dir"])
         files.append(config["postgresql"]["bin_dir"])


### PR DESCRIPTION
## What

Adds `restapi.authentication.mode` with three values — disabled,
permissive, strict — to allow enforcing REST API authentication on an
existing cluster without a flag-day cutover.

## Why

Today enabling REST API auth is effectively all-or-nothing across a
cluster: while some nodes require credentials and others don't, peer
calls during the leader race and switchovers can fail. There is no
supported migration window. (See #1636 for a case where per-node
credential differences did not behave as operators expected.)

permissive mode is that migration window: it accepts both
authenticated and unauthenticated requests (logging the latter) so
nodes can be rolled one at a time, then moved to strict once all are
done.

## Design

- disabled (default): current behavior, no enforcement. Existing
  configs are completely unaffected.
- permissive: accept both; warn (throttled) on unauthenticated access.
- strict: require valid credentials.

Auth state is an immutable snapshot swapped atomically on reload.
Outbound peer requests send credentials derived from
restapi.authentication so strict nodes authenticate to each other.
permissive/strict fail closed without complete credentials.

## Backwards compatibility

Default is disabled and the existing `auth` string keeps working, so
upgrading with no config change preserves current behavior.

## Testing

Unit tests cover all three modes, reload atomicity, the
allowlist/client-certificate non-bypass, outbound auth precedence,
and the throttled permissive warning. Validated on a real 3-node
cluster: rolling disabled -> permissive -> strict with no quorum loss,
switchover under strict, and failover recovery.

## Scope

This is the authentication mode only. A companion TLS mode
(permissive/strict for HTTPS migration) is planned as a separate PR.