### PR TITLE
Add remco templates as an alternative to confd (extras/remco)

### DIFF
--- a/extras/README.md
+++ b/extras/README.md
@@ -8,6 +8,24 @@ $ confd -prefix=/service/$PATRONI_SCOPE -backend etcd -node $PATRONI_ETCD_URL -i
 It will periodically update haproxy.cfg and pgbouncer.ini with the actual list of Patroni nodes from `etcd` and "reload" haproxy and pgbouncer.ini when it is necessary.
 
 
+### remco
+
+`remco` directory contains haproxy and pgbouncer template files for
+[remco](https://github.com/HeavyHorst/remco) -- 
+a lightweight configuration management tool, similar to confd but with pongo2 templates and support for multiple backends per resource.
+
+Copy the content of `remco` into `/etc/remco` (`resource.d` -> `/etc/remco/resource.d`,
+`template` -> `/etc/remco/templates`), set your etcd nodes and scope in the `resource.d/*.toml` files, then run remco:
+
+```bash
+$ remco -config /etc/remco/config
+```
+
+It will watch `/members` (and `/leader` for pgbouncer) under `/service/$PATRONI_SCOPE` in etcd, re-render `haproxy.cfg` / `pgbouncer.ini`
+whenever the Patroni cluster topology changes, and reload haproxy / pgbouncer
+accordingly.
+
+
 ### startup-scripts
 
 `startup-scripts` directory contains startup scripts for various OSes and management tools for Patroni.

--- a/extras/README.md
+++ b/extras/README.md
@@ -3,7 +3,7 @@
 `confd` directory contains haproxy and pgbouncer template files for the [confd](https://github.com/kelseyhightower/confd) -- lightweight configuration management tool
 You need to copy content of `confd` directory into /etcd/confd and run confd service:
 ```bash
-$ confd -prefix=/service/$PATRONI_SCOPE -backend etcd -node $PATRONI_ETCD_URL -interval=10
+confd -prefix=/service/$PATRONI_SCOPE -backend etcd -node $PATRONI_ETCD_URL -interval=10
 ```
 It will periodically update haproxy.cfg and pgbouncer.ini with the actual list of Patroni nodes from `etcd` and "reload" haproxy and pgbouncer.ini when it is necessary.
 
@@ -18,7 +18,7 @@ Copy the content of `remco` into `/etc/remco` (`resource.d` -> `/etc/remco/resou
 `template` -> `/etc/remco/templates`), set your etcd nodes and scope in the `resource.d/*.toml` files, then run remco:
 
 ```bash
-$ remco -config /etc/remco/config
+remco -config /etc/remco/config
 ```
 
 It will watch `/members` (and `/leader` for pgbouncer) under `/service/$PATRONI_SCOPE` in etcd, re-render `haproxy.cfg` / `pgbouncer.ini`

--- a/extras/remco/resource.d/haproxy.toml
+++ b/extras/remco/resource.d/haproxy.toml
@@ -1,0 +1,23 @@
+name = "haproxy"
+[[template]]
+src = "/etc/remco/templates/haproxy.tmpl"
+dst = "/etc/haproxy/haproxy.cfg"
+make_directories = true
+reload_cmd = "haproxy -f {{ .dst }} -p /var/run/haproxy.pid -D -sf $(cat /var/run/haproxy.pid)"
+
+check_cmd = "/usr/sbin/haproxy -c -f {{ .src }}"
+mode = "0644"
+
+[backend]
+[backend.etcd]
+nodes = [
+    "http://...:2379",
+    "http://...:2379",
+    "http://...:2379"
+]
+prefix = "/service/patroni"
+keys = ["/members"]
+watchKeys = ["/haproxy/reload"]
+watch = true
+interval = 60
+version = 3

--- a/extras/remco/resource.d/pgbouncer.toml
+++ b/extras/remco/resource.d/pgbouncer.toml
@@ -1,0 +1,21 @@
+name = "pgbouncer"
+
+[[template]]
+src = "/etc/remco/templates/pgbouncer.tmpl"
+dst = "/etc/pgbouncer/pgbouncer.ini"
+make_directories = true
+reload_cmd = "systemctl reload pgbouncer"
+mode = "0644"
+
+[backend]
+[backend.etcd]
+nodes = [
+    "http://...:2379",
+    "http://...:2379",
+    "http://...:2379"
+]
+prefix = "/service/patroni"
+keys = ["/members", "/leader"]
+watch = true
+interval = 60
+version = 3

--- a/extras/remco/template/haproxy-citus.tmpl
+++ b/extras/remco/template/haproxy-citus.tmpl
@@ -1,0 +1,39 @@
+global
+	maxconn 100
+
+defaults
+	log	global
+	mode	tcp
+	retries 2
+	timeout client 30m
+	timeout connect 4s
+	timeout server 30m
+	timeout check 5s
+
+listen stats
+	mode http
+	bind *:7000
+	stats enable
+	stats uri /
+
+
+listen master
+	bind *:5000
+	option httpchk OPTIONS /primary
+	http-check expect status 200
+	default-server inter 3s fall 3 rise 2 on-marked-down shutdown-sessions
+{% for node in ls("/members") %}
+    {%set nodeinfo = getv(printf("/members/%s", node)) | parseJSON  %}
+    server {{node}} {{nodeinfo.conn_url | split:"/" | index:"2" }}  maxconn 100 check check-ssl port {{(nodeinfo.api_url | split:"/" | index:"2" | split:":" | index:"1")  }} verify required ca-file /etc/ssl/certs/ssl-cert-snakeoil.pem crt /etc/ssl/private/ssl-cert-snakeoil.crt
+{% endfor %}
+
+
+listen replicas
+	bind *:5001
+	option httpchk OPTIONS /primary
+	http-check expect status 200
+	default-server inter 3s fall 3 rise 2 on-marked-down shutdown-sessions
+{% for node in ls("/members") %}
+    {%set nodeinfo = getv(printf("/members/%s", node)) | parseJSON  %}
+    server {{node}} {{nodeinfo.conn_url | split:"/" | index:"2" }}  maxconn 100 check check-ssl port {{(nodeinfo.api_url | split:"/" | index:"2" | split:":" | index:"1")  }} verify required ca-file /etc/ssl/certs/ssl-cert-snakeoil.pem crt /etc/ssl/private/ssl-cert-snakeoil.crt
+{% endfor %}

--- a/extras/remco/template/haproxy.tmpl
+++ b/extras/remco/template/haproxy.tmpl
@@ -1,0 +1,39 @@
+global
+	maxconn 100
+
+defaults
+	log	global
+	mode	tcp
+	retries 2
+	timeout client 30m
+	timeout connect 4s
+	timeout server 30m
+	timeout check 5s
+
+listen stats
+	mode http
+	bind *:7000
+	stats enable
+	stats uri /
+
+
+listen master
+	bind *:5000
+	option httpchk OPTIONS /master
+	http-check expect status 200
+	default-server inter 3s fall 3 rise 2 on-marked-down shutdown-sessions
+{% for node in ls("/members") %}
+    {%set nodeinfo = getv(printf("/members/%s", node)) | parseJSON  %}
+    server {{node}} {{nodeinfo.conn_url | split:"/" | index:"2" }}  maxconn 100 check port {{(nodeinfo.api_url | split:"/" | index:"2" | split:":" | index:"1")  }}
+{% endfor %}
+
+
+listen replicas
+	bind *:5001
+	option httpchk OPTIONS /replica
+	http-check expect status 200
+	default-server inter 3s fall 3 rise 2 on-marked-down shutdown-sessions
+{% for node in ls("/members") %}
+    {%set nodeinfo = getv(printf("/members/%s", node)) | parseJSON  %}
+    server {{node}} {{nodeinfo.conn_url | split:"/" | index:"2" }}  maxconn 100 check port {{(nodeinfo.api_url | split:"/" | index:"2" | split:":" | index:"1")  }}
+{% endfor %}

--- a/extras/remco/template/pgbouncer.tmpl
+++ b/extras/remco/template/pgbouncer.tmpl
@@ -1,0 +1,23 @@
+[databases]
+{% if exists("/leader") %}
+{% set leader_name = getv("/leader")   %}
+{%set leader_node_info = getv(printf("/members/%s", leader_name)) | parseJSON  %}
+{%set leader_conn_url = leader_node_info.conn_url| split:"/" | index:"2" %}
+* = host={{ leader_conn_url | split:":" | index: "0" }} port={{ leader_conn_url | split:":" | index: "1" }} pool_size=10
+{%endif%}
+
+
+[pgbouncer]
+logfile = /var/log/postgresql/pgbouncer.log
+pidfile = /var/run/postgresql/pgbouncer.pid
+listen_addr = *
+listen_port = 6432
+unix_socket_dir = /var/run/postgresql
+auth_type = trust
+auth_file = /etc/pgbouncer/userlist.txt
+auth_hba_file = /etc/pgbouncer/pg_hba.txt
+admin_users = pgbouncer
+stats_users = pgbouncer
+pool_mode = session
+max_client_conn = 100
+default_pool_size = 20


### PR DESCRIPTION
confd has been unmaintained for a while, and remco covers the same use case (render a config file from etcd data, reload the service on change) 