### PR TITLE
Resolve a couple warnings in ci

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Set up Python 3.7
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: 3.7
       if: matrix.os != 'macos'
@@ -35,7 +35,7 @@ jobs:
       if: matrix.os != 'macos'
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: 3.8
     - name: Install dependencies
@@ -44,7 +44,7 @@ jobs:
       run: python .github/workflows/run_tests.py
 
     - name: Set up Python 3.9
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: 3.9
     - name: Install dependencies
@@ -53,7 +53,7 @@ jobs:
       run: python .github/workflows/run_tests.py
 
     - name: Set up Python 3.10
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.10'
     - name: Install dependencies
@@ -62,7 +62,7 @@ jobs:
       run: python .github/workflows/run_tests.py
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: 3.11
     - name: Install dependencies
@@ -71,7 +71,7 @@ jobs:
       run: python .github/workflows/run_tests.py
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: 3.12
     - name: Install dependencies
@@ -80,7 +80,7 @@ jobs:
       run: python .github/workflows/run_tests.py
 
     - name: Set up Python 3.13
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: 3.13
       if: matrix.os != 'macos'
@@ -92,7 +92,7 @@ jobs:
       if: matrix.os != 'macos'
 
     - name: Set up Python 3.14
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: 3.14
       if: matrix.os != 'macos'
@@ -137,7 +137,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - uses: nolar/setup-k3d-k3s@v1
@@ -187,7 +187,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Set up Python 3.14
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: 3.14
 
@@ -205,7 +205,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Set up Python 3.13
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: 3.13
     - name: Install dependencies
@@ -221,7 +221,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: 3.11
         cache: pip
@@ -245,7 +245,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: 3.12
         cache: pip

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu, windows, macos]
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
 
     - name: Set up Python 3.7
       uses: actions/setup-python@v7
@@ -107,7 +107,7 @@ jobs:
       run: python .github/workflows/run_tests.py combine
 
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         flags: unit-${{ matrix.os }}
 
@@ -135,7 +135,7 @@ jobs:
           dcs: etcd3
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python
       uses: actions/setup-python@v7
       with:
@@ -158,7 +158,7 @@ jobs:
     - name: Run behave tests
       run: python .github/workflows/run_tests.py
     - name: Upload logs if behave failed
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: behave-${{ matrix.os }}-${{ matrix.dcs }}-${{ matrix.python-version }}-logs
@@ -184,7 +184,7 @@ jobs:
   pyright:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
 
     - name: Set up Python 3.14
       uses: actions/setup-python@v7
@@ -194,7 +194,7 @@ jobs:
     - name: Install dependencies
       run: python -m pip install -r requirements.txt psycopg2-binary psycopg
 
-    - uses: jakebailey/pyright-action@v2
+    - uses: jakebailey/pyright-action@v3
       with:
         version: 1.1.411
 
@@ -202,7 +202,7 @@ jobs:
     name: Test compatibility with the latest version of ydiff
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
 
     - name: Set up Python 3.13
       uses: actions/setup-python@v7
@@ -218,7 +218,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
 
     - name: Set up Python 3.11
       uses: actions/setup-python@v7
@@ -242,7 +242,7 @@ jobs:
   isort:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
 
     - name: Set up Python 3.12
       uses: actions/setup-python@v7

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import unittest
 
 from datetime import datetime, timedelta
@@ -63,9 +64,9 @@ class TestCtl(unittest.TestCase):
 
     @patch('patroni.ctl.logging.debug')
     def test_load_config(self, mock_logger_debug):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            self.assertRaises(PatroniCtlException, load_config, './non-existing-config-file', None)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_file = os.path.join(temp_dir, 'non-existing-config-file')
+            self.assertRaises(PatroniCtlException, load_config, config_file, None)
 
         with patch('os.path.exists', Mock(return_value=True)), \
                 patch('patroni.config.Config._load_config_path', Mock(return_value={})):
@@ -329,18 +330,19 @@ class TestCtl(unittest.TestCase):
             result = self.runner.invoke(ctl, ['query', 'alpha', '--member', 'abc', '--role', repr(role)])
             assert result.exit_code == 1
 
-        with self.runner.isolated_filesystem():
-            with open('dummy', 'w') as dummy_file:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dummy = os.path.join(temp_dir, 'dummy')
+            with open(dummy, 'w') as dummy_file:
                 dummy_file.write('SELECT 1')
 
             # Mutually exclusive
-            result = self.runner.invoke(ctl, ['query', 'alpha', '--file', 'dummy', '--command', 'dummy'])
+            result = self.runner.invoke(ctl, ['query', 'alpha', '--file', dummy, '--command', 'dummy'])
             assert result.exit_code == 1
 
-            result = self.runner.invoke(ctl, ['query', 'alpha', '--member', 'abc', '--file', 'dummy'])
+            result = self.runner.invoke(ctl, ['query', 'alpha', '--member', 'abc', '--file', dummy])
             assert result.exit_code == 0
 
-            os.remove('dummy')
+            os.remove(dummy)
 
         result = self.runner.invoke(ctl, ['query', 'alpha', '--command', 'SELECT 1'])
         assert 'mock column' in result.output


### PR DESCRIPTION
1. DeprecationWarning: 'isolated_filesystem' is deprecated and will be removed in Click 9.0
2. Node.js 20 is deprecated, could be raised by setup-python, pyright-action, checkout, codecov-action, upload-artifact