### PR TITLE
Time out stalled REST API connections

### DIFF
--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -222,6 +222,8 @@ REST API
 -  **PATRONI\_RESTAPI\_HTTP\_EXTRA\_HEADERS**: (optional) HTTP headers let the REST API server pass additional information with an HTTP response.
 -  **PATRONI\_RESTAPI\_HTTPS\_EXTRA\_HEADERS**: (optional) HTTPS headers let the REST API server pass additional information with an HTTP response when TLS is enabled. This will also pass additional information set in ``http_extra_headers``.
 -  **PATRONI\_RESTAPI\_REQUEST\_QUEUE\_SIZE**: (optional): Sets request queue size for TCP socket used by Patroni REST API.  Once the queue is full, further requests get a "Connection denied" error. The default value is 5.
+-  **PATRONI\_RESTAPI\_HANDSHAKE\_TIMEOUT**: (optional): Maximum time in seconds a single client is given to complete the TLS handshake. Connections that do not complete it in time are closed. It only applies when ``PATRONI_RESTAPI_CERTFILE`` is set. The default value is 2.
+-  **PATRONI\_RESTAPI\_REQUEST\_TIMEOUT**: (optional): Maximum time in seconds a single client is given to send its request, and to read the response. Connections that stay silent for longer are closed. The default value is 5.
 -  **PATRONI\_RESTAPI\_SERVER\_TOKENS**: (optional) Configures the value of the ``Server`` HTTP header.  ``Original`` (default) will expose the original behaviour and display the BaseHTTP and Python versions, e.g. ``BaseHTTP/0.6 Python/3.12.3``. ``Minimal``: The header will contain only the Patroni version, e.g. ``Patroni/4.0.0``. ``ProductOnly``: The header will contain only the product name, e.g. ``Patroni``.
 
 .. warning::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,6 +47,8 @@ In addition, you may tune the following Patroni configuration parameters:
 - ``thread_stack_size`` - stack size used for threads started by Patroni. Lowering this value reduces memory usage of the Patroni process. The default value set by Patroni is ``512kB``. Increase ``thread_stack_size`` if Patroni experience stack-related crashes; otherwise the default value is sufficient.
 - ``thread_pool_size`` - size of the thread pool used by Patroni for asynchronous tasks and REST API communication with other members during leader race or failsafe checks. The default value is ``5``, which is sufficient for three-node clusters.
 - ``restapi.thread_pool_size`` - size of the thread pool used to process REST API requests. The default value is ``5``, allowing up to five parallel REST API requests. Note that requests involving SQL queries are effectively serialized because a single database connection is used, so increasing this value typically provides no benefit.
+- ``restapi.handshake_timeout`` - maximum time in seconds a single client is given to complete the TLS handshake. It bounds how long a connection may hold a thread of ``restapi.thread_pool_size`` before sending any data. The default value is ``2``.
+- ``restapi.request_timeout`` - maximum time in seconds a single client is given to send its request, and to read the response. Together with ``restapi.handshake_timeout`` it bounds how long a single connection may hold a thread of ``restapi.thread_pool_size``. The default value is ``5``.
 
 ----
 

--- a/docs/yaml_configuration.rst
+++ b/docs/yaml_configuration.rst
@@ -384,6 +384,8 @@ REST API
    -  **http\_extra\_headers**: (optional): HTTP headers let the REST API server pass additional information with an HTTP response.
    -  **https\_extra\_headers**: (optional): HTTPS headers let the REST API server pass additional information with an HTTP response when TLS is enabled. This will also pass additional information set in ``http_extra_headers``.
    -  **request_queue_size**: (optional): Sets request queue size for TCP socket used by Patroni REST API.  Once the queue is full, further requests get a "Connection denied" error. The default value is 5.
+   -  **handshake\_timeout**: (optional): Maximum time in seconds a single client is given to complete the TLS handshake. Connections that do not complete it in time are closed. It only applies when ``certfile`` is set. The default value is 2.
+   -  **request\_timeout**: (optional): Maximum time in seconds a single client is given to send its request, and to read the response. Connections that stay silent for longer are closed. The default value is 5.
    -  **server_tokens**: (optional): Configures the value of the ``Server`` HTTP header.
       - ``Minimal``: The header will contain only the Patroni version, e.g. ``Patroni/4.0.0``.
       - ``ProductOnly``: The header will contain only the product name, e.g. ``Patroni``.

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -1498,6 +1498,16 @@ class RestApiHandler(BaseHTTPRequestHandler):
         result['dcs_last_seen'] = self.server.patroni.dcs.last_seen
         return result
 
+    def setup(self) -> None:
+        """Prepare the connection to handle a request.
+
+        Wrapper for :func:`~socketserver.StreamRequestHandler.setup` that additionally arms a timeout on
+        the connection. Without it a client that connects and then stays silent, or that never reads
+        the response, holds one of the ``restapi.thread_pool_size`` workers forever.
+        """
+        super(RestApiHandler, self).setup()
+        self.connection.settimeout(self.server.request_timeout)
+
     def handle_one_request(self) -> None:
         """Parse and dispatch a request to the appropriate ``do_*`` method.
 
@@ -1537,10 +1547,12 @@ class RestApiServer(ThreadingMixIn, HTTPServer):
         self.__auth_key = None
         self.__allowlist_include_members: Optional[bool] = None
         self.__allowlist: Tuple[Union[IPv4Network, IPv6Network], ...] = ()
+        self.__handshake_timeout: int = 2
         self.http_extra_headers: Dict[str, str] = {}
         self.patroni = patroni
         self.__listen = None
         self.request_queue_size = int(config.get('request_queue_size', 5))
+        self.request_timeout: int = 5
         try:
             thread_pool_size = max(5, int(config.get('thread_pool_size', 5)))
         except Exception as e:
@@ -1872,7 +1884,12 @@ class RestApiServer(ThreadingMixIn, HTTPServer):
         if hasattr(request, 'context'):  # SSLSocket
             from ssl import SSLSocket
             if isinstance(request, SSLSocket):  # pyright
+                previous_timeout = request.gettimeout()
                 try:
+                    # Without a timeout, a client that opens the connection and never sends a ClientHello
+                    # blocks this worker forever, and `restapi.thread_pool_size`. Such clients are enough
+                    # to make the REST API stop answering until Patroni is restarted.
+                    request.settimeout(self.__handshake_timeout)
                     request.do_handshake()
                 except OSError as e:
                     # The client may reset the connection (or otherwise fail the TLS handshake, e.g.
@@ -1884,6 +1901,7 @@ class RestApiServer(ThreadingMixIn, HTTPServer):
                                  client_address[0], client_address[1], e)
                     self.shutdown_request(request)
                     return
+                request.settimeout(previous_timeout)
         super(RestApiServer, self).process_request_thread(request, client_address)
 
     def process_request(self, request: Union[socket.socket, Tuple[bytes, socket.socket]],
@@ -2009,6 +2027,8 @@ class RestApiServer(ThreadingMixIn, HTTPServer):
 
         self.__allowlist = tuple(self._build_allowlist(config.get('allowlist')))
         self.__allowlist_include_members = config.get('allowlist_include_members')
+        self.__handshake_timeout = self._parse_timeout(config, 'handshake_timeout', 2)
+        self.request_timeout = self._parse_timeout(config, 'request_timeout', 5)
 
         ssl_options = {n: config[n] for n in ('certfile', 'keyfile', 'keyfile_password',
                                               'cafile', 'ciphers') if n in config}
@@ -2031,6 +2051,22 @@ class RestApiServer(ThreadingMixIn, HTTPServer):
 
         # Define the Server header response using the server_tokens option.
         self.server_header = self.construct_server_tokens(config.get('server_tokens', 'original'))
+
+    @staticmethod
+    def _parse_timeout(config: Dict[str, Any], name: str, default: int) -> int:
+        """Get the value of the *name* timeout, in seconds.
+
+        :param config: dictionary representing values under the ``restapi`` configuration section.
+        :param name: name of the timeout setting in *config*.
+        :param default: value to be used if *name* is absent or invalid.
+
+        :returns: value of ``restapi.<name>``, never below one second.
+        """
+        try:
+            return max(1, int(config.get(name, default)))
+        except Exception as e:
+            logger.warning('Failed to parse restapi.%s value "%s": %r', name, config.get(name), e)
+            return default
 
     def handle_error(self, request: Union[socket.socket, Tuple[bytes, socket.socket]],
                      client_address: Tuple[str, int]) -> None:

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -549,7 +549,8 @@ class Config(object):
         _set_section_values('restapi', ['listen', 'connect_address', 'certfile', 'keyfile', 'keyfile_password',
                                         'cafile', 'ciphers', 'verify_client', 'http_extra_headers',
                                         'https_extra_headers', 'allowlist', 'allowlist_include_members',
-                                        'request_queue_size', 'server_tokens'])
+                                        'request_queue_size', 'handshake_timeout', 'request_timeout',
+                                        'server_tokens'])
         _set_section_values('ctl', ['insecure', 'cacert', 'certfile', 'keyfile', 'keyfile_password'])
         _set_section_values('postgresql', ['listen', 'connect_address', 'proxy_address',
                                            'config_dir', 'data_dir', 'pgpass', 'bin_dir'])
@@ -574,7 +575,8 @@ class Config(object):
                 if value is not None:
                     ret[first][second] = value
 
-        for first, params in (('restapi', ('request_queue_size', 'thread_pool_size')),
+        for first, params in (('restapi', ('request_queue_size', 'thread_pool_size',
+                                           'handshake_timeout', 'request_timeout')),
                               ('log', ('max_queue_size', 'file_size', 'file_num', 'mode'))):
             for second in params:
                 value = ret.get(first, {}).pop(second, None)

--- a/patroni/validator.py
+++ b/patroni/validator.py
@@ -1126,6 +1126,8 @@ schema = Schema({
         Optional("http_extra_headers"): dict,
         Optional("https_extra_headers"): dict,
         Optional("request_queue_size"): IntValidator(min=0, max=4096, expected_type=int, raise_assert=True),
+        Optional("handshake_timeout"): IntValidator(min=1, expected_type=int, raise_assert=True),
+        Optional("request_timeout"): IntValidator(min=1, expected_type=int, raise_assert=True),
         Optional("server_tokens"): EnumValidator(('minimal', 'productonly', 'original'),
                                                  case_sensitive=False, raise_assert=True)
     },

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -187,6 +187,9 @@ class MockRequest(object):
     def sendall(self, *args, **kwargs):
         pass
 
+    def settimeout(self, *args, **kwargs):
+        pass
+
 
 class MockRestApiServer(RestApiServer):
 
@@ -790,6 +793,13 @@ class TestRestApiHandler(unittest.TestCase):
         MockRestApiServer(RestApiHandler, post + '0\n\n')
         MockRestApiServer(RestApiHandler, post + '14\n\n{"leader":"1"}')
 
+    def test_setup_bounds_request_with_a_timeout(self):
+        # A client that completes the TLS handshake (or connects in plain HTTP) and then sends nothing
+        # would otherwise hold a pool worker forever, so the connection gets a timeout of its own.
+        with patch.object(MockRequest, 'settimeout') as mock_settimeout:
+            MockRestApiServer(RestApiHandler, 'GET /replica')
+        mock_settimeout.assert_called_once_with(5)
+
 
 class TestRestApiServer(unittest.TestCase):
 
@@ -888,6 +898,83 @@ class TestRestApiServer(unittest.TestCase):
             mock_finish.assert_not_called()
             mock_shutdown.assert_called_once_with(sock)
             self.assertTrue(any('SSL handshake' in c[0][0] for c in mock_debug.call_args_list if c[0]))
+
+    def test_process_request_thread_ssl_handshake_timeout(self):
+        import ssl
+
+        # A client that opens a TCP connection to the TLS port and never sends a ClientHello would
+        # otherwise block a pool worker forever. The handshake must be bounded by a timeout, and the
+        # socket must go back to its original timeout once the handshake succeeded.
+        sock = self.__create_socket()
+        if not isinstance(sock, ssl.SSLSocket):  # pragma: no cover - ssl not available
+            self.skipTest('ssl is not available')
+
+        sock.do_handshake = Mock(side_effect=socket.timeout('timed out'))
+        with patch.object(sock, 'settimeout') as mock_settimeout, \
+                patch.object(self.srv, 'shutdown_request') as mock_shutdown, \
+                patch.object(RestApiServer, 'finish_request') as mock_finish:
+            self.assertIsNone(self.srv.process_request_thread(sock, ('127.0.0.1', 55555)))
+        mock_settimeout.assert_called_once_with(2)
+        mock_finish.assert_not_called()
+        mock_shutdown.assert_called_once_with(sock)
+
+        sock.do_handshake = Mock()
+        with patch.object(sock, 'settimeout') as mock_settimeout, \
+                patch.object(RestApiServer, 'finish_request', Mock()):
+            self.srv.process_request_thread(sock, ('127.0.0.1', 55555))
+        self.assertEqual([c[0][0] for c in mock_settimeout.call_args_list], [2, None])
+
+    @patch.object(HTTPServer, '__init__', Mock())
+    def test_request_timeout_config(self):
+        def reload_config(config):
+            with patch.object(MockRestApiServer, 'server_close', Mock()):
+                self.srv.reload_config(dict(config, listen=':8008'))
+
+        reload_config({})
+        self.assertEqual(self.srv.request_timeout, 5)
+
+        reload_config({'request_timeout': 30})
+        self.assertEqual(self.srv.request_timeout, 30)
+
+        reload_config({'request_timeout': 0})
+        self.assertEqual(self.srv.request_timeout, 1)
+
+        with patch('patroni.api.logger.warning') as mock_warning:
+            reload_config({'request_timeout': 'foo'})
+        self.assertEqual(self.srv.request_timeout, 5)
+        self.assertTrue(any('request_timeout' in str(c) for c in mock_warning.call_args_list))
+
+    @patch.object(HTTPServer, '__init__', Mock())
+    def test_handshake_timeout_config(self):
+        import ssl
+
+        if not isinstance(self.__create_socket(), ssl.SSLSocket):  # pragma: no cover - ssl not available
+            self.skipTest('ssl is not available')
+
+        def handshake_timeout():
+            sock = self.__create_socket()
+            with patch.object(sock, 'settimeout') as mock_settimeout, \
+                    patch.object(RestApiServer, 'finish_request', Mock()):
+                self.srv.process_request_thread(sock, ('127.0.0.1', 55555))
+            return mock_settimeout.call_args_list[0][0][0]
+
+        def reload_config(config):
+            with patch.object(MockRestApiServer, 'server_close', Mock()):
+                self.srv.reload_config(dict(config, listen=':8008'))
+
+        reload_config({'handshake_timeout': 15})
+        self.assertEqual(handshake_timeout(), 15)
+
+        with patch('patroni.api.logger.warning') as mock_warning:
+            reload_config({'handshake_timeout': 'foo'})
+        self.assertEqual(handshake_timeout(), 2)
+        self.assertTrue(any('handshake_timeout' in str(c) for c in mock_warning.call_args_list))
+
+        reload_config({'handshake_timeout': 0})
+        self.assertEqual(handshake_timeout(), 1)
+
+        reload_config({})
+        self.assertEqual(handshake_timeout(), 2)
 
     @patch.object(MockRestApiServer, 'process_request', Mock(side_effect=RuntimeError))
     @patch.object(MockRestApiServer, 'get_request')


### PR DESCRIPTION
The REST API is served by a fixed thread pool, and no timeout is set anywhere. A client that connects to the TLS port and never sends a ClientHello blocks a pool worker forever in do_handshake(), and a client that connects and never sends a request does the same in the handler. With the default restapi.thread_pool_size of 5, five such connections make the REST API stop answering until Patroni is restarted, while Patroni itself stays healthy and logs nothing above WARNING.

Add two settings that bound how long a single connection may hold a worker without making progress. restapi.handshake_timeout (default 5) caps the TLS handshake, restapi.request_timeout (default 10) caps sending the request and reading the response, over HTTPS and plain HTTP alike. Both are applied on reload and never go below one second.

These are socket timeouts, so they bound individual reads and writes on the client connection, not the time spent in the handler. A slow query does not trigger them, and neither timeout logs above DEBUG.

Introduced in #3526.
Fixes #3705.