### PR TITLE
Recheck the Kubernetes leader lock before acquisition

### DIFF
--- a/patroni/dcs/kubernetes.py
+++ b/patroni/dcs/kubernetes.py
@@ -789,10 +789,9 @@ class Kubernetes(AbstractDCS):
         self._api = CoreV1ApiProxy(config.get('use_endpoints'), bypass_api_service)
         self._should_create_config_service = self._api.use_endpoints
         self.reload_config(config)
-        # leader_observed_record, leader_resource_version, and leader_observed_time are used only for leader race!
+        # leader_observed_record and leader_observed_time are used only for leader race!
         self._leader_observed_record: Dict[str, str] = {}
         self._leader_observed_time = None
-        self._leader_resource_version = None
         self.__do_not_watch = False
 
         self._condition = Condition()
@@ -889,8 +888,6 @@ class Kubernetes(AbstractDCS):
         leader_path = path[:-1] if self._api.use_endpoints else path + self._LEADER
         leader = nodes.get(leader_path)
         metadata = leader and leader.metadata
-        if leader_path == self.leader_path:  # We want to memorize leader_resource_version only for our cluster
-            self._leader_resource_version = metadata.resource_version if metadata else None
         annotations: Dict[str, str] = metadata and metadata.annotations or {}
 
         # get last known leader lsn and slots
@@ -1278,6 +1275,17 @@ class Kubernetes(AbstractDCS):
         return self._update_leader_with_retry(annotations, resource_version, self.__ips)
 
     def attempt_to_acquire_leader(self) -> bool:
+        # Another member can acquire the lock after the HA loop decides to enter the election.
+        # Check the lock again and use the resource version from that same snapshot for the conditional write.
+        # REST requests can replace the shared DCS fields, so those fields may no longer match the snapshot we checked.
+        cluster = self.get_cluster()
+        if cluster.leader_name and cluster.leader_name != self._name:
+            logger.info('Could not take out TTL lock')
+            return False
+        resource_version = cluster.leader and cluster.leader.version
+        if TYPE_CHECKING:  # pragma: no cover
+            assert resource_version is None or isinstance(resource_version, str)
+
         now = self._isotime()
         annotations = {self._LEADER: self._name, 'ttl': str(self._ttl),
                        'renewTime': now, 'acquireTime': now, 'transitions': '0'}
@@ -1292,16 +1300,6 @@ class Kubernetes(AbstractDCS):
             else:
                 annotations['acquireTime'] = self._leader_observed_record.get('acquireTime') or now
             annotations['transitions'] = str(transitions)
-
-        resource_version = self._leader_resource_version
-        if resource_version:
-            kind = self._kinds.get(self.leader_path)
-            # If leader object in cache was updated we should better use fresh resource_version
-            if kind and kind.metadata.resource_version != resource_version:
-                kind_annotations = kind and kind.metadata.annotations or EMPTY_DICT
-                # But, only in case if leader annotations didn't change
-                if all(kind_annotations.get(k) == self._leader_observed_record.get(k) for k in annotations.keys()):
-                    resource_version = kind.metadata.resource_version
 
         retry = self._retry.copy()
 

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -306,7 +306,6 @@ class TestKubernetesConfigMaps(BaseTestKubernetes):
             self.assertRaises(KubernetesError, self.k.attempt_to_acquire_leader)
 
             mock_patch.side_effect = k8s_client.rest.ApiException(409, '')
-            self.k._leader_resource_version = '0'
             self.k._isotime = Mock(return_value='now')
             self.assertTrue(self.k.attempt_to_acquire_leader())
 
@@ -317,10 +316,7 @@ class TestKubernetesConfigMaps(BaseTestKubernetes):
             self.assertRaises(KubernetesError, self.k.attempt_to_acquire_leader)
 
     def test_take_leader(self):
-        self.k.take_leader()
-        self.k._leader_observed_record['leader'] = 'test'
-        self.k.patch_or_create = Mock(return_value=False)
-        self.k.take_leader()
+        self.assertTrue(self.k.take_leader())
 
     def test_manual_failover(self):
         with patch.object(k8s_client.CoreV1Api, 'patch_namespaced_config_map',
@@ -446,6 +442,35 @@ class TestKubernetesEndpoints(BaseTestKubernetes):
         self.assertIsNotNone(self.k.update_leader(cluster, '123'))
         self.k._kinds._object_cache['test'].metadata.annotations['leader'] = 'p-1'
         self.assertFalse(self.k.update_leader(cluster, '123'))
+
+    @patch.object(k8s_client.CoreV1Api, 'read_namespaced_endpoints', create=True)
+    @patch.object(k8s_client.CoreV1Api, 'patch_namespaced_endpoints', create=True)
+    def test_attempt_to_acquire_leader_with_stale_cluster_snapshot(self, mock_patch, mock_read):
+        metadata = k8s_client.V1ObjectMeta(resource_version='2', labels={'f': 'b'}, name='test',
+                                           annotations={'transitions': '5', 'renewTime': 'now',
+                                                        'acquireTime': 'now', 'ttl': '30'})
+        self.k._kinds.set('test', k8s_client.V1Endpoints(metadata=metadata))
+        self.assertTrue(self.k.get_cluster().is_unlocked())
+
+        metadata = k8s_client.V1ObjectMeta(resource_version='3', labels={'f': 'b'}, name='test',
+                                           annotations={'leader': 'p-1', 'transitions': '6', 'renewTime': 'now',
+                                                        'acquireTime': 'now', 'ttl': '30'})
+        mock_read.return_value = k8s_client.V1Endpoints(metadata=metadata)
+        self.k._kinds.set('test', mock_read.return_value)
+        # A REST API request (GET /cluster) reloads the cluster on the same DCS object
+        self.k.get_cluster()
+
+        mock_patch.side_effect = k8s_client.rest.ApiException(409, '')
+        self.assertFalse(self.k.attempt_to_acquire_leader())
+        mock_patch.assert_not_called()
+
+        # The lock of the other member expired
+        self.k._leader_observed_time = float('-inf')
+        mock_patch.side_effect = mock_namespaced_kind
+        self.assertTrue(self.k.attempt_to_acquire_leader())
+        args = mock_patch.call_args[0]
+        self.assertEqual(args[2].metadata.resource_version, '3')
+        self.assertEqual(args[2].metadata.annotations['transitions'], '7')
 
     @patch('time.sleep', Mock())
     @patch.object(k8s_client.CoreV1Api, 'read_namespaced_endpoints', create=True)


### PR DESCRIPTION
A concurrent /cluster request can refresh the saved resourceVersion
after the HA loop decides the cluster is unlocked. If another member
acquires the lock before that refresh, the losing candidate can
overwrite its lock using the new version.

Recheck the lock in attempt_to_acquire_leader() and bail out if
another member holds a valid lock. Use the resourceVersion from the
same snapshot for the conditional write.

Closes #3718
