### PR TITLE
Fix premature 503 in poll_failover_result() during transient unlocked state

### DIFF
--- a/patroni/api.py
+++ b/patroni/api.py
@@ -1159,7 +1159,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
                     else:
                         return 200, '{0}ed over to "{1}" instead of "{2}"'.format(action[:-4].title(),
                                                                                   cluster.leader.name, candidate)
-                if not cluster.failover:
+                if not cluster.failover and not cluster.is_unlocked():
                     return 503, action.title() + ' failed'
             except Exception as e:
                 logger.debug('Exception occurred during polling %s result: %s', action, e)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -663,6 +663,7 @@ class TestRestApiHandler(unittest.TestCase):
         # Failover key is empty in DCS
         with patch.object(RestApiHandler, 'write_response') as response_mock:
             cluster.failover = None
+            cluster.is_unlocked.return_value = False
             MockRestApiServer(RestApiHandler, request)
             response_mock.assert_called_with(503, 'Switchover failed')
 


### PR DESCRIPTION
The problem may happen with ZooKeeper, because it cleans up all ephemeral ZNodes when client disconnects from the server (even temporary).